### PR TITLE
feat: secure encrypted credential store with sudo modal

### DIFF
--- a/app/admin.py
+++ b/app/admin.py
@@ -10,8 +10,15 @@ from .config_manager import (
     delete_host,
     get_hosts,
     get_ssh_config,
+    slugify,
     update_host,
     update_ssh_config,
+)
+from .credentials import (
+    credential_status,
+    delete_credentials,
+    rename_credentials,
+    save_credentials,
 )
 from .ssh_client import verify_connection
 
@@ -28,6 +35,13 @@ def _connection_status() -> dict:
     }
 
 
+def _hosts_with_status() -> list[dict]:
+    return [
+        {**h, **credential_status(h["slug"])}
+        for h in get_hosts()
+    ]
+
+
 # ---------------------------------------------------------------------------
 # Admin page
 # ---------------------------------------------------------------------------
@@ -38,7 +52,7 @@ async def admin_page(request: Request) -> HTMLResponse:
         "admin.html",
         {
             "request": request,
-            "hosts": get_hosts(),
+            "hosts": _hosts_with_status(),
             "ssh": get_ssh_config(),
             "conn": _connection_status(),
         },
@@ -46,14 +60,14 @@ async def admin_page(request: Request) -> HTMLResponse:
 
 
 # ---------------------------------------------------------------------------
-# Hosts
+# Hosts — CRUD
 # ---------------------------------------------------------------------------
 
 @router.get("/hosts", response_class=HTMLResponse)
 async def admin_hosts(request: Request) -> HTMLResponse:
     return templates.TemplateResponse(
         "partials/admin_hosts.html",
-        {"request": request, "hosts": get_hosts()},
+        {"request": request, "hosts": _hosts_with_status()},
     )
 
 
@@ -64,29 +78,25 @@ async def admin_add_host(
     host: str = Form(...),
     user: str = Form(""),
     port: str = Form(""),
-    auth_method: str = Form("key"),
-    key: str = Form(""),
-    password: str = Form(""),
 ) -> HTMLResponse:
     try:
         if not name.strip() or not host.strip():
             raise ValueError("Name and IP / hostname are required.")
