### PR TITLE
Improve host management UI in admin panel

### DIFF
--- a/app/templates/partials/admin_host_edit_form.html
+++ b/app/templates/partials/admin_host_edit_form.html
@@ -1,29 +1,52 @@
 <tr id="host-row-{{ host.slug }}">
-  <td colspan="5" class="px-5 py-3">
+  <td colspan="5" class="px-5 py-4 bg-slate-700/20">
     <form
       hx-put="/admin/hosts/{{ host.slug }}"
       hx-target="#admin-hosts"
       hx-swap="innerHTML"
-      class="flex flex-wrap items-center gap-3">
-      <input type="text" name="name" value="{{ host.name }}" placeholder="Name *" required
-        class="w-36 bg-slate-800 border border-blue-500 rounded-lg px-3 py-1.5 text-sm text-slate-200 placeholder-slate-500 focus:outline-none" />
-      <input type="text" name="host" value="{{ host.host }}" placeholder="IP / hostname *" required
-        class="w-40 bg-slate-800 border border-blue-500 rounded-lg px-3 py-1.5 text-sm text-slate-200 placeholder-slate-500 focus:outline-none font-mono" />
-      <input type="text" name="user" value="{{ host.user or '' }}" placeholder="User (opt)"
-        class="w-28 bg-slate-800 border border-slate-600 rounded-lg px-3 py-1.5 text-sm text-slate-200 placeholder-slate-500 focus:outline-none focus:border-blue-500" />
-      <input type="number" name="port" value="{{ host.port or '' }}" placeholder="Port (opt)"
-        class="w-24 bg-slate-800 border border-slate-600 rounded-lg px-3 py-1.5 text-sm text-slate-200 placeholder-slate-500 focus:outline-none focus:border-blue-500" />
-      <div class="flex gap-2">
-        <button type="submit"
-          class="text-xs px-3 py-1.5 rounded-lg bg-blue-600 hover:bg-blue-500 text-white font-medium transition-colors">
-          Save
-        </button>
+      class="space-y-3">
+
+      <p class="text-xs font-medium text-slate-400">Editing <span class="text-slate-200">{{ host.name }}</span></p>
+
+      <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
+        <div>
+          <label class="block text-xs text-slate-500 mb-1">Display Name <span class="text-red-400">*</span></label>
+          <input type="text" name="name" value="{{ host.name }}" required
+            class="w-full bg-slate-900 border border-blue-500 rounded-lg px-3 py-1.5 text-sm text-slate-200 focus:outline-none" />
+        </div>
+        <div>
+          <label class="block text-xs text-slate-500 mb-1">IP / Hostname <span class="text-red-400">*</span></label>
+          <input type="text" name="host" value="{{ host.host }}" required
+            class="w-full bg-slate-900 border border-blue-500 rounded-lg px-3 py-1.5 text-sm text-slate-200 font-mono focus:outline-none" />
+        </div>
+        <div>
+          <label class="block text-xs text-slate-500 mb-1">SSH User <span class="text-slate-600">(optional)</span></label>
+          <input type="text" name="user" value="{{ host.user or '' }}" placeholder="Use SSH default"
+            class="w-full bg-slate-900 border border-slate-600 rounded-lg px-3 py-1.5 text-sm text-slate-200 placeholder-slate-600 focus:outline-none focus:border-blue-500" />
+        </div>
+        <div>
+          <label class="block text-xs text-slate-500 mb-1">SSH Port <span class="text-slate-600">(optional)</span></label>
+          <input type="number" name="port" value="{{ host.port or '' }}" placeholder="Use SSH default" min="1" max="65535"
+            class="w-full bg-slate-900 border border-slate-600 rounded-lg px-3 py-1.5 text-sm text-slate-200 placeholder-slate-600 focus:outline-none focus:border-blue-500" />
+        </div>
+        <div class="sm:col-span-2">
+          <label class="block text-xs text-slate-500 mb-1">SSH Key Path <span class="text-slate-600">(optional)</span></label>
+          <input type="text" name="key" value="{{ host.key or '' }}" placeholder="Use SSH default key"
+            class="w-full bg-slate-900 border border-slate-600 rounded-lg px-3 py-1.5 text-sm text-slate-200 placeholder-slate-600 font-mono focus:outline-none focus:border-blue-500" />
+        </div>
+      </div>
+
+      <div class="flex gap-2 justify-end">
         <button type="button"
           hx-get="/admin/hosts"
           hx-target="#admin-hosts"
           hx-swap="innerHTML"
           class="text-xs px-3 py-1.5 rounded-lg bg-slate-700 hover:bg-slate-600 text-slate-300 transition-colors">
           Cancel
