### PR TITLE
Add admin panel, env var config, and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,168 @@
+# Update Dashboard
+
+A self-hosted dashboard for monitoring and applying OS package updates and Docker stack image updates across multiple Linux hosts.
+
+Built with FastAPI + HTMX. No JavaScript frameworks, no database — just a single Docker container.
+
+![Dashboard screenshot](docs/screenshot.png)
+
+## Features
+
+- **OS package updates** — checks `apt` on each host via SSH, shows pending updates with version diffs
+- **One-click apt upgrade** — runs `apt upgrade` remotely with live log streaming
+- **Reboot detection** — shows a "Reboot required" badge and restart button when `/var/run/reboot-required` exists
+- **Docker stack monitoring** — compares running image digests against the registry to detect available updates (via Portainer API)
+- **One-click stack redeploy** — pulls latest images and restarts the stack via Portainer
+- **Admin panel** — manage hosts and SSH settings through the UI, no file editing required
+
+## Quick Start
+
+### 1. Clone the repo
+
+```bash
+git clone https://github.com/d4vastu/update-dashboard.git
+cd update-dashboard
+```
+
+### 2. Create your config file
+
+```bash
+cp config.example.yml config.yml
+```
+
+Edit `config.yml` to add your hosts and SSH settings (or use the Admin panel after starting).
+
+### 3. Add your SSH key
+
+Place your SSH private key in the `keys/` directory:
+
+```bash
+mkdir -p keys
+cp ~/.ssh/id_ed25519 keys/
+```
+
+The key must allow passwordless login to your hosts as root (or the configured user).
+
+### 4. Configure environment variables
+
+Edit the `environment:` section in `docker-compose.yml`:
+
+```yaml
+environment:
+  - PORTAINER_URL=https://192.168.1.x:9443
+  - PORTAINER_API_KEY=your_portainer_api_key_here
+  - PORTAINER_VERIFY_SSL=false
+```
+
+See [Environment Variables](#environment-variables) below for the full list.
+
+### 5. Start the container
+
+```bash
+docker compose up -d
+```
+
+Open **http://localhost:8765** in your browser.
+
+---
+
+## Environment Variables
+
+| Variable | Required | Description |
+|---|---|---|
+| `PORTAINER_URL` | For Docker monitoring | Full URL to your Portainer instance, e.g. `https://192.168.1.10:9443` |
+| `PORTAINER_API_KEY` | For Docker monitoring | Portainer API key. Generate one in Portainer → User settings → Access tokens |
+| `PORTAINER_VERIFY_SSL` | No | Set to `true` if Portainer uses a trusted certificate. Default: `false` |
+| `DOCKERHUB_USERNAME` | No | Docker Hub username. Raises rate limit from 100 to 200 pulls/6h |
+| `DOCKERHUB_TOKEN` | No | Docker Hub access token (not your password) |
+
+---
+
+## config.yml
+
+Hosts and SSH settings live in `config.yml`. This file is mounted into the container and can be edited via the **Admin panel** at `/admin`.
+
+```yaml
+ssh:
+  default_key: /app/keys/id_ed25519   # path inside the container
+  default_user: root
+  default_port: 22
+  connect_timeout: 15                  # seconds
+  command_timeout: 600                 # seconds (10 min for apt upgrade)
+
+hosts:
+  - name: "My Server"
+    host: 192.168.1.10
+
+  - name: "Another Host"
+    host: 192.168.1.20
+    user: ubuntu        # overrides default_user
+    port: 2222          # overrides default_port
+```
+
+**Note:** `config.yml` is gitignored. Never commit it — it contains your host IPs and may contain sensitive paths.
+
+---
+
+## Admin Panel
+
+Navigate to **/admin** to:
+
+- Add, edit, or remove hosts
+- Update SSH defaults (user, port, key path, timeouts)
+- View connection status for Portainer and Docker Hub
+
+Changes to hosts and SSH settings are written to `config.yml` immediately and take effect on the next check — no restart required.
+
+---
+
+## SSH Key Setup
+
+Your hosts need to accept passwordless SSH from the container. The recommended setup:
+
+```bash
+# Generate a dedicated key for the dashboard
+ssh-keygen -t ed25519 -f keys/id_ed25519 -N ""
+
+# Copy the public key to each host
+ssh-copy-id -i keys/id_ed25519.pub root@192.168.1.10
+```
+
+The `entrypoint.sh` script automatically fixes key permissions (`chmod 600`) at container startup since Docker volumes don't preserve them.
+
+---
+
+## Building from Source
+
+```bash
+git clone https://github.com/d4vastu/update-dashboard.git
+cd update-dashboard
+docker compose build
+docker compose up -d
+```
+
+Or run locally for development:
+
+```bash
+pip install -r requirements.txt
+CONFIG_PATH=./config.yml uvicorn app.main:app --reload --port 8000
+```
+
+---
+
+## Architecture
+
+```
+FastAPI (Python)
+├── SSH via asyncssh        → apt check / upgrade / reboot on each host
+├── Portainer API via httpx → list stacks, compare image digests, redeploy
+└── HTMX frontend           → partial HTML responses, no page reloads
+```
+
+Config is loaded from `config.yml` on each request (hosts + SSH). Secrets are injected via environment variables and never written to disk.
+
+---
+
+## License
+
+MIT

--- a/app/admin.py
+++ b/app/admin.py
@@ -1,0 +1,175 @@
+import os
+from pathlib import Path
+
+from fastapi import APIRouter, Form, Request
+from fastapi.responses import HTMLResponse
+from fastapi.templating import Jinja2Templates
+
+from .config_manager import (
+    add_host,
+    delete_host,
+    get_hosts,
+    get_ssh_config,
+    slugify,
+    update_host,
+    update_ssh_config,
+)
+
+router = APIRouter(prefix="/admin")
+templates = Jinja2Templates(directory=Path(__file__).parent / "templates")
+
+
+def _connection_status() -> dict:
+    return {
+        "portainer_url": os.getenv("PORTAINER_URL", ""),
+        "portainer_key_set": bool(os.getenv("PORTAINER_API_KEY", "")),
+        "dockerhub_user": os.getenv("DOCKERHUB_USERNAME", ""),
+        "dockerhub_token_set": bool(os.getenv("DOCKERHUB_TOKEN", "")),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Admin page
+# ---------------------------------------------------------------------------
+
+@router.get("", response_class=HTMLResponse)
+async def admin_page(request: Request) -> HTMLResponse:
+    return templates.TemplateResponse(
+        "admin.html",
+        {
+            "request": request,
+            "hosts": get_hosts(),
+            "ssh": get_ssh_config(),
+            "conn": _connection_status(),
+        },
+    )
+
+
+# ---------------------------------------------------------------------------
+# Hosts
+# ---------------------------------------------------------------------------
+
+@router.get("/hosts", response_class=HTMLResponse)
+async def admin_hosts(request: Request) -> HTMLResponse:
+    return templates.TemplateResponse(
+        "partials/admin_hosts.html",
+        {"request": request, "hosts": get_hosts()},
+    )
+
+
+@router.post("/hosts", response_class=HTMLResponse)
+async def admin_add_host(
+    request: Request,
+    name: str = Form(...),
+    host: str = Form(...),
+    user: str = Form(""),
+    port: str = Form(""),
+    key: str = Form(""),
+) -> HTMLResponse:
+    try:
+        add_host(
+            name=name.strip(),
+            host=host.strip(),
+            user=user.strip() or None,
+            port=int(port) if port.strip() else None,
+            key=key.strip() or None,
+        )
+    except Exception as exc:
+        return templates.TemplateResponse(
+            "partials/admin_hosts.html",
+            {"request": request, "hosts": get_hosts(), "error": str(exc)},
+        )
+    return templates.TemplateResponse(
+        "partials/admin_hosts.html",
+        {"request": request, "hosts": get_hosts()},
+    )
+
+
+@router.get("/hosts/{slug}/edit", response_class=HTMLResponse)
+async def admin_edit_host_form(request: Request, slug: str) -> HTMLResponse:
+    hosts = get_hosts()
+    host = next((h for h in hosts if h["slug"] == slug), None)
+    if not host:
+        return HTMLResponse("<span class='text-red-400 text-xs'>Host not found</span>")
+    return templates.TemplateResponse(
+        "partials/admin_host_edit_form.html",
+        {"request": request, "host": host},
+    )
+
+
+@router.put("/hosts/{slug}", response_class=HTMLResponse)
+async def admin_update_host(
+    request: Request,
+    slug: str,
+    name: str = Form(...),
+    host: str = Form(...),
+    user: str = Form(""),
+    port: str = Form(""),
+    key: str = Form(""),
+) -> HTMLResponse:
+    try:
+        update_host(
+            slug=slug,
+            name=name.strip(),
+            host=host.strip(),
+            user=user.strip() or None,
+            port=int(port) if port.strip() else None,
+            key=key.strip() or None,
+        )
+    except Exception as exc:
+        return templates.TemplateResponse(
+            "partials/admin_hosts.html",
+            {"request": request, "hosts": get_hosts(), "error": str(exc)},
+        )
+    return templates.TemplateResponse(
+        "partials/admin_hosts.html",
+        {"request": request, "hosts": get_hosts()},
+    )
+
+
+@router.delete("/hosts/{slug}", response_class=HTMLResponse)
+async def admin_delete_host(request: Request, slug: str) -> HTMLResponse:
+    try:
+        delete_host(slug)
+    except Exception as exc:
+        return templates.TemplateResponse(
+            "partials/admin_hosts.html",
+            {"request": request, "hosts": get_hosts(), "error": str(exc)},
+        )
+    return templates.TemplateResponse(
+        "partials/admin_hosts.html",
+        {"request": request, "hosts": get_hosts()},
+    )
+
+
+# ---------------------------------------------------------------------------
+# SSH settings
+# ---------------------------------------------------------------------------
+
+@router.put("/ssh", response_class=HTMLResponse)
+async def admin_update_ssh(
+    request: Request,
+    default_user: str = Form("root"),
+    default_port: str = Form("22"),
+    default_key: str = Form("/app/keys/id_ed25519"),
+    connect_timeout: str = Form("15"),
+    command_timeout: str = Form("600"),
+) -> HTMLResponse:
+    try:
+        update_ssh_config(
+            default_user=default_user.strip(),
+            default_port=int(default_port),
+            default_key=default_key.strip(),
+            connect_timeout=int(connect_timeout),
+            command_timeout=int(command_timeout),
+        )
+        saved = True
+    except Exception as exc:
+        return templates.TemplateResponse(
+            "partials/admin_ssh.html",
+            {"request": request, "ssh": get_ssh_config(), "error": str(exc)},
+        )
+    return templates.TemplateResponse(
+        "partials/admin_ssh.html",
+        {"request": request, "ssh": get_ssh_config(), "saved": saved},
+    )

--- a/app/config_manager.py
+++ b/app/config_manager.py
@@ -1,0 +1,103 @@
+import os
+import threading
+from pathlib import Path
+
+import yaml
+
+_CONFIG_PATH = Path(os.getenv("CONFIG_PATH", "/app/config.yml"))
+_lock = threading.Lock()
+
+
+def slugify(name: str) -> str:
+    return name.lower().replace(" ", "-").replace("_", "-")
+
+
+def load_config() -> dict:
+    with _lock:
+        if not _CONFIG_PATH.exists():
+            return {"hosts": [], "ssh": {}}
+        return yaml.safe_load(_CONFIG_PATH.read_text()) or {}
+
+
+def save_config(config: dict) -> None:
+    with _lock:
+        _CONFIG_PATH.write_text(
+            yaml.dump(config, default_flow_style=False, allow_unicode=True, sort_keys=False)
+        )
+
+
+# ---------------------------------------------------------------------------
+# Hosts
+# ---------------------------------------------------------------------------
+
+def get_hosts() -> list[dict]:
+    config = load_config()
+    hosts = config.get("hosts", []) or []
+    return [
+        {**h, "slug": slugify(h["name"])}
+        for h in hosts
+        if "XXX" not in str(h.get("host", ""))
+    ]
+
+
+def add_host(name: str, host: str, user: str | None, port: int | None, key: str | None) -> None:
+    config = load_config()
+    hosts = config.setdefault("hosts", [])
+    entry: dict = {"name": name, "host": host}
+    if user:
+        entry["user"] = user
+    if port:
+        entry["port"] = port
+    if key:
+        entry["key"] = key
+    hosts.append(entry)
+    save_config(config)
+
+
+def update_host(slug: str, name: str, host: str, user: str | None, port: int | None, key: str | None) -> None:
+    config = load_config()
+    hosts = config.get("hosts", [])
+    for i, h in enumerate(hosts):
+        if slugify(h["name"]) == slug:
+            entry: dict = {"name": name, "host": host}
+            if user:
+                entry["user"] = user
+            if port:
+                entry["port"] = port
+            if key:
+                entry["key"] = key
+            hosts[i] = entry
+            break
+    save_config(config)
+
+
+def delete_host(slug: str) -> None:
+    config = load_config()
+    config["hosts"] = [h for h in config.get("hosts", []) if slugify(h["name"]) != slug]
+    save_config(config)
+
+
+# ---------------------------------------------------------------------------
+# SSH settings
+# ---------------------------------------------------------------------------
+
+def get_ssh_config() -> dict:
+    return load_config().get("ssh", {})
+
+
+def update_ssh_config(
+    default_user: str,
+    default_port: int,
+    default_key: str,
+    connect_timeout: int,
+    command_timeout: int,
+) -> None:
+    config = load_config()
+    config["ssh"] = {
+        "default_key": default_key,
+        "default_user": default_user,
+        "default_port": default_port,
+        "connect_timeout": connect_timeout,
+        "command_timeout": command_timeout,
+    }
+    save_config(config)

--- a/app/main.py
+++ b/app/main.py
@@ -1,11 +1,13 @@
+import os
 import uuid
 from pathlib import Path
 
-import yaml
 from fastapi import BackgroundTasks, FastAPI, Request
 from fastapi.responses import HTMLResponse
 from fastapi.templating import Jinja2Templates
 
+from .admin import router as admin_router
+from .config_manager import get_hosts, get_ssh_config
 from .portainer_client import PortainerClient
 from .ssh_client import check_host_updates, reboot_host, run_host_update_buffered
 
@@ -14,46 +16,42 @@ from .ssh_client import check_host_updates, reboot_host, run_host_update_buffere
 # ---------------------------------------------------------------------------
 
 app = FastAPI(title="Update Dashboard")
+app.include_router(admin_router)
 templates = Jinja2Templates(directory=Path(__file__).parent / "templates")
 
 # ---------------------------------------------------------------------------
-# Config
+# Config — secrets from env vars, structure from config.yml
 # ---------------------------------------------------------------------------
 
-_config_path = Path("/app/config.yml")
-config: dict = yaml.safe_load(_config_path.read_text())
-
-ssh_cfg: dict = config.get("ssh", {})
-dockerhub_creds: dict | None = config.get("dockerhub")
-
 portainer: PortainerClient | None = None
+
+# DockerHub credentials (optional, raises registry pull rate limit)
+_dockerhub_user = os.getenv("DOCKERHUB_USERNAME", "")
+_dockerhub_token = os.getenv("DOCKERHUB_TOKEN", "")
+dockerhub_creds: dict | None = (
+    {"username": _dockerhub_user, "token": _dockerhub_token}
+    if _dockerhub_user and _dockerhub_token
+    else None
+)
 
 
 @app.on_event("startup")
 async def _startup() -> None:
     global portainer
-    pcfg = config.get("portainer", {})
-    url = pcfg.get("url", "")
-    key = pcfg.get("api_key", "")
-    if url and key and key != "YOUR_PORTAINER_API_KEY_HERE":
-        portainer = PortainerClient(
-            url=url,
-            api_key=key,
-            verify_ssl=pcfg.get("verify_ssl", False),
-        )
+    url = os.getenv("PORTAINER_URL", "")
+    key = os.getenv("PORTAINER_API_KEY", "")
+    verify_ssl = os.getenv("PORTAINER_VERIFY_SSL", "false").lower() == "true"
+    if url and key:
+        portainer = PortainerClient(url=url, api_key=key, verify_ssl=verify_ssl)
 
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
 
-def _slugify(name: str) -> str:
-    return name.lower().replace(" ", "-").replace("_", "-")
-
-
 def _get_host(slug: str) -> dict:
-    for h in config.get("hosts", []):
-        if _slugify(h["name"]) == slug:
+    for h in get_hosts():
+        if h["slug"] == slug:
             return h
     raise KeyError(f"Host {slug!r} not in config")
 
@@ -68,7 +66,7 @@ _jobs: dict[str, dict] = {}
 
 async def _job_run_host_update(job_id: str, host: dict) -> None:
     try:
-        lines = await run_host_update_buffered(host, ssh_cfg)
+        lines = await run_host_update_buffered(host, get_ssh_config())
         _jobs[job_id]["lines"] = lines
         _jobs[job_id]["status"] = "done"
     except Exception as exc:
@@ -80,7 +78,7 @@ async def _job_run_host_update(job_id: str, host: dict) -> None:
 
 async def _job_run_host_restart(job_id: str, host: dict) -> None:
     try:
-        lines = await reboot_host(host, ssh_cfg)
+        lines = await reboot_host(host, get_ssh_config())
         _jobs[job_id]["lines"] = lines
         _jobs[job_id]["status"] = "done"
     except Exception as exc:
@@ -109,14 +107,9 @@ async def _job_run_stack_update(job_id: str, stack_id: int, endpoint_id: int) ->
 
 @app.get("/", response_class=HTMLResponse)
 async def dashboard(request: Request) -> HTMLResponse:
-    hosts = [
-        {**h, "slug": _slugify(h["name"])}
-        for h in config.get("hosts", [])
-        if "XXX" not in str(h.get("host", ""))   # skip unfilled placeholders
-    ]
     return templates.TemplateResponse(
         "index.html",
-        {"request": request, "hosts": hosts, "portainer_configured": portainer is not None},
+        {"request": request, "hosts": get_hosts(), "portainer_configured": portainer is not None},
     )
 
 
@@ -128,7 +121,7 @@ async def dashboard(request: Request) -> HTMLResponse:
 async def host_check(request: Request, slug: str) -> HTMLResponse:
     try:
         host = _get_host(slug)
-        result = await check_host_updates(host, ssh_cfg)
+        result = await check_host_updates(host, get_ssh_config())
         return templates.TemplateResponse(
             "partials/host_status.html",
             {

--- a/app/templates/admin.html
+++ b/app/templates/admin.html
@@ -1,0 +1,104 @@
+<!DOCTYPE html>
+<html lang="en" class="h-full">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Admin — Update Dashboard</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script src="https://unpkg.com/htmx.org@1.9.12"></script>
+  <style>
+    body { background-color: #0f172a; }
+  </style>
+</head>
+<body class="min-h-full text-slate-200 font-sans">
+
+  <div class="max-w-4xl mx-auto px-4 py-8">
+
+    <!-- Header -->
+    <div class="flex items-center justify-between mb-8">
+      <div>
+        <h1 class="text-2xl font-bold text-white">Admin</h1>
+        <p class="text-sm text-slate-500 mt-0.5">Manage hosts and configuration</p>
+      </div>
+      <a href="/"
+        class="px-4 py-2 rounded-lg bg-slate-700 hover:bg-slate-600 text-sm font-medium text-slate-300 transition-colors">
+        ← Dashboard
+      </a>
+    </div>
+
+    <!-- Connection Status -->
+    <section class="mb-8">
+      <h2 class="text-base font-semibold text-slate-300 mb-3">Connection Settings</h2>
+      <div class="bg-slate-800/50 rounded-xl border border-slate-700 p-5 space-y-4">
+        <p class="text-xs text-slate-500">These are set via environment variables in your <code class="text-slate-300 bg-slate-700 px-1 rounded">docker-compose.yml</code>.</p>
+
+        <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+          <!-- Portainer -->
+          <div class="space-y-2">
+            <p class="text-xs font-medium text-slate-400 uppercase tracking-wider">Portainer</p>
+            <div class="flex items-center gap-2 text-sm">
+              {% if conn.portainer_url %}
+              <span class="w-2 h-2 rounded-full bg-green-400 flex-shrink-0"></span>
+              <span class="text-slate-300 font-mono text-xs truncate">{{ conn.portainer_url }}</span>
+              {% else %}
+              <span class="w-2 h-2 rounded-full bg-slate-600 flex-shrink-0"></span>
+              <span class="text-slate-500 text-xs">PORTAINER_URL not set</span>
+              {% endif %}
+            </div>
+            <div class="flex items-center gap-2 text-sm">
+              {% if conn.portainer_key_set %}
+              <span class="w-2 h-2 rounded-full bg-green-400 flex-shrink-0"></span>
+              <span class="text-slate-300 text-xs">API key configured</span>
+              {% else %}
+              <span class="w-2 h-2 rounded-full bg-amber-500 flex-shrink-0"></span>
+              <span class="text-slate-400 text-xs">PORTAINER_API_KEY not set</span>
+              {% endif %}
+            </div>
+          </div>
+
+          <!-- DockerHub -->
+          <div class="space-y-2">
+            <p class="text-xs font-medium text-slate-400 uppercase tracking-wider">Docker Hub <span class="normal-case font-normal text-slate-500">(optional)</span></p>
+            <div class="flex items-center gap-2 text-sm">
+              {% if conn.dockerhub_user %}
+              <span class="w-2 h-2 rounded-full bg-green-400 flex-shrink-0"></span>
+              <span class="text-slate-300 text-xs">{{ conn.dockerhub_user }}</span>
+              {% else %}
+              <span class="w-2 h-2 rounded-full bg-slate-600 flex-shrink-0"></span>
+              <span class="text-slate-500 text-xs">DOCKERHUB_USERNAME not set</span>
+              {% endif %}
+            </div>
+            <div class="flex items-center gap-2 text-sm">
+              {% if conn.dockerhub_token_set %}
+              <span class="w-2 h-2 rounded-full bg-green-400 flex-shrink-0"></span>
+              <span class="text-slate-300 text-xs">Token configured</span>
+              {% else %}
+              <span class="w-2 h-2 rounded-full bg-slate-600 flex-shrink-0"></span>
+              <span class="text-slate-500 text-xs">DOCKERHUB_TOKEN not set</span>
+              {% endif %}
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- Hosts -->
+    <section class="mb-8">
+      <h2 class="text-base font-semibold text-slate-300 mb-3">Hosts</h2>
+      <div id="admin-hosts">
+        {% include "partials/admin_hosts.html" %}
+      </div>
+    </section>
+
+    <!-- SSH Defaults -->
+    <section class="mb-8">
+      <h2 class="text-base font-semibold text-slate-300 mb-3">SSH Defaults</h2>
+      <div id="admin-ssh">
+        {% include "partials/admin_ssh.html" %}
+      </div>
+    </section>
+
+  </div>
+
+</body>
+</html>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -22,11 +22,17 @@
         <h1 class="text-2xl font-bold text-white">Update Dashboard</h1>
         <p class="text-sm text-slate-500 mt-0.5">OS packages + Docker stacks across all hosts</p>
       </div>
-      <button
-        onclick="document.querySelectorAll('[data-check]').forEach(el => htmx.trigger(el, 'check'))"
-        class="px-4 py-2 rounded-lg bg-slate-700 hover:bg-slate-600 text-sm font-medium text-white transition-colors">
-        Refresh All
-      </button>
+      <div class="flex items-center gap-3">
+        <button
+          onclick="document.querySelectorAll('[data-check]').forEach(el => htmx.trigger(el, 'check'))"
+          class="px-4 py-2 rounded-lg bg-slate-700 hover:bg-slate-600 text-sm font-medium text-white transition-colors">
+          Refresh All
+        </button>
+        <a href="/admin"
+          class="px-4 py-2 rounded-lg bg-slate-700 hover:bg-slate-600 text-sm font-medium text-slate-300 transition-colors">
+          Admin
+        </a>
+      </div>
     </div>
 
     <!-- OS Updates -->

--- a/app/templates/partials/admin_host_edit_form.html
+++ b/app/templates/partials/admin_host_edit_form.html
@@ -1,0 +1,31 @@
+<tr id="host-row-{{ host.slug }}">
+  <td colspan="5" class="px-5 py-3">
+    <form
+      hx-put="/admin/hosts/{{ host.slug }}"
+      hx-target="#admin-hosts"
+      hx-swap="innerHTML"
+      class="flex flex-wrap items-center gap-3">
+      <input type="text" name="name" value="{{ host.name }}" placeholder="Name *" required
+        class="w-36 bg-slate-800 border border-blue-500 rounded-lg px-3 py-1.5 text-sm text-slate-200 placeholder-slate-500 focus:outline-none" />
+      <input type="text" name="host" value="{{ host.host }}" placeholder="IP / hostname *" required
+        class="w-40 bg-slate-800 border border-blue-500 rounded-lg px-3 py-1.5 text-sm text-slate-200 placeholder-slate-500 focus:outline-none font-mono" />
+      <input type="text" name="user" value="{{ host.user or '' }}" placeholder="User (opt)"
+        class="w-28 bg-slate-800 border border-slate-600 rounded-lg px-3 py-1.5 text-sm text-slate-200 placeholder-slate-500 focus:outline-none focus:border-blue-500" />
+      <input type="number" name="port" value="{{ host.port or '' }}" placeholder="Port (opt)"
+        class="w-24 bg-slate-800 border border-slate-600 rounded-lg px-3 py-1.5 text-sm text-slate-200 placeholder-slate-500 focus:outline-none focus:border-blue-500" />
+      <div class="flex gap-2">
+        <button type="submit"
+          class="text-xs px-3 py-1.5 rounded-lg bg-blue-600 hover:bg-blue-500 text-white font-medium transition-colors">
+          Save
+        </button>
+        <button type="button"
+          hx-get="/admin/hosts"
+          hx-target="#admin-hosts"
+          hx-swap="innerHTML"
+          class="text-xs px-3 py-1.5 rounded-lg bg-slate-700 hover:bg-slate-600 text-slate-300 transition-colors">
+          Cancel
+        </button>
+      </div>
+    </form>
+  </td>
+</tr>

--- a/app/templates/partials/admin_hosts.html
+++ b/app/templates/partials/admin_hosts.html
@@ -1,0 +1,77 @@
+{% if error is defined and error %}
+<div class="mb-3 px-4 py-2 rounded-lg bg-red-900/40 border border-red-700 text-red-300 text-sm">{{ error }}</div>
+{% endif %}
+
+<div class="bg-slate-800/50 rounded-xl border border-slate-700 overflow-hidden">
+  {% if hosts %}
+  <table class="w-full">
+    <thead>
+      <tr class="border-b border-slate-700">
+        <th class="text-left px-5 py-3 text-xs font-medium text-slate-500 uppercase tracking-wider">Name</th>
+        <th class="text-left px-5 py-3 text-xs font-medium text-slate-500 uppercase tracking-wider">Host / IP</th>
+        <th class="text-left px-5 py-3 text-xs font-medium text-slate-500 uppercase tracking-wider">User</th>
+        <th class="text-left px-5 py-3 text-xs font-medium text-slate-500 uppercase tracking-wider">Port</th>
+        <th class="px-5 py-3 w-28"></th>
+      </tr>
+    </thead>
+    <tbody id="hosts-tbody" class="divide-y divide-slate-700/50">
+      {% for host in hosts %}
+      <tr id="host-row-{{ host.slug }}" class="hover:bg-slate-700/20 transition-colors">
+        <td class="px-5 py-3 text-sm font-medium text-slate-200">{{ host.name }}</td>
+        <td class="px-5 py-3 text-sm font-mono text-slate-400">{{ host.host }}</td>
+        <td class="px-5 py-3 text-sm text-slate-400">
+          {% if host.user %}{{ host.user }}{% else %}<span class="text-slate-600">—</span>{% endif %}
+        </td>
+        <td class="px-5 py-3 text-sm text-slate-400">
+          {% if host.port %}{{ host.port }}{% else %}<span class="text-slate-600">—</span>{% endif %}
+        </td>
+        <td class="px-5 py-3 text-right">
+          <div class="flex items-center justify-end gap-2">
+            <button
+              hx-get="/admin/hosts/{{ host.slug }}/edit"
+              hx-target="#host-row-{{ host.slug }}"
+              hx-swap="outerHTML"
+              class="text-xs px-2.5 py-1 rounded bg-slate-700 hover:bg-slate-600 text-slate-300 transition-colors">
+              Edit
+            </button>
+            <button
+              hx-delete="/admin/hosts/{{ host.slug }}"
+              hx-target="#admin-hosts"
+              hx-swap="innerHTML"
+              hx-confirm="Remove host '{{ host.name }}'?"
+              class="text-xs px-2.5 py-1 rounded bg-red-900/50 hover:bg-red-800/60 text-red-300 border border-red-800 transition-colors">
+              Delete
+            </button>
+          </div>
+        </td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+  {% else %}
+  <div class="px-5 py-6 text-sm text-slate-500 text-center">No hosts configured yet.</div>
+  {% endif %}
+
+  <!-- Add host form -->
+  <form
+    hx-post="/admin/hosts"
+    hx-target="#admin-hosts"
+    hx-swap="innerHTML"
+    class="border-t border-slate-700 px-5 py-4 bg-slate-900/30">
+    <p class="text-xs font-medium text-slate-400 uppercase tracking-wider mb-3">Add Host</p>
+    <div class="grid grid-cols-2 sm:grid-cols-5 gap-3">
+      <input type="text" name="name" placeholder="Name *" required
+        class="col-span-2 sm:col-span-1 bg-slate-800 border border-slate-600 rounded-lg px-3 py-2 text-sm text-slate-200 placeholder-slate-500 focus:outline-none focus:border-blue-500" />
+      <input type="text" name="host" placeholder="IP / hostname *" required
+        class="col-span-2 sm:col-span-1 bg-slate-800 border border-slate-600 rounded-lg px-3 py-2 text-sm text-slate-200 placeholder-slate-500 focus:outline-none focus:border-blue-500 font-mono" />
+      <input type="text" name="user" placeholder="User (opt)"
+        class="bg-slate-800 border border-slate-600 rounded-lg px-3 py-2 text-sm text-slate-200 placeholder-slate-500 focus:outline-none focus:border-blue-500" />
+      <input type="number" name="port" placeholder="Port (opt)"
+        class="bg-slate-800 border border-slate-600 rounded-lg px-3 py-2 text-sm text-slate-200 placeholder-slate-500 focus:outline-none focus:border-blue-500" />
+      <button type="submit"
+        class="bg-blue-600 hover:bg-blue-500 text-white text-sm font-medium rounded-lg px-4 py-2 transition-colors">
+        Add
+      </button>
+    </div>
+  </form>
+</div>

--- a/app/templates/partials/admin_ssh.html
+++ b/app/templates/partials/admin_ssh.html
@@ -1,0 +1,48 @@
+<div class="bg-slate-800/50 rounded-xl border border-slate-700 p-5">
+  {% if saved is defined and saved %}
+  <div class="mb-4 px-4 py-2 rounded-lg bg-green-900/40 border border-green-700 text-green-300 text-sm">Settings saved.</div>
+  {% endif %}
+  {% if error is defined and error %}
+  <div class="mb-4 px-4 py-2 rounded-lg bg-red-900/40 border border-red-700 text-red-300 text-sm">{{ error }}</div>
+  {% endif %}
+
+  <form
+    hx-put="/admin/ssh"
+    hx-target="#admin-ssh"
+    hx-swap="innerHTML"
+    class="space-y-4">
+    <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+      <div>
+        <label class="block text-xs font-medium text-slate-400 mb-1.5">Default User</label>
+        <input type="text" name="default_user" value="{{ ssh.default_user or 'root' }}"
+          class="w-full bg-slate-800 border border-slate-600 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:border-blue-500" />
+      </div>
+      <div>
+        <label class="block text-xs font-medium text-slate-400 mb-1.5">Default Port</label>
+        <input type="number" name="default_port" value="{{ ssh.default_port or 22 }}"
+          class="w-full bg-slate-800 border border-slate-600 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:border-blue-500" />
+      </div>
+      <div class="sm:col-span-2">
+        <label class="block text-xs font-medium text-slate-400 mb-1.5">Default Key Path <span class="text-slate-500 font-normal">(inside container)</span></label>
+        <input type="text" name="default_key" value="{{ ssh.default_key or '/app/keys/id_ed25519' }}"
+          class="w-full bg-slate-800 border border-slate-600 rounded-lg px-3 py-2 text-sm text-slate-200 font-mono focus:outline-none focus:border-blue-500" />
+      </div>
+      <div>
+        <label class="block text-xs font-medium text-slate-400 mb-1.5">Connect Timeout <span class="text-slate-500 font-normal">(seconds)</span></label>
+        <input type="number" name="connect_timeout" value="{{ ssh.connect_timeout or 15 }}"
+          class="w-full bg-slate-800 border border-slate-600 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:border-blue-500" />
+      </div>
+      <div>
+        <label class="block text-xs font-medium text-slate-400 mb-1.5">Command Timeout <span class="text-slate-500 font-normal">(seconds)</span></label>
+        <input type="number" name="command_timeout" value="{{ ssh.command_timeout or 600 }}"
+          class="w-full bg-slate-800 border border-slate-600 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:border-blue-500" />
+      </div>
+    </div>
+    <div class="flex justify-end">
+      <button type="submit"
+        class="px-4 py-2 rounded-lg bg-blue-600 hover:bg-blue-500 text-sm font-medium text-white transition-colors">
+        Save SSH Settings
+      </button>
+    </div>
+  </form>
+</div>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,20 @@
 services:
   update-dashboard:
-    build: .
+    image: ghcr.io/d4vastu/update-dashboard:latest  # or use 'build: .' to build locally
+    # build: .
     container_name: update-dashboard
     ports:
       - "8765:8000"
     volumes:
-      - ./config.yml:/app/config.yml:ro
-      - ./keys:/app/keys:ro
+      - ./config.yml:/app/config.yml        # hosts + SSH settings (writable for admin panel)
+      - ./keys:/app/keys:ro                  # SSH private keys
+    environment:
+      # --- Portainer (required for Docker stack monitoring) ---
+      - PORTAINER_URL=https://192.168.1.x:9443
+      - PORTAINER_API_KEY=your_portainer_api_key_here
+      - PORTAINER_VERIFY_SSL=false           # set to true if using a valid cert
+
+      # --- Docker Hub (optional — raises anonymous pull rate limit) ---
+      # - DOCKERHUB_USERNAME=your_username
+      # - DOCKERHUB_TOKEN=your_access_token
     restart: unless-stopped


### PR DESCRIPTION
## Summary

- **Admin panel** at `/admin` — add/edit/remove hosts, update SSH defaults, view Portainer/DockerHub connection status
- **Secrets moved to env vars** — `PORTAINER_URL`, `PORTAINER_API_KEY`, `DOCKERHUB_USERNAME`, `DOCKERHUB_TOKEN` are now injected via `docker-compose.yml` environment, nothing sensitive lives in `config.yml`
- **`config.yml`** now only holds hosts and SSH settings — writable by the admin panel at runtime
- **README** — quick start, env var reference table, SSH key setup, config.yml structure, architecture overview

## Test plan

- [ ] Start container with `PORTAINER_URL` / `PORTAINER_API_KEY` env vars set — dashboard Docker section works
- [ ] Navigate to `/admin` — connection status shows green for configured vars
- [ ] Add a host via admin panel, verify it appears on dashboard and checks fire
- [ ] Edit and delete a host
- [ ] Update SSH defaults, verify changes persist in `config.yml`
- [ ] Start container with no Portainer env vars — Docker section shows "not configured", admin shows grey indicators

🤖 Generated with [Claude Code](https://claude.com/claude-code)