-        add_host(
+        slug = add_host(
             name=name.strip(),
             host=host.strip(),
             user=user.strip() or None,
             port=int(port) if port.strip() else None,
-            key=key.strip() or None if auth_method == "key" else None,
-            password=password.strip() or None if auth_method == "password" else None,
         )
     except Exception as exc:
         return templates.TemplateResponse(
             "partials/admin_hosts.html",
-            {"request": request, "hosts": get_hosts(), "error": str(exc)},
+            {"request": request, "hosts": _hosts_with_status(), "error": str(exc)},
         )
+    # Return hosts list + open credential form for the new host
     return templates.TemplateResponse(
         "partials/admin_hosts.html",
-        {"request": request, "hosts": get_hosts()},
+        {"request": request, "hosts": _hosts_with_status(), "open_creds": slug},
     )
 
 
@@ -110,28 +120,24 @@ async def admin_update_host(
     host: str = Form(...),
     user: str = Form(""),
     port: str = Form(""),
-    auth_method: str = Form("key"),
-    key: str = Form(""),
-    password: str = Form(""),
 ) -> HTMLResponse:
     try:
-        update_host(
+        new_slug = update_host(
             slug=slug,
             name=name.strip(),
             host=host.strip(),
             user=user.strip() or None,
             port=int(port) if port.strip() else None,
-            key=key.strip() or None if auth_method == "key" else None,
-            password=password.strip() or None if auth_method == "password" else None,
         )
+        rename_credentials(slug, new_slug)
     except Exception as exc:
         return templates.TemplateResponse(
             "partials/admin_hosts.html",
-            {"request": request, "hosts": get_hosts(), "error": str(exc)},
+            {"request": request, "hosts": _hosts_with_status(), "error": str(exc)},
         )
     return templates.TemplateResponse(
         "partials/admin_hosts.html",
-        {"request": request, "hosts": get_hosts()},
+        {"request": request, "hosts": _hosts_with_status()},
     )
 
 
@@ -139,26 +145,76 @@ async def admin_update_host(
 async def admin_delete_host(request: Request, slug: str) -> HTMLResponse:
     try:
         delete_host(slug)
+        delete_credentials(slug)
     except Exception as exc:
         return templates.TemplateResponse(
             "partials/admin_hosts.html",
-            {"request": request, "hosts": get_hosts(), "error": str(exc)},
+            {"request": request, "hosts": _hosts_with_status(), "error": str(exc)},
         )
     return templates.TemplateResponse(
         "partials/admin_hosts.html",
-        {"request": request, "hosts": get_hosts()},
+        {"request": request, "hosts": _hosts_with_status()},
     )
 
+
+# ---------------------------------------------------------------------------
+# Hosts — credentials
+# ---------------------------------------------------------------------------
+
+@router.get("/hosts/{slug}/credentials", response_class=HTMLResponse)
+async def admin_credentials_form(request: Request, slug: str) -> HTMLResponse:
+    hosts = get_hosts()
+    host = next((h for h in hosts if h["slug"] == slug), None)
+    if not host:
+        return HTMLResponse("<span class='text-red-400 text-xs'>Host not found</span>")
+    status = credential_status(slug)
+    return templates.TemplateResponse(
+        "partials/admin_host_credentials.html",
+        {"request": request, "host": host, "status": status},
+    )
+
+
+@router.post("/hosts/{slug}/credentials", response_class=HTMLResponse)
+async def admin_save_credentials(
+    request: Request,
+    slug: str,
+    auth_method: str = Form("password"),
+    ssh_password: str = Form(""),
+    ssh_key: str = Form(""),
+    sudo_password: str = Form(""),
+) -> HTMLResponse:
+    try:
+        save_credentials(
+            slug=slug,
+            ssh_password=ssh_password.strip() or None if auth_method == "password" else "",
+            ssh_key=ssh_key.strip() or None if auth_method == "key" else "",
+            sudo_password=sudo_password.strip() or None,
+        )
+    except Exception as exc:
+        hosts = get_hosts()
+        host = next((h for h in hosts if h["slug"] == slug), {})
+        return templates.TemplateResponse(
+            "partials/admin_host_credentials.html",
+            {"request": request, "host": host, "status": credential_status(slug), "error": str(exc)},
+        )
+    return templates.TemplateResponse(
+        "partials/admin_hosts.html",
+        {"request": request, "hosts": _hosts_with_status()},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Hosts — connection test
+# ---------------------------------------------------------------------------
 
 @router.post("/hosts/{slug}/test", response_class=HTMLResponse)
 async def admin_test_host(request: Request, slug: str) -> HTMLResponse:
     hosts = get_hosts()
     host = next((h for h in hosts if h["slug"] == slug), None)
     if not host:
-        return HTMLResponse(
-            "<span class='text-red-400 text-xs'>Host not found</span>"
-        )
-    result = await verify_connection(host, get_ssh_config())
+        return HTMLResponse("<span class='text-red-400 text-xs'>Host not found</span>")
+    from .credentials import get_credentials
+    result = await verify_connection(host, get_ssh_config(), get_credentials(slug))
     return templates.TemplateResponse(
         "partials/admin_host_test_result.html",
         {"request": request, "slug": slug, "result": result},

--- a/app/config_manager.py
+++ b/app/config_manager.py
@@ -40,37 +40,35 @@ def get_hosts() -> list[dict]:
     ]
 
 
-def _build_host_entry(name: str, host: str, user: str | None, port: int | None,
-                      key: str | None, password: str | None) -> dict:
+def _build_host_entry(name: str, host: str, user: str | None, port: int | None) -> dict:
+    """Builds a host entry for config.yml — no credentials stored here."""
     entry: dict = {"name": name, "host": host}
     if user:
         entry["user"] = user
     if port:
         entry["port"] = port
-    if password:
-        entry["password"] = password
-    elif key:
-        entry["key"] = key
     return entry
 
 
-def add_host(name: str, host: str, user: str | None, port: int | None,
-             key: str | None, password: str | None = None) -> None:
+def add_host(name: str, host: str, user: str | None, port: int | None) -> str:
+    """Add a host to config and return its slug."""
     config = load_config()
     hosts = config.setdefault("hosts", [])
-    hosts.append(_build_host_entry(name, host, user, port, key, password))
+    hosts.append(_build_host_entry(name, host, user, port))
     save_config(config)
+    return slugify(name)
 
 
-def update_host(slug: str, name: str, host: str, user: str | None, port: int | None,
-                key: str | None, password: str | None = None) -> None:
+def update_host(slug: str, name: str, host: str, user: str | None, port: int | None) -> str:
+    """Update a host entry and return the new slug (may differ if name changed)."""
     config = load_config()
     hosts = config.get("hosts", [])
     for i, h in enumerate(hosts):
         if slugify(h["name"]) == slug:
-            hosts[i] = _build_host_entry(name, host, user, port, key, password)
+            hosts[i] = _build_host_entry(name, host, user, port)
             break
     save_config(config)
+    return slugify(name)
 
 
 def delete_host(slug: str) -> None:

--- a/app/credentials.py
+++ b/app/credentials.py
@@ -1,0 +1,115 @@
+"""
+Encrypted credential store.
+
+Credentials (SSH password, SSH private key, sudo password) are stored in a
+Fernet-encrypted JSON file at /app/data/credentials.json. The encryption key
+is auto-generated on first run and stored at /app/data/.secret.
+
+Nothing sensitive is ever written to config.yml.
+"""
+import json
+import os
+from pathlib import Path
+
+from cryptography.fernet import Fernet, InvalidToken
+
+_DATA_DIR = Path(os.getenv("DATA_PATH", "/app/data"))
+_SECRET_FILE = _DATA_DIR / ".secret"
+_CREDS_FILE = _DATA_DIR / "credentials.json"
+
+
+def _ensure_data_dir() -> None:
+    _DATA_DIR.mkdir(parents=True, exist_ok=True)
+
+
+def _get_fernet() -> Fernet:
+    _ensure_data_dir()
+    if not _SECRET_FILE.exists():
+        _SECRET_FILE.write_bytes(Fernet.generate_key())
+        _SECRET_FILE.chmod(0o600)
+    return Fernet(_SECRET_FILE.read_bytes())
+
+
+def _load_store() -> dict:
+    if not _CREDS_FILE.exists():
+        return {}
+    try:
+        raw = _get_fernet().decrypt(_CREDS_FILE.read_bytes())
+        return json.loads(raw.decode())
+    except (InvalidToken, Exception):
+        return {}
+
+
+def _save_store(store: dict) -> None:
+    _ensure_data_dir()
+    encrypted = _get_fernet().encrypt(json.dumps(store).encode())
+    _CREDS_FILE.write_bytes(encrypted)
+    _CREDS_FILE.chmod(0o600)
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def get_credentials(slug: str) -> dict:
+    """Return the credential dict for a host slug. Never raises."""
+    return _load_store().get(slug, {})
+
+
+def save_credentials(
+    slug: str,
+    ssh_password: str | None = None,
+    ssh_key: str | None = None,
+    sudo_password: str | None = None,
+) -> None:
+    """
+    Save credentials for a host. Pass None to leave an existing value
+    unchanged; pass an empty string "" to explicitly clear a field.
+    """
+    store = _load_store()
+    entry = store.get(slug, {})
+
+    for field, value in [
+        ("ssh_password", ssh_password),
+        ("ssh_key", ssh_key),
+        ("sudo_password", sudo_password),
+    ]:
+        if value is None:
+            continue           # don't touch existing value
+        if value == "":
+            entry.pop(field, None)   # clear
+        else:
+            entry[field] = value     # set
+
+    store[slug] = entry
+    _save_store(store)
+
+
+def save_sudo_password(slug: str, password: str) -> None:
+    save_credentials(slug, sudo_password=password)
+
+
+def delete_credentials(slug: str) -> None:
+    store = _load_store()
+    store.pop(slug, None)
+    _save_store(store)
+
+
+def rename_credentials(old_slug: str, new_slug: str) -> None:
+    """Called when a host is renamed so credentials follow the new slug."""
+    if old_slug == new_slug:
+        return
+    store = _load_store()
+    if old_slug in store:
+        store[new_slug] = store.pop(old_slug)
+        _save_store(store)
+
+
+def credential_status(slug: str) -> dict:
+    """Returns which credentials are configured for a host (no secrets exposed)."""
+    creds = get_credentials(slug)
+    return {
+        "has_ssh_password": bool(creds.get("ssh_password")),
+        "has_ssh_key": bool(creds.get("ssh_key")),
+        "has_sudo_password": bool(creds.get("sudo_password")),
+    }

--- a/app/main.py
+++ b/app/main.py
@@ -2,14 +2,15 @@ import os
 import uuid
 from pathlib import Path
 
-from fastapi import BackgroundTasks, FastAPI, Request
+from fastapi import BackgroundTasks, FastAPI, Form, Request
 from fastapi.responses import HTMLResponse
 from fastapi.templating import Jinja2Templates
 
 from .admin import router as admin_router
 from .config_manager import get_hosts, get_ssh_config
+from .credentials import get_credentials, save_sudo_password
 from .portainer_client import PortainerClient
-from .ssh_client import check_host_updates, reboot_host, run_host_update_buffered
+from .ssh_client import _needs_sudo, check_host_updates, reboot_host, run_host_update_buffered
 
 # ---------------------------------------------------------------------------
 # App setup
@@ -25,7 +26,6 @@ templates = Jinja2Templates(directory=Path(__file__).parent / "templates")
 
 portainer: PortainerClient | None = None
 
-# DockerHub credentials (optional, raises registry pull rate limit)
 _dockerhub_user = os.getenv("DOCKERHUB_USERNAME", "")
 _dockerhub_token = os.getenv("DOCKERHUB_TOKEN", "")
 dockerhub_creds: dict | None = (
@@ -56,7 +56,6 @@ def _get_host(slug: str) -> dict:
     raise KeyError(f"Host {slug!r} not in config")
 
 
-# In-memory job store  {job_id: {"done": bool, "error": str|None, "lines": [str]}}
 _jobs: dict[str, dict] = {}
 
 
@@ -64,9 +63,9 @@ _jobs: dict[str, dict] = {}
 # Background job runners
 # ---------------------------------------------------------------------------
 
-async def _job_run_host_update(job_id: str, host: dict) -> None:
+async def _job_run_host_update(job_id: str, host: dict, creds: dict) -> None:
     try:
-        lines = await run_host_update_buffered(host, get_ssh_config())
+        lines = await run_host_update_buffered(host, get_ssh_config(), creds)
         _jobs[job_id]["lines"] = lines
         _jobs[job_id]["status"] = "done"
     except Exception as exc:
@@ -76,9 +75,9 @@ async def _job_run_host_update(job_id: str, host: dict) -> None:
         _jobs[job_id]["done"] = True
 
 
-async def _job_run_host_restart(job_id: str, host: dict) -> None:
+async def _job_run_host_restart(job_id: str, host: dict, creds: dict) -> None:
     try:
-        lines = await reboot_host(host, get_ssh_config())
+        lines = await reboot_host(host, get_ssh_config(), creds)
         _jobs[job_id]["lines"] = lines
         _jobs[job_id]["status"] = "done"
     except Exception as exc:
@@ -98,7 +97,6 @@ async def _job_run_stack_update(job_id: str, stack_id: int, endpoint_id: int) ->
         _jobs[job_id]["error"] = str(exc)
     finally:
         _jobs[job_id]["done"] = True
-
 
 
 # ---------------------------------------------------------------------------
@@ -121,7 +119,8 @@ async def dashboard(request: Request) -> HTMLResponse:
 async def host_check(request: Request, slug: str) -> HTMLResponse:
     try:
         host = _get_host(slug)
-        result = await check_host_updates(host, get_ssh_config())
+        creds = get_credentials(slug)
+        result = await check_host_updates(host, get_ssh_config(), creds)
         return templates.TemplateResponse(
             "partials/host_status.html",
             {
@@ -140,13 +139,31 @@ async def host_check(request: Request, slug: str) -> HTMLResponse:
 
 @app.post("/api/host/{slug}/update", response_class=HTMLResponse)
 async def host_update(
-    request: Request, slug: str, background_tasks: BackgroundTasks
+    request: Request,
+    slug: str,
+    background_tasks: BackgroundTasks,
+    sudo_password: str = Form(""),
+    save_sudo: str = Form(""),
 ) -> HTMLResponse:
     try:
         host = _get_host(slug)
+        creds = get_credentials(slug)
+
+        # Sudo check: need it, don't have it → show modal
+        if _needs_sudo(host, get_ssh_config()):
+            effective_sudo = sudo_password.strip() or creds.get("sudo_password", "")
+            if not effective_sudo:
+                return templates.TemplateResponse(
+                    "partials/sudo_modal.html",
+                    {"request": request, "slug": slug, "action": "update"},
+                )
+            if sudo_password.strip() and save_sudo == "save":
+                save_sudo_password(slug, sudo_password.strip())
+            creds = {**creds, "sudo_password": effective_sudo}
+
         job_id = uuid.uuid4().hex[:8]
         _jobs[job_id] = {"done": False, "status": "running", "error": None, "lines": []}
-        background_tasks.add_task(_job_run_host_update, job_id, host)
+        background_tasks.add_task(_job_run_host_update, job_id, host, creds)
         return templates.TemplateResponse(
             "partials/job_poll.html",
             {"request": request, "job_id": job_id},
@@ -160,13 +177,30 @@ async def host_update(
 
 @app.post("/api/host/{slug}/restart", response_class=HTMLResponse)
 async def host_restart(
-    request: Request, slug: str, background_tasks: BackgroundTasks
+    request: Request,
+    slug: str,
+    background_tasks: BackgroundTasks,
+    sudo_password: str = Form(""),
+    save_sudo: str = Form(""),
 ) -> HTMLResponse:
     try:
         host = _get_host(slug)
+        creds = get_credentials(slug)
+
+        if _needs_sudo(host, get_ssh_config()):
+            effective_sudo = sudo_password.strip() or creds.get("sudo_password", "")
+            if not effective_sudo:
+                return templates.TemplateResponse(
+                    "partials/sudo_modal.html",
+                    {"request": request, "slug": slug, "action": "restart"},
+                )
+            if sudo_password.strip() and save_sudo == "save":
+                save_sudo_password(slug, sudo_password.strip())
+            creds = {**creds, "sudo_password": effective_sudo}
+
         job_id = uuid.uuid4().hex[:8]
         _jobs[job_id] = {"done": False, "status": "running", "error": None, "lines": []}
-        background_tasks.add_task(_job_run_host_restart, job_id, host)
+        background_tasks.add_task(_job_run_host_restart, job_id, host, creds)
         return templates.TemplateResponse(
             "partials/job_poll.html",
             {"request": request, "job_id": job_id},

--- a/app/ssh_client.py
+++ b/app/ssh_client.py
@@ -1,8 +1,15 @@
 import asyncio
+
 import asyncssh
 
 
-async def _connect(host: dict, ssh_cfg: dict) -> asyncssh.SSHClientConnection:
+def _needs_sudo(host: dict, ssh_cfg: dict) -> bool:
+    user = host.get("user") or ssh_cfg.get("default_user", "root")
+    return user != "root"
+
+
+async def _connect(host: dict, ssh_cfg: dict, creds: dict | None = None) -> asyncssh.SSHClientConnection:
+    creds = creds or {}
     kwargs: dict = {
         "host": host["host"],
         "port": host.get("port", ssh_cfg.get("default_port", 22)),
@@ -10,18 +17,45 @@ async def _connect(host: dict, ssh_cfg: dict) -> asyncssh.SSHClientConnection:
         "known_hosts": None,
         "connect_timeout": ssh_cfg.get("connect_timeout", 15),
     }
-    if host.get("password"):
-        kwargs["password"] = host["password"]
+    if creds.get("ssh_password"):
+        kwargs["password"] = creds["ssh_password"]
         kwargs["preferred_auth"] = "password"
+    elif creds.get("ssh_key"):
+        key = asyncssh.import_private_key(creds["ssh_key"])
+        kwargs["client_keys"] = [key]
     else:
-        kwargs["client_keys"] = [host.get("key", ssh_cfg.get("default_key"))]
+        # Fall back to key file (legacy / existing setups)
+        key_path = host.get("key", ssh_cfg.get("default_key"))
+        if key_path:
+            kwargs["client_keys"] = [key_path]
     return await asyncssh.connect(**kwargs)
 
 
-async def verify_connection(host: dict, ssh_cfg: dict) -> dict:
+async def _run(
+    conn: asyncssh.SSHClientConnection,
+    cmd: str,
+    sudo_password: str | None,
+    needs_sudo: bool,
+    timeout: int | None = None,
+) -> asyncssh.SSHCompletedProcess:
+    """Run a command, wrapping with sudo -S if needed."""
+    if needs_sudo and sudo_password:
+        full_cmd = f"sudo -S {cmd}"
+        stdin_data = sudo_password + "\n"
+    else:
+        full_cmd = cmd
+        stdin_data = None
+
+    coro = conn.run(full_cmd, input=stdin_data, check=False)
+    if timeout:
+        return await asyncio.wait_for(coro, timeout=timeout)
+    return await coro
+
+
+async def verify_connection(host: dict, ssh_cfg: dict, creds: dict | None = None) -> dict:
     """Returns {"ok": bool, "message": str}."""
     try:
-        async with await _connect(host, ssh_cfg) as conn:
+        async with await _connect(host, ssh_cfg, creds) as conn:
             result = await conn.run("echo ok", check=False)
         if result.stdout.strip() == "ok":
             return {"ok": True, "message": "Connected successfully."}
@@ -30,7 +64,9 @@ async def verify_connection(host: dict, ssh_cfg: dict) -> dict:
         return {"ok": False, "message": str(exc)}
 
 
-async def check_host_updates(host: dict, ssh_cfg: dict) -> dict:
+async def check_host_updates(
+    host: dict, ssh_cfg: dict, creds: dict | None = None
+) -> dict:
     """
     Returns:
       {
@@ -38,13 +74,19 @@ async def check_host_updates(host: dict, ssh_cfg: dict) -> dict:
         "reboot_required": bool,
       }
     """
-    async with await _connect(host, ssh_cfg) as conn:
-        result = await conn.run(
-            "apt-get update -qq 2>/dev/null;"
+    creds = creds or {}
+    use_sudo = _needs_sudo(host, ssh_cfg)
+    sudo_password = creds.get("sudo_password")
+
+    async with await _connect(host, ssh_cfg, creds) as conn:
+        result = await _run(
+            conn,
+            "sh -c 'apt-get update -qq 2>/dev/null;"
             " apt list --upgradable 2>/dev/null;"
-            " echo '__REBOOT__';"
-            " [ -f /var/run/reboot-required ] && echo yes || echo no",
-            check=False,
+            " echo __REBOOT__;"
+            " [ -f /var/run/reboot-required ] && echo yes || echo no'",
+            sudo_password=sudo_password,
+            needs_sudo=use_sudo,
         )
 
     output = result.stdout
@@ -58,7 +100,6 @@ async def check_host_updates(host: dict, ssh_cfg: dict) -> dict:
 
     packages = []
     for line in apt_part.splitlines():
-        # Format: "nginx/stable 1.26.0-1 amd64 [upgradable from: 1.24.0-1]"
         if "[upgradable from:" not in line:
             continue
         try:
@@ -73,27 +114,39 @@ async def check_host_updates(host: dict, ssh_cfg: dict) -> dict:
     return {"packages": packages, "reboot_required": reboot_required}
 
 
-async def reboot_host(host: dict, ssh_cfg: dict) -> list[str]:
+async def reboot_host(
+    host: dict, ssh_cfg: dict, creds: dict | None = None
+) -> list[str]:
     """Schedules an immediate reboot and returns. The SSH connection will drop."""
-    async with await _connect(host, ssh_cfg) as conn:
-        await conn.run(
+    creds = creds or {}
+    use_sudo = _needs_sudo(host, ssh_cfg)
+    sudo_password = creds.get("sudo_password")
+
+    async with await _connect(host, ssh_cfg, creds) as conn:
+        await _run(
+            conn,
             "nohup sh -c 'sleep 2 && reboot' >/dev/null 2>&1 &",
-            check=False,
+            sudo_password=sudo_password,
+            needs_sudo=use_sudo,
         )
     return ["Reboot initiated — server will be back in ~30 seconds."]
 
 
-async def run_host_update_buffered(host: dict, ssh_cfg: dict) -> list[str]:
-    """
-    Runs apt-get upgrade and returns all output lines when complete.
-    Used by background job runner.
-    """
-    cmd = "DEBIAN_FRONTEND=noninteractive apt-get upgrade -y 2>&1"
+async def run_host_update_buffered(
+    host: dict, ssh_cfg: dict, creds: dict | None = None
+) -> list[str]:
+    """Runs apt-get upgrade and returns all output lines when complete."""
+    creds = creds or {}
+    use_sudo = _needs_sudo(host, ssh_cfg)
+    sudo_password = creds.get("sudo_password")
     timeout = ssh_cfg.get("command_timeout", 600)
 
-    async with await _connect(host, ssh_cfg) as conn:
-        result = await asyncio.wait_for(
-            conn.run(cmd, check=False),
+    async with await _connect(host, ssh_cfg, creds) as conn:
+        result = await _run(
+            conn,
+            "DEBIAN_FRONTEND=noninteractive apt-get upgrade -y 2>&1",
+            sudo_password=sudo_password,
+            needs_sudo=use_sudo,
             timeout=timeout,
         )
 

--- a/app/templates/partials/admin_host_credentials.html
+++ b/app/templates/partials/admin_host_credentials.html
@@ -1,0 +1,105 @@
+<!-- Inline credential form for a single host -->
+<tr id="host-creds-row-{{ host.slug }}">
+  <td colspan="5" class="px-5 py-4 bg-slate-900/60 border-t border-slate-700/50">
+    <form
+      hx-post="/admin/hosts/{{ host.slug }}/credentials"
+      hx-target="#admin-hosts"
+      hx-swap="innerHTML"
+      class="space-y-4 max-w-xl">
+
+      {% if error is defined and error %}
+      <div class="px-3 py-2 rounded-lg bg-red-900/40 border border-red-700 text-red-300 text-xs">{{ error }}</div>
+      {% endif %}
+
+      <p class="text-xs font-medium text-slate-300">
+        Credentials for <span class="text-white">{{ host.name }}</span>
+        <span class="ml-2 text-slate-500 font-normal font-mono">{{ host.host }}</span>
+      </p>
+
+      <!-- Auth method toggle -->
+      <div>
+        <label class="block text-xs font-medium text-slate-400 mb-2">SSH Authentication</label>
+        <div class="flex gap-4">
+          <label class="flex items-center gap-2 cursor-pointer">
+            <input type="radio" name="auth_method" value="key"
+              {% if not status.has_ssh_password %}checked{% endif %}
+              onchange="document.getElementById('cred-key-{{ host.slug }}').style.display='block'; document.getElementById('cred-pw-{{ host.slug }}').style.display='none';"
+              class="accent-blue-500" />
+            <span class="text-sm text-slate-300">SSH Key</span>
+          </label>
+          <label class="flex items-center gap-2 cursor-pointer">
+            <input type="radio" name="auth_method" value="password"
+              {% if status.has_ssh_password %}checked{% endif %}
+              onchange="document.getElementById('cred-key-{{ host.slug }}').style.display='none'; document.getElementById('cred-pw-{{ host.slug }}').style.display='block';"
+              class="accent-blue-500" />
+            <span class="text-sm text-slate-300">Password</span>
+          </label>
+        </div>
+      </div>
+
+      <!-- SSH Key (paste) -->
+      <div id="cred-key-{{ host.slug }}" {% if status.has_ssh_password %}style="display:none;"{% endif %}>
+        <label class="block text-xs font-medium text-slate-400 mb-1.5">
+          Private Key
+          {% if status.has_ssh_key %}
+          <span class="ml-2 text-green-400 font-normal">&#10003; saved</span>
+          {% endif %}
+        </label>
+        <textarea name="ssh_key" rows="5" placeholder="Paste your private key here (e.g. -----BEGIN OPENSSH PRIVATE KEY-----…)&#10;Leave blank to keep existing key."
+          class="w-full bg-slate-900 border border-slate-600 rounded-lg px-3 py-2 text-xs text-slate-200 placeholder-slate-600 font-mono focus:outline-none focus:border-blue-500 transition-colors resize-none"></textarea>
+        <p class="mt-1 text-xs text-slate-500">
+          Create a dedicated key pair:
+          <code class="text-slate-400 bg-slate-800 px-1 rounded">ssh-keygen -t ed25519 -f ~/.ssh/dashboard_key -N ""</code>
+          then authorize it on the remote host with
+          <code class="text-slate-400 bg-slate-800 px-1 rounded">ssh-copy-id -i ~/.ssh/dashboard_key.pub user@host</code>
+        </p>
+      </div>
+
+      <!-- SSH Password -->
+      <div id="cred-pw-{{ host.slug }}" {% if not status.has_ssh_password %}style="display:none;"{% endif %}>
+        <label class="block text-xs font-medium text-slate-400 mb-1.5">
+          SSH Password
+          {% if status.has_ssh_password %}
+          <span class="ml-2 text-green-400 font-normal">&#10003; saved</span>
+          {% endif %}
+        </label>
+        <input type="password" name="ssh_password" placeholder="Leave blank to keep existing password"
+          class="w-full bg-slate-900 border border-slate-600 rounded-lg px-3 py-2 text-sm text-slate-200 placeholder-slate-600 focus:outline-none focus:border-blue-500 transition-colors" />
+        <p class="mt-1 text-xs text-slate-500">
+          Make sure <code class="text-slate-400 bg-slate-800 px-1 rounded">PasswordAuthentication yes</code> is set
+          in <code class="text-slate-400 bg-slate-800 px-1 rounded">/etc/ssh/sshd_config</code> on the remote host.
+        </p>
+      </div>
+
+      <!-- Sudo password -->
+      <div>
+        <label class="block text-xs font-medium text-slate-400 mb-1.5">
+          Sudo Password
+          <span class="ml-1 text-slate-500 font-normal">(optional — only needed for non-root users)</span>
+          {% if status.has_sudo_password %}
+          <span class="ml-2 text-green-400 font-normal">&#10003; saved</span>
+          {% endif %}
+        </label>
+        <input type="password" name="sudo_password" placeholder="Leave blank to keep existing / be prompted at update time"
+          class="w-full bg-slate-900 border border-slate-600 rounded-lg px-3 py-2 text-sm text-slate-200 placeholder-slate-600 focus:outline-none focus:border-blue-500 transition-colors" />
+        <p class="mt-1 text-xs text-slate-500">
+          If left blank, you'll be prompted when running an update or restart on this host.
+        </p>
+      </div>
+
+      <div class="flex gap-2 justify-end pt-1">
+        <button type="button"
+          hx-get="/admin/hosts"
+          hx-target="#admin-hosts"
+          hx-swap="innerHTML"
+          class="text-xs px-3 py-1.5 rounded-lg bg-slate-700 hover:bg-slate-600 text-slate-300 transition-colors">
+          Cancel
+        </button>
+        <button type="submit"
+          class="text-xs px-3 py-1.5 rounded-lg bg-blue-600 hover:bg-blue-500 text-white font-medium transition-colors">
+          Save Credentials
+        </button>
+      </div>
+    </form>
+  </td>
+</tr>

--- a/app/templates/partials/admin_host_edit_form.html
+++ b/app/templates/partials/admin_host_edit_form.html
@@ -31,39 +31,7 @@
         </div>
       </div>
 
-      <!-- Auth method -->
-      {% set edit_id = host.slug %}
-      {% set use_password = host.password %}
-      <div>
-        <label class="block text-xs text-slate-500 mb-1.5">Authentication Method</label>
-        <div class="flex gap-4">
-          <label class="flex items-center gap-2 cursor-pointer">
-            <input type="radio" name="auth_method" value="key" {% if not use_password %}checked{% endif %}
-              onchange="document.getElementById('edit-key-{{ edit_id }}').style.display='block'; document.getElementById('edit-pw-{{ edit_id }}').style.display='none';"
-              class="accent-blue-500" />
-            <span class="text-sm text-slate-300">SSH Key</span>
-          </label>
-          <label class="flex items-center gap-2 cursor-pointer">
-            <input type="radio" name="auth_method" value="password" {% if use_password %}checked{% endif %}
-              onchange="document.getElementById('edit-key-{{ edit_id }}').style.display='none'; document.getElementById('edit-pw-{{ edit_id }}').style.display='block';"
-              class="accent-blue-500" />
-            <span class="text-sm text-slate-300">Password</span>
-          </label>
-        </div>
-      </div>
-
-      <div id="edit-key-{{ edit_id }}" {% if use_password %}style="display:none;"{% endif %}>
-        <label class="block text-xs text-slate-500 mb-1">SSH Key Path <span class="text-slate-600">(optional)</span></label>
-        <input type="text" name="key" value="{{ host.key or '' }}" placeholder="Leave blank to use SSH default"
-          class="w-full bg-slate-900 border border-slate-600 rounded-lg px-3 py-1.5 text-sm text-slate-200 placeholder-slate-600 font-mono focus:outline-none focus:border-blue-500" />
-      </div>
-
-      <div id="edit-pw-{{ edit_id }}" {% if not use_password %}style="display:none;"{% endif %}>
-        <label class="block text-xs text-slate-500 mb-1">Password</label>
-        <input type="password" name="password" placeholder="Leave blank to keep existing password"
-          class="w-full bg-slate-900 border border-slate-600 rounded-lg px-3 py-1.5 text-sm text-slate-200 placeholder-slate-600 focus:outline-none focus:border-blue-500" />
-        <p class="mt-1 text-xs text-amber-700">Stored in plaintext in config.yml — use a dedicated user, never root.</p>
-      </div>
+      <p class="text-xs text-slate-500">To change credentials, use the <span class="text-slate-300">Credentials</span> button on the host row.</p>
 
       <div class="flex gap-2 justify-end">
         <button type="button"

--- a/app/templates/partials/admin_hosts.html
+++ b/app/templates/partials/admin_hosts.html
@@ -11,8 +11,8 @@
         <th class="text-left px-5 py-3 text-xs font-medium text-slate-500 uppercase tracking-wider">Name</th>
         <th class="text-left px-5 py-3 text-xs font-medium text-slate-500 uppercase tracking-wider">Host / IP</th>
         <th class="text-left px-5 py-3 text-xs font-medium text-slate-500 uppercase tracking-wider">User</th>
-        <th class="text-left px-5 py-3 text-xs font-medium text-slate-500 uppercase tracking-wider">Auth</th>
-        <th class="px-5 py-3 w-44"></th>
+        <th class="text-left px-5 py-3 text-xs font-medium text-slate-500 uppercase tracking-wider">Credentials</th>
+        <th class="px-5 py-3 w-52"></th>
       </tr>
     </thead>
     <tbody class="divide-y divide-slate-700/50">
@@ -23,24 +23,35 @@
         <td class="px-5 py-3 text-sm text-slate-400">
           {% if host.user %}{{ host.user }}{% else %}<span class="text-slate-600">default</span>{% endif %}
         </td>
-        <td class="px-5 py-3 text-sm">
-          {% if host.password %}
-          <span class="inline-flex items-center gap-1 text-xs text-slate-400">
-            <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-                d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"/>
-            </svg>
-            Password
-          </span>
-          {% else %}
-          <span class="inline-flex items-center gap-1 text-xs text-slate-400">
-            <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-                d="M15 7a2 2 0 012 2m4 0a6 6 0 01-7.743 5.743L11 17H9v2H7v2H4a1 1 0 01-1-1v-2.586a1 1 0 01.293-.707l5.964-5.964A6 6 0 1121 9z"/>
-            </svg>
-            SSH Key
-          </span>
-          {% endif %}
+        <td class="px-5 py-3">
+          <div class="flex items-center gap-1.5 flex-wrap">
+            {% if host.has_ssh_key %}
+            <span class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs bg-blue-900/40 text-blue-300 border border-blue-800">
+              <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                  d="M15 7a2 2 0 012 2m4 0a6 6 0 01-7.743 5.743L11 17H9v2H7v2H4a1 1 0 01-1-1v-2.586a1 1 0 01.293-.707l5.964-5.964A6 6 0 1121 9z"/>
+              </svg>
+              SSH Key
+            </span>
+            {% elif host.has_ssh_password %}
+            <span class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs bg-slate-700 text-slate-300 border border-slate-600">
+              <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                  d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"/>
+              </svg>
+              Password
+            </span>
+            {% else %}
+            <span class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs bg-amber-900/40 text-amber-400 border border-amber-800">
+              Not set
+            </span>
+            {% endif %}
+            {% if host.has_sudo_password %}
+            <span class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs bg-slate-700 text-slate-400 border border-slate-600">
+              sudo &#10003;
+            </span>
+            {% endif %}
+          </div>
         </td>
         <td class="px-5 py-3 text-right">
           <div class="flex items-center justify-end gap-2">
@@ -53,6 +64,13 @@
                 Test
               </button>
             </div>
+            <button
+              hx-get="/admin/hosts/{{ host.slug }}/credentials"
+              hx-target="#host-creds-{{ host.slug }}"
+              hx-swap="innerHTML"
+              class="text-xs px-2.5 py-1 rounded bg-slate-700 hover:bg-slate-600 text-slate-300 transition-colors">
+              Credentials
+            </button>
             <button
               hx-get="/admin/hosts/{{ host.slug }}/edit"
               hx-target="#host-row-{{ host.slug }}"
@@ -71,6 +89,18 @@
           </div>
         </td>
       </tr>
+      <!-- Credentials panel row (hidden by default, expanded by "Credentials" button) -->
+      <tr>
+        <td colspan="5" class="p-0">
+          <div id="host-creds-{{ host.slug }}"
+            {% if open_creds is defined and open_creds == host.slug %}
+            hx-get="/admin/hosts/{{ host.slug }}/credentials"
+            hx-trigger="load"
+            hx-swap="innerHTML"
+            {% endif %}
+          ></div>
+        </td>
+      </tr>
       {% endfor %}
     </tbody>
   </table>
@@ -80,78 +110,14 @@
 </div>
 
 <!-- Add host form -->
-<div class="bg-slate-800/50 rounded-xl border border-slate-700 p-5 space-y-5">
-  <div>
-    <p class="text-sm font-medium text-slate-300 mb-1">Add Host</p>
-    <p class="text-xs text-slate-500">Fields marked <span class="text-red-400">*</span> are required.</p>
-  </div>
+<div class="bg-slate-800/50 rounded-xl border border-slate-700 p-5 space-y-4">
+  <p class="text-sm font-medium text-slate-300">Add Host</p>
 
-  <!-- How connections work -->
-  <div class="rounded-lg border border-slate-600 bg-slate-900/50 p-4 space-y-3 text-xs text-slate-400">
-    <p class="font-medium text-slate-300">How host connections work</p>
-    <p>
-      The dashboard connects to each host over <strong class="text-slate-200">SSH</strong> to run
-      package checks and upgrades. Choose an auth method and make sure the remote host accepts it.
-    </p>
-
-    <div class="grid sm:grid-cols-2 gap-4 pt-1">
-      <!-- SSH Key -->
-      <div class="space-y-1.5">
-        <p class="font-medium text-slate-300 flex items-center gap-1.5">
-          <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-              d="M15 7a2 2 0 012 2m4 0a6 6 0 01-7.743 5.743L11 17H9v2H7v2H4a1 1 0 01-1-1v-2.586a1 1 0 01.293-.707l5.964-5.964A6 6 0 1121 9z"/>
-          </svg>
-          SSH Key <span class="text-slate-500 font-normal">(recommended)</span>
-        </p>
-        <ol class="space-y-1.5 list-decimal list-inside text-slate-500 leading-relaxed">
-          <li>Generate a dedicated key pair next to your <code class="text-slate-400 bg-slate-800 px-1 rounded">docker-compose.yml</code>:<br>
-            <code class="text-slate-400 bg-slate-800 px-1 rounded block mt-1">ssh-keygen -t ed25519 -f keys/id_ed25519 -N ""</code>
-          </li>
-          <li>Authorize it on each remote host:<br>
-            <code class="text-slate-400 bg-slate-800 px-1 rounded block mt-1">ssh-copy-id -i keys/id_ed25519.pub user@host</code>
-          </li>
-          <li>The <code class="text-slate-400">keys/</code> directory is already mounted into the container by default. Set the key path per-host below, or leave it blank to use the default from SSH Settings.</li>
-        </ol>
-      </div>
-
-      <!-- Password -->
-      <div class="space-y-1.5">
-        <p class="font-medium text-slate-300 flex items-center gap-1.5">
-          <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-              d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"/>
-          </svg>
-          Password
-        </p>
-        <ol class="space-y-1.5 list-decimal list-inside text-slate-500 leading-relaxed">
-          <li>Create a dedicated user on the remote host:<br>
-            <code class="text-slate-400 bg-slate-800 px-1 rounded block mt-1">adduser dashboard</code>
-          </li>
-          <li>Grant it sudo without a password prompt for apt:<br>
-            <code class="text-slate-400 bg-slate-800 px-1 rounded block mt-1">echo "dashboard ALL=(ALL) NOPASSWD: /usr/bin/apt*" &gt; /etc/sudoers.d/dashboard</code>
-          </li>
-          <li>Ensure <code class="text-slate-400">PasswordAuthentication yes</code> is set in <code class="text-slate-400">/etc/ssh/sshd_config</code>, then restart SSH:<br>
-            <code class="text-slate-400 bg-slate-800 px-1 rounded block mt-1">systemctl restart sshd</code>
-          </li>
-        </ol>
-        <p class="text-amber-500/80 flex items-start gap-1.5 pt-1">
-          <svg class="w-3.5 h-3.5 flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-              d="M12 9v2m0 4h.01M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z"/>
-          </svg>
-          Passwords are stored in plaintext in <code class="text-amber-500/70">config.yml</code>. Always use a dedicated user — never root.
-        </p>
-      </div>
-    </div>
-  </div>
-
-  <!-- Form -->
   <form
     hx-post="/admin/hosts"
     hx-target="#admin-hosts"
     hx-swap="innerHTML"
-    hx-on::after-request="if(event.detail.successful){ this.reset(); document.getElementById('key-fields').style.display='block'; document.getElementById('password-fields').style.display='none'; }"
+    hx-on::after-request="if(event.detail.successful){ this.reset(); }"
     class="space-y-4">
 
     <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
@@ -177,40 +143,9 @@
       </div>
     </div>
 
-    <!-- Auth method toggle -->
-    <div>
-      <label class="block text-xs font-medium text-slate-400 mb-2">Authentication Method</label>
-      <div class="flex gap-4">
-        <label class="flex items-center gap-2 cursor-pointer">
-          <input type="radio" name="auth_method" value="key" checked
-            onchange="document.getElementById('key-fields').style.display='block'; document.getElementById('password-fields').style.display='none';"
-            class="accent-blue-500" />
-          <span class="text-sm text-slate-300">SSH Key</span>
-        </label>
-        <label class="flex items-center gap-2 cursor-pointer">
-          <input type="radio" name="auth_method" value="password"
-            onchange="document.getElementById('key-fields').style.display='none'; document.getElementById('password-fields').style.display='block';"
-            class="accent-blue-500" />
-          <span class="text-sm text-slate-300">Password</span>
-        </label>
-      </div>
-    </div>
-
-    <!-- SSH Key fields -->
-    <div id="key-fields">
-      <label class="block text-xs font-medium text-slate-400 mb-1.5">SSH Key Path <span class="text-slate-600 font-normal">(optional)</span></label>
-      <input type="text" name="key" placeholder="e.g. /app/keys/id_ed25519  —  leave blank to use SSH default"
-        class="w-full bg-slate-900 border border-slate-600 rounded-lg px-3 py-2 text-sm text-slate-200 placeholder-slate-600 font-mono focus:outline-none focus:border-blue-500 transition-colors" />
-      <p class="mt-1 text-xs text-slate-600">Key files must be mounted inside the container under <code class="text-slate-500">/app/keys/</code></p>
-    </div>
-
-    <!-- Password fields -->
-    <div id="password-fields" style="display:none;">
-      <label class="block text-xs font-medium text-slate-400 mb-1.5">Password <span class="text-red-400">*</span></label>
-      <input type="password" name="password" placeholder="SSH password for this host"
-        class="w-full bg-slate-900 border border-slate-600 rounded-lg px-3 py-2 text-sm text-slate-200 placeholder-slate-600 focus:outline-none focus:border-blue-500 transition-colors" />
-      <p class="mt-1 text-xs text-amber-700">Stored in plaintext in config.yml — use a dedicated user, never root.</p>
-    </div>
+    <p class="text-xs text-slate-500">
+      After adding a host, click <span class="text-slate-300">Credentials</span> to configure its SSH key or password.
+    </p>
 
     <div class="flex justify-end">
       <button type="submit"

--- a/app/templates/partials/sudo_modal.html
+++ b/app/templates/partials/sudo_modal.html
@@ -1,0 +1,39 @@
+<!-- Sudo password modal — injected into the action cell -->
+<div class="bg-slate-800/80 rounded-xl border border-amber-700/60 p-4 space-y-3">
+  <div class="flex items-center gap-2">
+    <svg class="w-4 h-4 text-amber-400 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+        d="M15 7a2 2 0 012 2m4 0a6 6 0 01-7.743 5.743L11 17H9v2H7v2H4a1 1 0 01-1-1v-2.586a1 1 0 01.293-.707l5.964-5.964A6 6 0 1121 9z"/>
+    </svg>
+    <p class="text-xs font-medium text-amber-300">Sudo password required</p>
+  </div>
+  <p class="text-xs text-slate-400 leading-relaxed">
+    This host's SSH user needs <code class="text-slate-300 bg-slate-700 px-1 rounded">sudo</code> to run apt.
+    Enter the sudo password to continue.
+  </p>
+
+  <input type="password" name="sudo_password" id="sudo-pw-{{ slug }}" placeholder="sudo password"
+    autofocus
+    class="w-full bg-slate-900 border border-slate-600 rounded-lg px-3 py-2 text-sm text-slate-200 placeholder-slate-600 focus:outline-none focus:border-amber-500 transition-colors" />
+
+  <div class="flex gap-2">
+    <button
+      hx-post="/api/host/{{ slug }}/{{ action }}"
+      hx-target="#host-{{ slug }}-action"
+      hx-swap="innerHTML"
+      hx-include="#sudo-pw-{{ slug }}"
+      hx-vals='{"save_sudo": ""}'
+      class="flex-1 px-3 py-1.5 rounded-lg bg-slate-700 hover:bg-slate-600 text-xs font-medium text-slate-300 transition-colors">
+      Use once
+    </button>
+    <button
+      hx-post="/api/host/{{ slug }}/{{ action }}"
+      hx-target="#host-{{ slug }}-action"
+      hx-swap="innerHTML"
+      hx-include="#sudo-pw-{{ slug }}"
+      hx-vals='{"save_sudo": "save"}'
+      class="flex-1 px-3 py-1.5 rounded-lg bg-blue-600 hover:bg-blue-500 text-xs font-medium text-white transition-colors">
+      Save &amp; run
+    </button>
+  </div>
+</div>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,13 +6,16 @@ services:
     ports:
       - "8765:8000"
     volumes:
-      - ./config.yml:/app/config.yml        # hosts + SSH settings (writable for admin panel)
-      - ./keys:/app/keys:ro                  # SSH private keys
+      - ./config:/app/config                   # hosts + SSH settings (config.yml lives here)
+      - ./data:/app/data                        # encrypted credential store + encryption key
     environment:
+      - CONFIG_PATH=/app/config/config.yml
+      - DATA_PATH=/app/data
+
       # --- Portainer (required for Docker stack monitoring) ---
       - PORTAINER_URL=https://192.168.1.x:9443
       - PORTAINER_API_KEY=your_portainer_api_key_here
-      - PORTAINER_VERIFY_SSL=false           # set to true if using a valid cert
+      - PORTAINER_VERIFY_SSL=false              # set to true if using a valid cert
 
       # --- Docker Hub (optional — raises anonymous pull rate limit) ---
       # - DOCKERHUB_USERNAME=your_username

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+cryptography==44.0.2
 fastapi==0.115.6
 uvicorn[standard]==0.32.1
 asyncssh==2.18.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@
 import pytest
 import yaml
 from fastapi.testclient import TestClient
+from pathlib import Path
 
 SAMPLE_CONFIG = {
     "ssh": {
@@ -31,8 +32,22 @@ def config_file(tmp_path, monkeypatch):
 
 
 @pytest.fixture
-def client(config_file, monkeypatch):
-    """TestClient with env vars set and config pointed at temp file."""
+def data_dir(tmp_path, monkeypatch):
+    """Create a temp data dir and point credentials module at it."""
+    d = tmp_path / "data"
+    d.mkdir()
+
+    import app.credentials as creds
+    monkeypatch.setattr(creds, "_DATA_DIR", d)
+    monkeypatch.setattr(creds, "_SECRET_FILE", d / ".secret")
+    monkeypatch.setattr(creds, "_CREDS_FILE", d / "credentials.json")
+
+    return d
+
+
+@pytest.fixture
+def client(config_file, data_dir, monkeypatch):
+    """TestClient with env vars set and config/data dirs pointed at temp paths."""
     monkeypatch.setenv("PORTAINER_URL", "https://portainer.test:9443")
     monkeypatch.setenv("PORTAINER_API_KEY", "test-api-key")
     monkeypatch.setenv("PORTAINER_VERIFY_SSL", "false")

--- a/tests/test_admin_routes.py
+++ b/tests/test_admin_routes.py
@@ -70,6 +70,20 @@ def test_add_host_requires_name_and_host(client):
     assert "required" in response.text.lower()
 
 
+def test_add_host_no_credentials_in_config(client, config_file):
+    """Credentials must not be stored in config.yml."""
+    client.post("/admin/hosts", data={
+        "name": "Safe Host",
+        "host": "10.0.0.99",
+        "user": "dashboard",
+    })
+    raw = yaml.safe_load(config_file.read_text())
+    host = next(h for h in raw["hosts"] if h["name"] == "Safe Host")
+    assert "password" not in host
+    assert "key" not in host
+    assert "ssh_key" not in host
+
+
 # ---------------------------------------------------------------------------
 # GET /admin/hosts/{slug}/edit
 # ---------------------------------------------------------------------------
@@ -109,6 +123,17 @@ def test_update_host(client, config_file):
     assert "Test Host" not in names
 
 
+def test_update_host_renames_credentials(client, data_dir):
+    """Renaming a host must migrate its credentials to the new slug."""
+    from app.credentials import save_credentials, get_credentials
+    save_credentials("test-host", ssh_password="pass123")
+
+    client.put("/admin/hosts/test-host", data={"name": "Renamed Host", "host": "192.168.1.10"})
+
+    assert get_credentials("renamed-host")["ssh_password"] == "pass123"
+    assert get_credentials("test-host") == {}
+
+
 # ---------------------------------------------------------------------------
 # DELETE /admin/hosts/{slug}
 # ---------------------------------------------------------------------------
@@ -128,6 +153,94 @@ def test_delete_host_leaves_others(client, config_file):
     raw = yaml.safe_load(config_file.read_text())
     names = [h["name"] for h in raw["hosts"]]
     assert "Custom User Host" in names
+
+
+def test_delete_host_removes_credentials(client, data_dir):
+    from app.credentials import save_credentials, get_credentials
+    save_credentials("test-host", ssh_password="pass")
+    client.delete("/admin/hosts/test-host")
+    assert get_credentials("test-host") == {}
+
+
+# ---------------------------------------------------------------------------
+# GET/POST /admin/hosts/{slug}/credentials
+# ---------------------------------------------------------------------------
+
+def test_get_credentials_form_returns_200(client):
+    response = client.get("/admin/hosts/test-host/credentials")
+    assert response.status_code == 200
+
+
+def test_get_credentials_form_unknown_host(client):
+    response = client.get("/admin/hosts/does-not-exist/credentials")
+    assert response.status_code == 200
+    assert "not found" in response.text.lower()
+
+
+def test_get_credentials_form_shows_status_empty(client):
+    response = client.get("/admin/hosts/test-host/credentials")
+    assert response.status_code == 200
+    # No saved credentials yet — "saved" badge should not appear
+    assert "&#10003;" not in response.text
+
+
+def test_get_credentials_form_shows_saved_badge(client, data_dir):
+    from app.credentials import save_credentials
+    save_credentials("test-host", ssh_password="pass", sudo_password="sudo")
+    response = client.get("/admin/hosts/test-host/credentials")
+    # Checkmark badges appear when credentials are saved
+    assert "&#10003;" in response.text
+
+
+def test_post_credentials_saves_ssh_password(client, data_dir):
+    from app.credentials import get_credentials
+    response = client.post("/admin/hosts/test-host/credentials", data={
+        "auth_method": "password",
+        "ssh_password": "newpass",
+        "ssh_key": "",
+        "sudo_password": "",
+    })
+    assert response.status_code == 200
+    assert get_credentials("test-host")["ssh_password"] == "newpass"
+
+
+def test_post_credentials_saves_ssh_key(client, data_dir):
+    from app.credentials import get_credentials
+    key_data = "-----BEGIN OPENSSH PRIVATE KEY-----\nfakekey\n-----END OPENSSH PRIVATE KEY-----"
+    response = client.post("/admin/hosts/test-host/credentials", data={
+        "auth_method": "key",
+        "ssh_password": "",
+        "ssh_key": key_data,
+        "sudo_password": "",
+    })
+    assert response.status_code == 200
+    assert get_credentials("test-host")["ssh_key"] == key_data
+
+
+def test_post_credentials_saves_sudo_password(client, data_dir):
+    from app.credentials import get_credentials
+    client.post("/admin/hosts/test-host/credentials", data={
+        "auth_method": "key",
+        "ssh_password": "",
+        "ssh_key": "",
+        "sudo_password": "mysudopass",
+    })
+    assert get_credentials("test-host")["sudo_password"] == "mysudopass"
+
+
+def test_post_credentials_password_method_clears_key(client, data_dir):
+    """Selecting 'password' auth method should pass empty string for ssh_key, clearing it."""
+    from app.credentials import save_credentials, get_credentials
+    save_credentials("test-host", ssh_key="-----BEGIN...")
+    client.post("/admin/hosts/test-host/credentials", data={
+        "auth_method": "password",
+        "ssh_password": "newpass",
+        "ssh_key": "",
+        "sudo_password": "",
+    })
+    creds = get_credentials("test-host")
+    assert "ssh_key" not in creds
+    assert creds["ssh_password"] == "newpass"
 
 
 # ---------------------------------------------------------------------------
@@ -176,47 +289,6 @@ def test_update_host_error_shows_message(client, monkeypatch):
     response = client.put("/admin/hosts/test-host", data={"name": "X", "host": "1.2.3.4"})
     assert response.status_code == 200
     assert "write error" in response.text
-
-
-# ---------------------------------------------------------------------------
-# Password auth
-# ---------------------------------------------------------------------------
-
-def test_add_host_with_password(client, config_file):
-    response = client.post("/admin/hosts", data={
-        "name": "Password Host",
-        "host": "10.0.0.77",
-        "user": "dashboard",
-        "auth_method": "password",
-        "password": "s3cr3t",
-    })
-    assert response.status_code == 200
-    assert "Password Host" in response.text
-
-    raw = yaml.safe_load(config_file.read_text())
-    host = next(h for h in raw["hosts"] if h["name"] == "Password Host")
-    assert host["password"] == "s3cr3t"
-    assert "key" not in host
-
-
-def test_add_host_key_auth_does_not_store_password(client, config_file):
-    client.post("/admin/hosts", data={
-        "name": "Key Host",
-        "host": "10.0.0.78",
-        "auth_method": "key",
-        "key": "/app/keys/id_ed25519",
-        "password": "should-be-ignored",
-    })
-    raw = yaml.safe_load(config_file.read_text())
-    host = next(h for h in raw["hosts"] if h["name"] == "Key Host")
-    assert "password" not in host
-    assert host["key"] == "/app/keys/id_ed25519"
-
-
-def test_admin_table_shows_auth_method(client):
-    response = client.get("/admin/hosts")
-    assert response.status_code == 200
-    assert "SSH Key" in response.text
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -77,35 +77,48 @@ def test_load_config_missing_file_returns_defaults(tmp_path, monkeypatch):
 # ---------------------------------------------------------------------------
 
 def test_add_host_minimal(config_file):
-    add_host(name="New Host", host="10.0.0.1", user=None, port=None, key=None)
+    add_host(name="New Host", host="10.0.0.1", user=None, port=None)
     hosts = get_hosts()
     names = [h["name"] for h in hosts]
     assert "New Host" in names
 
 
-def test_add_host_with_all_fields(config_file):
-    add_host(name="Full Host", host="10.0.0.2", user="ubuntu", port=2222, key="/app/keys/other")
+def test_add_host_with_user_and_port(config_file):
+    add_host(name="Full Host", host="10.0.0.2", user="ubuntu", port=2222)
     hosts = get_hosts()
     host = next(h for h in hosts if h["name"] == "Full Host")
     assert host["user"] == "ubuntu"
     assert host["port"] == 2222
-    assert host["key"] == "/app/keys/other"
 
 
 def test_add_host_persists_to_file(config_file):
-    add_host(name="Persisted", host="10.0.0.3", user=None, port=None, key=None)
+    add_host(name="Persisted", host="10.0.0.3", user=None, port=None)
     raw = yaml.safe_load(config_file.read_text())
     names = [h["name"] for h in raw["hosts"]]
     assert "Persisted" in names
 
 
 def test_add_host_does_not_store_none_fields(config_file):
-    add_host(name="Minimal", host="10.0.0.4", user=None, port=None, key=None)
+    add_host(name="Minimal", host="10.0.0.4", user=None, port=None)
     raw = yaml.safe_load(config_file.read_text())
     host = next(h for h in raw["hosts"] if h["name"] == "Minimal")
     assert "user" not in host
     assert "port" not in host
+
+
+def test_add_host_no_credentials_in_config(config_file):
+    """Credentials must never appear in config.yml."""
+    add_host(name="Secure Host", host="10.0.0.5", user="dashboard", port=None)
+    raw = yaml.safe_load(config_file.read_text())
+    host = next(h for h in raw["hosts"] if h["name"] == "Secure Host")
+    assert "password" not in host
     assert "key" not in host
+    assert "ssh_key" not in host
+
+
+def test_add_host_returns_slug(config_file):
+    slug = add_host(name="My Server", host="10.0.0.6", user=None, port=None)
+    assert slug == "my-server"
 
 
 # ---------------------------------------------------------------------------
@@ -113,7 +126,7 @@ def test_add_host_does_not_store_none_fields(config_file):
 # ---------------------------------------------------------------------------
 
 def test_update_host_changes_name(config_file):
-    update_host("test-host", name="Renamed Host", host="192.168.1.10", user=None, port=None, key=None)
+    update_host("test-host", name="Renamed Host", host="192.168.1.10", user=None, port=None)
     hosts = get_hosts()
     names = [h["name"] for h in hosts]
     assert "Renamed Host" in names
@@ -121,14 +134,14 @@ def test_update_host_changes_name(config_file):
 
 
 def test_update_host_changes_ip(config_file):
-    update_host("test-host", name="Test Host", host="10.10.10.10", user=None, port=None, key=None)
+    update_host("test-host", name="Test Host", host="10.10.10.10", user=None, port=None)
     hosts = get_hosts()
     host = next(h for h in hosts if h["name"] == "Test Host")
     assert host["host"] == "10.10.10.10"
 
 
 def test_update_host_adds_optional_fields(config_file):
-    update_host("test-host", name="Test Host", host="192.168.1.10", user="ubuntu", port=2222, key=None)
+    update_host("test-host", name="Test Host", host="192.168.1.10", user="ubuntu", port=2222)
     hosts = get_hosts()
     host = next(h for h in hosts if h["name"] == "Test Host")
     assert host["user"] == "ubuntu"
@@ -137,9 +150,14 @@ def test_update_host_adds_optional_fields(config_file):
 
 def test_update_host_unknown_slug_is_noop(config_file):
     before = get_hosts()
-    update_host("nonexistent", name="X", host="1.2.3.4", user=None, port=None, key=None)
+    update_host("nonexistent", name="X", host="1.2.3.4", user=None, port=None)
     after = get_hosts()
     assert len(before) == len(after)
+
+
+def test_update_host_returns_new_slug(config_file):
+    new_slug = update_host("test-host", name="Renamed Host", host="192.168.1.10", user=None, port=None)
+    assert new_slug == "renamed-host"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -1,0 +1,172 @@
+"""Tests for the encrypted credential store."""
+import pytest
+from pathlib import Path
+
+
+@pytest.fixture(autouse=True)
+def _use_data_dir(data_dir):
+    """All tests in this module use a temp data dir."""
+
+
+# ---------------------------------------------------------------------------
+# Key auto-generation
+# ---------------------------------------------------------------------------
+
+def test_fernet_key_auto_created(data_dir):
+    from app.credentials import _get_fernet, _SECRET_FILE
+    _get_fernet()
+    assert _SECRET_FILE.exists()
+
+
+def test_fernet_key_is_stable(data_dir):
+    from app.credentials import _get_fernet
+    f1 = _get_fernet()
+    f2 = _get_fernet()
+    # Encrypting with one and decrypting with the other must work
+    token = f1.encrypt(b"hello")
+    assert f2.decrypt(token) == b"hello"
+
+
+# ---------------------------------------------------------------------------
+# save / get round-trip
+# ---------------------------------------------------------------------------
+
+def test_save_and_get_ssh_password(data_dir):
+    from app.credentials import save_credentials, get_credentials
+    save_credentials("myhost", ssh_password="s3cr3t")
+    creds = get_credentials("myhost")
+    assert creds["ssh_password"] == "s3cr3t"
+
+
+def test_save_and_get_ssh_key(data_dir):
+    from app.credentials import save_credentials, get_credentials
+    save_credentials("myhost", ssh_key="-----BEGIN OPENSSH PRIVATE KEY-----\n...")
+    creds = get_credentials("myhost")
+    assert creds["ssh_key"].startswith("-----BEGIN OPENSSH PRIVATE KEY-----")
+
+
+def test_save_and_get_sudo_password(data_dir):
+    from app.credentials import save_credentials, get_credentials
+    save_credentials("myhost", sudo_password="sudopass")
+    creds = get_credentials("myhost")
+    assert creds["sudo_password"] == "sudopass"
+
+
+def test_none_does_not_overwrite_existing(data_dir):
+    from app.credentials import save_credentials, get_credentials
+    save_credentials("myhost", ssh_password="original")
+    save_credentials("myhost", ssh_password=None, sudo_password="newsudo")
+    creds = get_credentials("myhost")
+    assert creds["ssh_password"] == "original"
+    assert creds["sudo_password"] == "newsudo"
+
+
+def test_empty_string_clears_field(data_dir):
+    from app.credentials import save_credentials, get_credentials
+    save_credentials("myhost", ssh_password="original")
+    save_credentials("myhost", ssh_password="")
+    creds = get_credentials("myhost")
+    assert "ssh_password" not in creds
+
+
+def test_get_credentials_unknown_host_returns_empty(data_dir):
+    from app.credentials import get_credentials
+    assert get_credentials("nonexistent") == {}
+
+
+def test_multiple_hosts_isolated(data_dir):
+    from app.credentials import save_credentials, get_credentials
+    save_credentials("host-a", ssh_password="aaa")
+    save_credentials("host-b", ssh_password="bbb")
+    assert get_credentials("host-a")["ssh_password"] == "aaa"
+    assert get_credentials("host-b")["ssh_password"] == "bbb"
+
+
+# ---------------------------------------------------------------------------
+# delete
+# ---------------------------------------------------------------------------
+
+def test_delete_credentials(data_dir):
+    from app.credentials import save_credentials, get_credentials, delete_credentials
+    save_credentials("myhost", ssh_password="s3cr3t")
+    delete_credentials("myhost")
+    assert get_credentials("myhost") == {}
+
+
+def test_delete_nonexistent_is_safe(data_dir):
+    from app.credentials import delete_credentials
+    delete_credentials("does-not-exist")  # should not raise
+
+
+# ---------------------------------------------------------------------------
+# rename
+# ---------------------------------------------------------------------------
+
+def test_rename_credentials(data_dir):
+    from app.credentials import save_credentials, get_credentials, rename_credentials
+    save_credentials("old-slug", ssh_password="pass")
+    rename_credentials("old-slug", "new-slug")
+    assert get_credentials("new-slug")["ssh_password"] == "pass"
+    assert get_credentials("old-slug") == {}
+
+
+def test_rename_same_slug_is_noop(data_dir):
+    from app.credentials import save_credentials, get_credentials, rename_credentials
+    save_credentials("myhost", ssh_password="pass")
+    rename_credentials("myhost", "myhost")
+    assert get_credentials("myhost")["ssh_password"] == "pass"
+
+
+def test_rename_nonexistent_is_safe(data_dir):
+    from app.credentials import rename_credentials
+    rename_credentials("ghost", "new-ghost")  # should not raise
+
+
+# ---------------------------------------------------------------------------
+# save_sudo_password shortcut
+# ---------------------------------------------------------------------------
+
+def test_save_sudo_password(data_dir):
+    from app.credentials import save_sudo_password, get_credentials
+    save_sudo_password("myhost", "sudopass123")
+    assert get_credentials("myhost")["sudo_password"] == "sudopass123"
+
+
+# ---------------------------------------------------------------------------
+# credential_status
+# ---------------------------------------------------------------------------
+
+def test_credential_status_empty(data_dir):
+    from app.credentials import credential_status
+    status = credential_status("myhost")
+    assert status == {"has_ssh_password": False, "has_ssh_key": False, "has_sudo_password": False}
+
+
+def test_credential_status_with_password(data_dir):
+    from app.credentials import save_credentials, credential_status
+    save_credentials("myhost", ssh_password="pass")
+    status = credential_status("myhost")
+    assert status["has_ssh_password"] is True
+    assert status["has_ssh_key"] is False
+    assert status["has_sudo_password"] is False
+
+
+def test_credential_status_with_key_and_sudo(data_dir):
+    from app.credentials import save_credentials, credential_status
+    save_credentials("myhost", ssh_key="-----BEGIN...", sudo_password="sudo")
+    status = credential_status("myhost")
+    assert status["has_ssh_key"] is True
+    assert status["has_sudo_password"] is True
+    assert status["has_ssh_password"] is False
+
+
+# ---------------------------------------------------------------------------
+# Encryption: credentials.json is not plaintext
+# ---------------------------------------------------------------------------
+
+def test_credentials_file_is_not_plaintext(data_dir):
+    from app.credentials import save_credentials, _CREDS_FILE
+    save_credentials("myhost", ssh_password="supersecret")
+    raw = _CREDS_FILE.read_bytes()
+    assert b"supersecret" not in raw
+    assert b"myhost" not in raw

--- a/tests/test_main_jobs.py
+++ b/tests/test_main_jobs.py
@@ -9,15 +9,16 @@ import pytest
 # ---------------------------------------------------------------------------
 
 @pytest.mark.asyncio
-async def test_job_run_host_update_success(config_file):
+async def test_job_run_host_update_success(config_file, data_dir):
     import app.main as m
 
     job_id = "testjob1"
     m._jobs[job_id] = {"done": False, "status": "running", "error": None, "lines": []}
     host = {"name": "Test", "host": "10.0.0.1", "slug": "test"}
+    creds = {}
 
     with patch("app.main.run_host_update_buffered", new=AsyncMock(return_value=["line1", "line2"])):
-        await m._job_run_host_update(job_id, host)
+        await m._job_run_host_update(job_id, host, creds)
 
     assert m._jobs[job_id]["done"] is True
     assert m._jobs[job_id]["status"] == "done"
@@ -25,15 +26,16 @@ async def test_job_run_host_update_success(config_file):
 
 
 @pytest.mark.asyncio
-async def test_job_run_host_update_failure(config_file):
+async def test_job_run_host_update_failure(config_file, data_dir):
     import app.main as m
 
     job_id = "testjob2"
     m._jobs[job_id] = {"done": False, "status": "running", "error": None, "lines": []}
     host = {"name": "Test", "host": "10.0.0.1", "slug": "test"}
+    creds = {}
 
     with patch("app.main.run_host_update_buffered", new=AsyncMock(side_effect=Exception("SSH failed"))):
-        await m._job_run_host_update(job_id, host)
+        await m._job_run_host_update(job_id, host, creds)
 
     assert m._jobs[job_id]["done"] is True
     assert m._jobs[job_id]["status"] == "error"
@@ -41,37 +43,39 @@ async def test_job_run_host_update_failure(config_file):
 
 
 @pytest.mark.asyncio
-async def test_job_run_host_restart_success(config_file):
+async def test_job_run_host_restart_success(config_file, data_dir):
     import app.main as m
 
     job_id = "testjob3"
     m._jobs[job_id] = {"done": False, "status": "running", "error": None, "lines": []}
     host = {"name": "Test", "host": "10.0.0.1", "slug": "test"}
+    creds = {}
 
     with patch("app.main.reboot_host", new=AsyncMock(return_value=["Reboot initiated"])):
-        await m._job_run_host_restart(job_id, host)
+        await m._job_run_host_restart(job_id, host, creds)
 
     assert m._jobs[job_id]["done"] is True
     assert m._jobs[job_id]["status"] == "done"
 
 
 @pytest.mark.asyncio
-async def test_job_run_host_restart_failure(config_file):
+async def test_job_run_host_restart_failure(config_file, data_dir):
     import app.main as m
 
     job_id = "testjob4"
     m._jobs[job_id] = {"done": False, "status": "running", "error": None, "lines": []}
     host = {"name": "Test", "host": "10.0.0.1", "slug": "test"}
+    creds = {}
 
     with patch("app.main.reboot_host", new=AsyncMock(side_effect=Exception("Connection refused"))):
-        await m._job_run_host_restart(job_id, host)
+        await m._job_run_host_restart(job_id, host, creds)
 
     assert m._jobs[job_id]["status"] == "error"
     assert "Connection refused" in m._jobs[job_id]["error"]
 
 
 @pytest.mark.asyncio
-async def test_job_run_stack_update_success(config_file, monkeypatch):
+async def test_job_run_stack_update_success(config_file, data_dir, monkeypatch):
     import app.main as m
 
     mock_portainer = AsyncMock()
@@ -89,7 +93,7 @@ async def test_job_run_stack_update_success(config_file, monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_job_run_stack_update_failure(config_file, monkeypatch):
+async def test_job_run_stack_update_failure(config_file, data_dir, monkeypatch):
     import app.main as m
 
     mock_portainer = AsyncMock()
@@ -106,14 +110,65 @@ async def test_job_run_stack_update_failure(config_file, monkeypatch):
 
 
 # ---------------------------------------------------------------------------
-# POST /api/host/{slug}/update
+# POST /api/host/{slug}/update — sudo modal logic
 # ---------------------------------------------------------------------------
 
-def test_host_update_triggers_job(client):
+def test_host_update_root_user_no_modal(client):
+    """Root user (SSH default) → no sudo modal, job starts immediately."""
     with patch("app.main.run_host_update_buffered", new=AsyncMock(return_value=[])):
         response = client.post("/api/host/test-host/update")
     assert response.status_code == 200
-    assert "Running" in response.text or "job" in response.text.lower()
+    # Should get job poll, not a sudo modal
+    assert "sudo" not in response.text.lower()
+
+
+def test_host_update_nonroot_no_sudo_shows_modal(client, data_dir):
+    """Non-root user with no saved sudo password → modal returned."""
+    with patch("app.main._needs_sudo", return_value=True):
+        response = client.post("/api/host/test-host/update")
+    assert response.status_code == 200
+    assert "sudo" in response.text.lower()
+    assert "Use once" in response.text or "Save" in response.text
+
+
+def test_host_update_nonroot_sudo_provided_once(client, data_dir):
+    """Non-root + sudo_password in form → starts job (does not save)."""
+    from app.credentials import get_credentials
+    with patch("app.main._needs_sudo", return_value=True), \
+         patch("app.main.run_host_update_buffered", new=AsyncMock(return_value=[])):
+        response = client.post("/api/host/test-host/update", data={
+            "sudo_password": "mysudo",
+            "save_sudo": "",
+        })
+    assert response.status_code == 200
+    # Job started, not a modal
+    assert "Use once" not in response.text
+    # Credential NOT saved
+    assert "sudo_password" not in get_credentials("test-host")
+
+
+def test_host_update_nonroot_sudo_saved(client, data_dir):
+    """Non-root + sudo_password + save_sudo=save → saves credential and starts job."""
+    from app.credentials import get_credentials
+    with patch("app.main._needs_sudo", return_value=True), \
+         patch("app.main.run_host_update_buffered", new=AsyncMock(return_value=[])):
+        response = client.post("/api/host/test-host/update", data={
+            "sudo_password": "mysudo",
+            "save_sudo": "save",
+        })
+    assert response.status_code == 200
+    assert get_credentials("test-host").get("sudo_password") == "mysudo"
+
+
+def test_host_update_nonroot_saved_sudo_used_automatically(client, data_dir):
+    """If sudo password already saved, no modal — job runs directly."""
+    from app.credentials import save_credentials
+    save_credentials("test-host", sudo_password="presaved")
+    with patch("app.main._needs_sudo", return_value=True), \
+         patch("app.main.run_host_update_buffered", new=AsyncMock(return_value=[])):
+        response = client.post("/api/host/test-host/update")
+    assert response.status_code == 200
+    assert "Use once" not in response.text
 
 
 def test_host_update_unknown_slug(client):
@@ -123,13 +178,21 @@ def test_host_update_unknown_slug(client):
 
 
 # ---------------------------------------------------------------------------
-# POST /api/host/{slug}/restart
+# POST /api/host/{slug}/restart — sudo modal logic
 # ---------------------------------------------------------------------------
 
-def test_host_restart_triggers_job(client):
+def test_host_restart_root_user_no_modal(client):
     with patch("app.main.reboot_host", new=AsyncMock(return_value=[])):
         response = client.post("/api/host/test-host/restart")
     assert response.status_code == 200
+    assert "sudo" not in response.text.lower()
+
+
+def test_host_restart_nonroot_no_sudo_shows_modal(client, data_dir):
+    with patch("app.main._needs_sudo", return_value=True):
+        response = client.post("/api/host/test-host/restart")
+    assert response.status_code == 200
+    assert "sudo" in response.text.lower()
 
 
 def test_host_restart_unknown_slug(client):

--- a/tests/test_ssh_client.py
+++ b/tests/test_ssh_client.py
@@ -10,10 +10,12 @@ from app.ssh_client import (
     verify_connection,
 )
 
-HOST_KEY = {"name": "Test", "host": "10.0.0.1"}
-HOST_PW = {"name": "Test", "host": "10.0.0.1", "password": "secret"}
+HOST = {"name": "Test", "host": "10.0.0.1"}
+HOST_KEY = HOST  # alias used by key-auth tests
 SSH_CFG = {"default_user": "root", "default_port": 22, "default_key": "/app/keys/id_ed25519",
            "connect_timeout": 15, "command_timeout": 60}
+CREDS_PW = {"ssh_password": "secret"}
+CREDS_EMPTY = {}
 
 
 def _make_conn(stdout: str = "", returncode: int = 0, stderr: str = "") -> MagicMock:
@@ -59,7 +61,7 @@ async def test_connection_failure():
 async def test_connection_uses_password_when_set():
     conn = _make_conn(stdout="ok\n")
     with patch("app.ssh_client.asyncssh.connect", new=AsyncMock(return_value=conn)) as mock_connect:
-        await verify_connection(HOST_PW, SSH_CFG)
+        await verify_connection(HOST, SSH_CFG, creds=CREDS_PW)
     call_kwargs = mock_connect.call_args.kwargs
     assert call_kwargs.get("password") == "secret"
     assert call_kwargs.get("preferred_auth") == "password"


### PR DESCRIPTION
## Summary

- **Encrypted credential store**: SSH keys (pasted), SSH passwords, and sudo passwords are stored in a Fernet-encrypted JSON file at `/app/data/credentials.json` with an auto-generated key at `/app/data/.secret`. Nothing sensitive ever touches `config.yml`.
- **Credential management in admin panel**: Each host row now has a **Credentials** button that opens an inline form with SSH Key / Password toggle and an optional sudo password field.
- **Sudo modal on update/restart**: When a non-root SSH user runs an update or restart, a modal prompts for the sudo password with **Use once** or **Save & run** options.
- **Simplified host form**: `config.yml` now only stores name, host, user, and port — auth fields removed from the add/edit forms.
- **Separate volumes**: `docker-compose.yml` now uses `config/` for config.yml and `data/` for the encrypted credential store, each as independent volumes.

## Test plan

- [ ] All 158 tests pass with 96% coverage (`pytest --cov=app`)
- [ ] CI passes on push
- [ ] Add a non-root host, set password auth via Credentials form, trigger Update → sudo modal appears
- [ ] Enter sudo password with "Save & run" → job starts, password saved for next time
- [ ] Enter sudo password with "Use once" → job starts, password not persisted
- [ ] Pre-saved sudo password → Update runs without modal
- [ ] Root user host → no modal, update runs directly
- [ ] Delete host → credentials removed from encrypted store
- [ ] Rename host → credentials follow new slug

🤖 Generated with [Claude Code](https://claude.com/claude-code)