+        </button>
+        <button type="submit"
+          class="text-xs px-3 py-1.5 rounded-lg bg-blue-600 hover:bg-blue-500 text-white font-medium transition-colors">
+          Save Changes
         </button>
       </div>
     </form>

--- a/app/templates/partials/admin_hosts.html
+++ b/app/templates/partials/admin_hosts.html
@@ -2,7 +2,8 @@
 <div class="mb-3 px-4 py-2 rounded-lg bg-red-900/40 border border-red-700 text-red-300 text-sm">{{ error }}</div>
 {% endif %}
 
-<div class="bg-slate-800/50 rounded-xl border border-slate-700 overflow-hidden">
+<!-- Hosts table -->
+<div class="bg-slate-800/50 rounded-xl border border-slate-700 overflow-hidden mb-4">
   {% if hosts %}
   <table class="w-full">
     <thead>
@@ -14,16 +15,16 @@
         <th class="px-5 py-3 w-28"></th>
       </tr>
     </thead>
-    <tbody id="hosts-tbody" class="divide-y divide-slate-700/50">
+    <tbody class="divide-y divide-slate-700/50">
       {% for host in hosts %}
       <tr id="host-row-{{ host.slug }}" class="hover:bg-slate-700/20 transition-colors">
         <td class="px-5 py-3 text-sm font-medium text-slate-200">{{ host.name }}</td>
         <td class="px-5 py-3 text-sm font-mono text-slate-400">{{ host.host }}</td>
         <td class="px-5 py-3 text-sm text-slate-400">
-          {% if host.user %}{{ host.user }}{% else %}<span class="text-slate-600">—</span>{% endif %}
+          {% if host.user %}{{ host.user }}{% else %}<span class="text-slate-600">default</span>{% endif %}
         </td>
         <td class="px-5 py-3 text-sm text-slate-400">
-          {% if host.port %}{{ host.port }}{% else %}<span class="text-slate-600">—</span>{% endif %}
+          {% if host.port %}{{ host.port }}{% else %}<span class="text-slate-600">default</span>{% endif %}
         </td>
         <td class="px-5 py-3 text-right">
           <div class="flex items-center justify-end gap-2">
@@ -49,28 +50,74 @@
     </tbody>
   </table>
   {% else %}
-  <div class="px-5 py-6 text-sm text-slate-500 text-center">No hosts configured yet.</div>
+  <div class="px-5 py-8 text-sm text-slate-500 text-center">
+    No hosts configured yet. Add one below.
+  </div>
   {% endif %}
+</div>
 
-  <!-- Add host form -->
+<!-- Add host form -->
+<div class="bg-slate-800/50 rounded-xl border border-slate-700 p-5">
+  <p class="text-sm font-medium text-slate-300 mb-1">Add Host</p>
+  <p class="text-xs text-slate-500 mb-4">
+    Fields marked <span class="text-red-400">*</span> are required.
+    Leave optional fields blank to use the SSH defaults configured below.
+  </p>
+
   <form
     hx-post="/admin/hosts"
     hx-target="#admin-hosts"
     hx-swap="innerHTML"
-    class="border-t border-slate-700 px-5 py-4 bg-slate-900/30">
-    <p class="text-xs font-medium text-slate-400 uppercase tracking-wider mb-3">Add Host</p>
-    <div class="grid grid-cols-2 sm:grid-cols-5 gap-3">
-      <input type="text" name="name" placeholder="Name *" required
-        class="col-span-2 sm:col-span-1 bg-slate-800 border border-slate-600 rounded-lg px-3 py-2 text-sm text-slate-200 placeholder-slate-500 focus:outline-none focus:border-blue-500" />
-      <input type="text" name="host" placeholder="IP / hostname *" required
-        class="col-span-2 sm:col-span-1 bg-slate-800 border border-slate-600 rounded-lg px-3 py-2 text-sm text-slate-200 placeholder-slate-500 focus:outline-none focus:border-blue-500 font-mono" />
-      <input type="text" name="user" placeholder="User (opt)"
-        class="bg-slate-800 border border-slate-600 rounded-lg px-3 py-2 text-sm text-slate-200 placeholder-slate-500 focus:outline-none focus:border-blue-500" />
-      <input type="number" name="port" placeholder="Port (opt)"
-        class="bg-slate-800 border border-slate-600 rounded-lg px-3 py-2 text-sm text-slate-200 placeholder-slate-500 focus:outline-none focus:border-blue-500" />
+    hx-on::after-request="if(event.detail.successful) this.reset()"
+    class="space-y-4">
+
+    <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+      <div>
+        <label class="block text-xs font-medium text-slate-400 mb-1.5">
+          Display Name <span class="text-red-400">*</span>
+        </label>
+        <input type="text" name="name" placeholder="e.g. Proxmox Main" required
+          class="w-full bg-slate-900 border border-slate-600 rounded-lg px-3 py-2 text-sm text-slate-200 placeholder-slate-600 focus:outline-none focus:border-blue-500 transition-colors" />
+      </div>
+
+      <div>
+        <label class="block text-xs font-medium text-slate-400 mb-1.5">
+          IP Address or Hostname <span class="text-red-400">*</span>
+        </label>
+        <input type="text" name="host" placeholder="e.g. 192.168.1.10" required
+          class="w-full bg-slate-900 border border-slate-600 rounded-lg px-3 py-2 text-sm text-slate-200 placeholder-slate-600 font-mono focus:outline-none focus:border-blue-500 transition-colors" />
+      </div>
+
+      <div>
+        <label class="block text-xs font-medium text-slate-400 mb-1.5">
+          SSH User <span class="text-slate-600 font-normal">(optional)</span>
+        </label>
+        <input type="text" name="user" placeholder="Defaults to SSH default user"
+          class="w-full bg-slate-900 border border-slate-600 rounded-lg px-3 py-2 text-sm text-slate-200 placeholder-slate-600 focus:outline-none focus:border-blue-500 transition-colors" />
+      </div>
+
+      <div>
+        <label class="block text-xs font-medium text-slate-400 mb-1.5">
+          SSH Port <span class="text-slate-600 font-normal">(optional)</span>
+        </label>
+        <input type="number" name="port" placeholder="Defaults to SSH default port" min="1" max="65535"
+          class="w-full bg-slate-900 border border-slate-600 rounded-lg px-3 py-2 text-sm text-slate-200 placeholder-slate-600 focus:outline-none focus:border-blue-500 transition-colors" />
+      </div>
+
+      <div class="sm:col-span-2">
+        <label class="block text-xs font-medium text-slate-400 mb-1.5">
+          SSH Key Path <span class="text-slate-600 font-normal">(optional)</span>
+        </label>
+        <input type="text" name="key" placeholder="Defaults to SSH default key, e.g. /app/keys/id_ed25519"
+          class="w-full bg-slate-900 border border-slate-600 rounded-lg px-3 py-2 text-sm text-slate-200 placeholder-slate-600 font-mono focus:outline-none focus:border-blue-500 transition-colors" />
+        <p class="mt-1 text-xs text-slate-600">Key files must be mounted inside the container under <code class="text-slate-500">/app/keys/</code></p>
+      </div>
+    </div>
+
+    <div class="flex justify-end">
       <button type="submit"
-        class="bg-blue-600 hover:bg-blue-500 text-white text-sm font-medium rounded-lg px-4 py-2 transition-colors">
-        Add
+        class="px-4 py-2 rounded-lg bg-blue-600 hover:bg-blue-500 text-sm font-medium text-white transition-colors">
+        Add Host
       </button>
     </div>
   </form>


### PR DESCRIPTION
## Summary

- Proper labels on all fields (was placeholder-only before)
- Helper text on optional fields: *"Defaults to SSH default user/port/key"*
- SSH key path field added to both add and edit forms, with a note that keys must be mounted under `/app/keys/`
- Empty state message when no hosts are configured
- Table cells show `default` instead of `—` for optional fields — clearer intent
- Add form resets after successful submission
- Edit form has clearer section label and logical Cancel / Save button order

## Test plan

- [ ] Add a host with only Name + IP — verify it appears in table with `default` for user/port
- [ ] Add a host with all fields filled — verify all values shown
- [ ] Edit a host — verify form pre-populates correctly and cancel returns to table
- [ ] Delete a host — verify confirmation dialog and removal

🤖 Generated with [Claude Code](https://claude.com/claude-code)