### PR TITLE
feat: multi-PM support for OS update checks

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -147,6 +147,7 @@ async def host_check(request: Request, slug: str) -> HTMLResponse:
                 "slug": slug,
                 "packages": result["packages"],
                 "reboot_required": result["reboot_required"],
+                "package_manager": result.get("package_manager", ""),
             },
         )
     except Exception as exc:

--- a/app/package_managers.py
+++ b/app/package_managers.py
@@ -1,0 +1,350 @@
+"""
+Package manager abstraction.
+
+Each PackageManager knows how to:
+  - produce a single shell command that lists available updates
+  - parse that command's stdout into a list of Package dicts
+  - determine whether a reboot is recommended from its output + the package list
+
+Reboot logic has two independent signals — either triggers the flag:
+  1. PM-provided reboot indicator (e.g. /var/run/reboot-required, needs-restarting)
+  2. A kernel package appearing in the update list
+"""
+
+from __future__ import annotations
+
+import re
+
+
+# ---------------------------------------------------------------------------
+# Package dict shape
+# ---------------------------------------------------------------------------
+
+# {"name": str, "current": str, "available": str}
+Package = dict[str, str]
+
+
+# ---------------------------------------------------------------------------
+# Kernel package heuristic (shared across all PMs)
+# ---------------------------------------------------------------------------
+
+_KERNEL_NAMES = frozenset({"linux", "linux-lts", "linux-zen", "linux-hardened"})
+
+def _is_kernel_package(name: str) -> bool:
+    return (
+        name in _KERNEL_NAMES
+        or name.startswith("kernel")
+        or name.startswith("linux-image")
+        or name.startswith("linux-headers")
+    )
+
+
+def _kernel_update_in(packages: list[Package]) -> bool:
+    return any(_is_kernel_package(p["name"]) for p in packages)
+
+
+# ---------------------------------------------------------------------------
+# Detection
+# ---------------------------------------------------------------------------
+
+# Single command that prints the PM name and nothing else.
+DETECT_CMD = (
+    "command -v apt-get >/dev/null 2>&1 && echo apt && exit; "
+    "command -v dnf    >/dev/null 2>&1 && echo dnf && exit; "
+    "command -v yum    >/dev/null 2>&1 && echo yum && exit; "
+    "command -v zypper >/dev/null 2>&1 && echo zypper && exit; "
+    "command -v pacman >/dev/null 2>&1 && echo pacman && exit; "
+    "command -v apk    >/dev/null 2>&1 && echo apk && exit; "
+    "echo unknown"
+)
+
+
+def get_package_manager(name: str) -> "PackageManager":
+    return _REGISTRY.get(name.strip(), UnknownPackageManager(name.strip()))
+
+
+# ---------------------------------------------------------------------------
+# Base class
+# ---------------------------------------------------------------------------
+
+class PackageManager:
+    name: str = "unknown"
+
+    def list_cmd(self) -> str:
+        """Single shell command — stdout fed to parse()."""
+        raise NotImplementedError
+
+    def upgrade_cmd(self) -> str:
+        """Command that upgrades all packages non-interactively."""
+        raise NotImplementedError
+
+    def parse(self, stdout: str) -> tuple[list[Package], bool]:
+        """
+        Returns (packages, reboot_required).
+        reboot_required is True when the PM or kernel heuristic says so.
+        """
+        raise NotImplementedError
+
+
+# ---------------------------------------------------------------------------
+# APT  (Debian / Ubuntu / Raspberry Pi OS)
+# ---------------------------------------------------------------------------
+
+class AptPackageManager(PackageManager):
+    name = "apt"
+
+    def list_cmd(self) -> str:
+        return (
+            "apt-get update -qq 2>/dev/null; "
+            "apt list --upgradable 2>/dev/null; "
+            "echo __REBOOT__; "
+            "[ -f /var/run/reboot-required ] && echo yes || echo no"
+        )
+
+    def upgrade_cmd(self) -> str:
+        return "DEBIAN_FRONTEND=noninteractive apt-get upgrade -y 2>&1"
+
+    def parse(self, stdout: str) -> tuple[list[Package], bool]:
+        reboot_required = False
+        if "__REBOOT__" in stdout:
+            apt_part, reboot_part = stdout.split("__REBOOT__", 1)
+            reboot_required = reboot_part.strip().startswith("yes")
+        else:
+            apt_part = stdout
+
+        packages: list[Package] = []
+        for line in apt_part.splitlines():
+            if "[upgradable from:" not in line:
+                continue
+            try:
+                name = line.split("/")[0]
+                parts = line.split()
+                available = parts[1] if len(parts) > 1 else "?"
+                current = parts[-1].rstrip("]") if len(parts) > 3 else "?"
+                packages.append({"name": name, "current": current, "available": available})
+            except Exception:
+                continue
+
+        return packages, reboot_required or _kernel_update_in(packages)
+
+
+# ---------------------------------------------------------------------------
+# DNF  (Fedora / RHEL 8+ / Rocky / AlmaLinux)
+# ---------------------------------------------------------------------------
+
+class DnfPackageManager(PackageManager):
+    name = "dnf"
+
+    def list_cmd(self) -> str:
+        # dnf check-update exits 100 when updates exist, 0 when none, other on error.
+        # needs-restarting -r exits 1 when reboot needed (may not be installed).
+        return (
+            "dnf check-update -q 2>/dev/null; echo __EXIT__$?; "
+            "echo __REBOOT__; "
+            "needs-restarting -r >/dev/null 2>&1; echo $?"
+        )
+
+    def upgrade_cmd(self) -> str:
+        return "dnf upgrade -y 2>&1"
+
+    def parse(self, stdout: str) -> tuple[list[Package], bool]:
+        packages: list[Package] = []
+        reboot_required = False
+
+        # Split on sentinels
+        parts = stdout.split("__EXIT__")
+        update_block = parts[0]
+
+        if len(parts) > 1:
+            after_exit = parts[1]
+            reboot_block = after_exit.split("__REBOOT__", 1)[-1].strip() if "__REBOOT__" in after_exit else ""
+            # needs-restarting -r returns 1 when reboot needed
+            reboot_required = reboot_block.strip().startswith("1")
+
+        # Parse dnf check-update output:
+        # name.arch    available_version    repo
+        for line in update_block.splitlines():
+            line = line.strip()
+            if not line or line.startswith("Last metadata") or line.startswith("Obsoleting"):
+                continue
+            cols = line.split()
+            if len(cols) < 3:
+                continue
+            name_arch = cols[0]
+            available = cols[1]
+            # Strip arch suffix (e.g. bash.x86_64 → bash)
+            name = name_arch.rsplit(".", 1)[0]
+            packages.append({"name": name, "current": "installed", "available": available})
+
+        return packages, reboot_required or _kernel_update_in(packages)
+
+
+# ---------------------------------------------------------------------------
+# YUM  (CentOS 7 / RHEL 7)
+# ---------------------------------------------------------------------------
+
+class YumPackageManager(PackageManager):
+    name = "yum"
+
+    def list_cmd(self) -> str:
+        return (
+            "yum check-update -q 2>/dev/null; echo __EXIT__$?; "
+            "echo __REBOOT__; "
+            "needs-restarting -r >/dev/null 2>&1; echo $?"
+        )
+
+    def upgrade_cmd(self) -> str:
+        return "yum upgrade -y 2>&1"
+
+    def parse(self, stdout: str) -> tuple[list[Package], bool]:
+        # Same format as dnf
+        return DnfPackageManager().parse(stdout)
+
+
+# ---------------------------------------------------------------------------
+# Zypper  (openSUSE / SLES)
+# ---------------------------------------------------------------------------
+
+class ZypperPackageManager(PackageManager):
+    name = "zypper"
+
+    def list_cmd(self) -> str:
+        return (
+            "zypper -q lu 2>/dev/null; "
+            "echo __REBOOT__; "
+            "zypper needs-rebooting >/dev/null 2>&1 && echo yes || echo no"
+        )
+
+    def upgrade_cmd(self) -> str:
+        return "zypper --non-interactive up 2>&1"
+
+    def parse(self, stdout: str) -> tuple[list[Package], bool]:
+        packages: list[Package] = []
+        reboot_required = False
+
+        if "__REBOOT__" in stdout:
+            zypper_part, reboot_part = stdout.split("__REBOOT__", 1)
+            reboot_required = reboot_part.strip().startswith("yes")
+        else:
+            zypper_part = stdout
+
+        # zypper lu columns: S | Repo | Name | Current Version | Available Version | Arch
+        for line in zypper_part.splitlines():
+            if "|" not in line:
+                continue
+            cols = [c.strip() for c in line.split("|")]
+            if len(cols) < 6:
+                continue
+            status = cols[0]
+            if status not in ("v", "i", ">"):
+                continue
+            name = cols[2]
+            current = cols[3]
+            available = cols[4]
+            if name and available:
+                packages.append({"name": name, "current": current, "available": available})
+
+        return packages, reboot_required or _kernel_update_in(packages)
+
+
+# ---------------------------------------------------------------------------
+# Pacman  (Arch Linux / Manjaro)
+# ---------------------------------------------------------------------------
+
+class PacmanPackageManager(PackageManager):
+    name = "pacman"
+
+    def list_cmd(self) -> str:
+        # pacman -Qu lists packages with pending updates: "name old -> new"
+        return "pacman -Sy -q 2>/dev/null; pacman -Qu 2>/dev/null"
+
+    def upgrade_cmd(self) -> str:
+        return "pacman -Su --noconfirm 2>&1"
+
+    def parse(self, stdout: str) -> tuple[list[Package], bool]:
+        packages: list[Package] = []
+        # Format: "bash 5.2.021-2 -> 5.2.026-1"
+        for line in stdout.splitlines():
+            line = line.strip()
+            if not line or line.startswith("::") or "->" not in line:
+                continue
+            parts = line.split()
+            if len(parts) < 4:
+                continue
+            name = parts[0]
+            current = parts[1]
+            available = parts[3]
+            packages.append({"name": name, "current": current, "available": available})
+
+        return packages, _kernel_update_in(packages)
+
+
+# ---------------------------------------------------------------------------
+# APK  (Alpine Linux)
+# ---------------------------------------------------------------------------
+
+class ApkPackageManager(PackageManager):
+    name = "apk"
+
+    def list_cmd(self) -> str:
+        # apk version -q -l '<' lists packages where installed < available
+        return "apk update -q 2>/dev/null; apk version -q -l '<' 2>/dev/null"
+
+    def upgrade_cmd(self) -> str:
+        return "apk upgrade 2>&1"
+
+    def parse(self, stdout: str) -> tuple[list[Package], bool]:
+        packages: list[Package] = []
+        # Format: "bash-5.1.16-r2 < 5.2.0-r0 [community]"
+        for line in stdout.splitlines():
+            line = line.strip()
+            if "<" not in line or line.startswith("fetch") or line.startswith("OK"):
+                continue
+            # Split on whitespace, find < separator
+            parts = line.split()
+            if len(parts) < 3 or parts[1] != "<":
+                continue
+            # "bash-5.1.16-r2" → name="bash", current="5.1.16-r2"
+            pkg_ver = parts[0]
+            # Split on last hyphen-preceded-by-digit run
+            match = re.match(r"^(.+?)-(\d.*)$", pkg_ver)
+            if match:
+                name, current = match.group(1), match.group(2)
+            else:
+                name, current = pkg_ver, "?"
+            available = parts[2]
+            packages.append({"name": name, "current": current, "available": available})
+
+        return packages, _kernel_update_in(packages)
+
+
+# ---------------------------------------------------------------------------
+# Unknown fallback
+# ---------------------------------------------------------------------------
+
+class UnknownPackageManager(PackageManager):
+    def __init__(self, name: str = "unknown"):
+        self.name = name
+
+    def list_cmd(self) -> str:
+        return "echo 'Package manager not supported'"
+
+    def upgrade_cmd(self) -> str:
+        return "echo 'Package manager not supported'"
+
+    def parse(self, stdout: str) -> tuple[list[Package], bool]:
+        return [], False
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+_REGISTRY: dict[str, PackageManager] = {
+    "apt":    AptPackageManager(),
+    "dnf":    DnfPackageManager(),
+    "yum":    YumPackageManager(),
+    "zypper": ZypperPackageManager(),
+    "pacman": PacmanPackageManager(),
+    "apk":    ApkPackageManager(),
+}

--- a/app/ssh_client.py
+++ b/app/ssh_client.py
@@ -2,6 +2,8 @@ import asyncio
 
 import asyncssh
 
+from .package_managers import DETECT_CMD, get_package_manager
+
 
 def _needs_sudo(host: dict, ssh_cfg: dict) -> bool:
     user = host.get("user") or ssh_cfg.get("default_user", "root")
@@ -24,7 +26,6 @@ async def _connect(host: dict, ssh_cfg: dict, creds: dict | None = None) -> asyn
         key = asyncssh.import_private_key(creds["ssh_key"])
         kwargs["client_keys"] = [key]
     else:
-        # Fall back to key file (legacy / existing setups)
         key_path = host.get("key", ssh_cfg.get("default_key"))
         if key_path:
             kwargs["client_keys"] = [key_path]
@@ -52,6 +53,11 @@ async def _run(
     return await coro
 
 
+async def _detect_pm(conn: asyncssh.SSHClientConnection, sudo_password: str | None, needs_sudo: bool):
+    result = await _run(conn, DETECT_CMD, sudo_password=sudo_password, needs_sudo=needs_sudo)
+    return get_package_manager(result.stdout.strip())
+
+
 async def verify_connection(host: dict, ssh_cfg: dict, creds: dict | None = None) -> dict:
     """Returns {"ok": bool, "message": str}."""
     try:
@@ -72,6 +78,7 @@ async def check_host_updates(
       {
         "packages": [{"name": str, "current": str, "available": str}, ...],
         "reboot_required": bool,
+        "package_manager": str,
       }
     """
     creds = creds or {}
@@ -79,39 +86,16 @@ async def check_host_updates(
     sudo_password = creds.get("sudo_password")
 
     async with await _connect(host, ssh_cfg, creds) as conn:
+        pm = await _detect_pm(conn, sudo_password, use_sudo)
         result = await _run(
             conn,
-            "sh -c 'apt-get update -qq 2>/dev/null;"
-            " apt list --upgradable 2>/dev/null;"
-            " echo __REBOOT__;"
-            " [ -f /var/run/reboot-required ] && echo yes || echo no'",
+            pm.list_cmd(),
             sudo_password=sudo_password,
             needs_sudo=use_sudo,
         )
 
-    output = result.stdout
-    reboot_required = False
-
-    if "__REBOOT__" in output:
-        apt_part, reboot_part = output.split("__REBOOT__", 1)
-        reboot_required = reboot_part.strip().startswith("yes")
-    else:
-        apt_part = output
-
-    packages = []
-    for line in apt_part.splitlines():
-        if "[upgradable from:" not in line:
-            continue
-        try:
-            name = line.split("/")[0]
-            parts = line.split()
-            available = parts[1] if len(parts) > 1 else "?"
-            current = parts[-1].rstrip("]") if len(parts) > 3 else "?"
-            packages.append({"name": name, "current": current, "available": available})
-        except Exception:
-            continue
-
-    return {"packages": packages, "reboot_required": reboot_required}
+    packages, reboot_required = pm.parse(result.stdout)
+    return {"packages": packages, "reboot_required": reboot_required, "package_manager": pm.name}
 
 
 async def reboot_host(
@@ -135,16 +119,17 @@ async def reboot_host(
 async def run_host_update_buffered(
     host: dict, ssh_cfg: dict, creds: dict | None = None
 ) -> list[str]:
-    """Runs apt-get upgrade and returns all output lines when complete."""
+    """Detects the package manager, runs the appropriate upgrade command, returns all output lines."""
     creds = creds or {}
     use_sudo = _needs_sudo(host, ssh_cfg)
     sudo_password = creds.get("sudo_password")
     timeout = ssh_cfg.get("command_timeout", 600)
 
     async with await _connect(host, ssh_cfg, creds) as conn:
+        pm = await _detect_pm(conn, sudo_password, use_sudo)
         result = await _run(
             conn,
-            "DEBIAN_FRONTEND=noninteractive apt-get upgrade -y 2>&1",
+            pm.upgrade_cmd(),
             sudo_password=sudo_password,
             needs_sudo=use_sudo,
             timeout=timeout,

--- a/app/templates/partials/host_status.html
+++ b/app/templates/partials/host_status.html
@@ -2,6 +2,9 @@
 <span class="inline-flex items-center gap-1.5 px-2.5 py-0.5 rounded-full text-xs font-medium bg-amber-900/50 text-amber-300 border border-amber-700">
   {{ packages | length }} update{{ 's' if packages | length != 1 }}
 </span>
+{% if package_manager and package_manager != "unknown" %}
+<span class="ml-1 text-xs text-slate-600">via {{ package_manager }}</span>
+{% endif %}
 <div class="mt-2 text-xs text-slate-400 max-h-24 overflow-y-auto space-y-0.5">
   {% for pkg in packages %}
   <div>{{ pkg.name }} <span class="text-slate-500">{{ pkg.current }} → {{ pkg.available }}</span></div>
@@ -11,7 +14,7 @@
   hx-post="/api/host/{{ slug }}/update"
   hx-target="#host-{{ slug }}-action"
   hx-swap="innerHTML"
-  hx-confirm="Run apt upgrade on {{ slug }}?"
+  hx-confirm="Run upgrade on {{ slug }}?"
   class="mt-2 px-3 py-1 text-xs rounded bg-blue-600 hover:bg-blue-500 text-white font-medium transition-colors">
   Update
 </button>
@@ -19,6 +22,9 @@
 <span class="inline-flex items-center gap-1.5 px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-900/50 text-green-300 border border-green-700">
   Up to date
 </span>
+{% if package_manager and package_manager != "unknown" %}
+<span class="ml-1 text-xs text-slate-600">via {{ package_manager }}</span>
+{% endif %}
 {% endif %}
 {% if reboot_required %}
 <div class="mt-2 flex items-center gap-2">

--- a/tests/test_package_managers.py
+++ b/tests/test_package_managers.py
@@ -1,0 +1,472 @@
+"""Tests for package manager detection and output parsing."""
+import pytest
+from app.package_managers import (
+    AptPackageManager,
+    DnfPackageManager,
+    YumPackageManager,
+    ZypperPackageManager,
+    PacmanPackageManager,
+    ApkPackageManager,
+    UnknownPackageManager,
+    get_package_manager,
+    _is_kernel_package,
+    _kernel_update_in,
+)
+
+
+# ---------------------------------------------------------------------------
+# Kernel heuristic
+# ---------------------------------------------------------------------------
+
+def test_is_kernel_package_linux_image():
+    assert _is_kernel_package("linux-image-6.1.0-amd64")
+
+def test_is_kernel_package_linux_headers():
+    assert _is_kernel_package("linux-headers-generic")
+
+def test_is_kernel_package_kernel():
+    assert _is_kernel_package("kernel")
+
+def test_is_kernel_package_kernel_core():
+    assert _is_kernel_package("kernel-core")
+
+def test_is_kernel_package_linux_arch():
+    assert _is_kernel_package("linux")
+
+def test_is_kernel_package_linux_lts():
+    assert _is_kernel_package("linux-lts")
+
+def test_is_not_kernel_package():
+    assert not _is_kernel_package("bash")
+    assert not _is_kernel_package("nginx")
+    assert not _is_kernel_package("curl")
+
+def test_kernel_update_in_detects():
+    packages = [{"name": "bash", "current": "5.0", "available": "5.1"},
+                {"name": "linux-image-6.1", "current": "6.0", "available": "6.1"}]
+    assert _kernel_update_in(packages)
+
+def test_kernel_update_in_false():
+    packages = [{"name": "bash", "current": "5.0", "available": "5.1"}]
+    assert not _kernel_update_in(packages)
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+def test_get_package_manager_apt():
+    assert get_package_manager("apt").name == "apt"
+
+def test_get_package_manager_dnf():
+    assert get_package_manager("dnf").name == "dnf"
+
+def test_get_package_manager_yum():
+    assert get_package_manager("yum").name == "yum"
+
+def test_get_package_manager_zypper():
+    assert get_package_manager("zypper").name == "zypper"
+
+def test_get_package_manager_pacman():
+    assert get_package_manager("pacman").name == "pacman"
+
+def test_get_package_manager_apk():
+    assert get_package_manager("apk").name == "apk"
+
+def test_get_package_manager_unknown():
+    pm = get_package_manager("unknown")
+    assert isinstance(pm, UnknownPackageManager)
+
+def test_get_package_manager_empty_string():
+    pm = get_package_manager("")
+    assert isinstance(pm, UnknownPackageManager)
+
+
+# ---------------------------------------------------------------------------
+# APT
+# ---------------------------------------------------------------------------
+
+APT_OUTPUT = (
+    "Listing... Done\n"
+    "curl/stable 8.0.0 amd64 [upgradable from: 7.0.0]\n"
+    "nginx/stable 1.26.0-1 amd64 [upgradable from: 1.24.0-1]\n"
+    "__REBOOT__\n"
+    "no\n"
+)
+
+APT_REBOOT_OUTPUT = (
+    "linux-image-6.1.0/stable 6.1.0 amd64 [upgradable from: 6.0.0]\n"
+    "__REBOOT__\n"
+    "yes\n"
+)
+
+def test_apt_parses_packages():
+    pm = AptPackageManager()
+    packages, reboot = pm.parse(APT_OUTPUT)
+    assert len(packages) == 2
+    assert packages[0]["name"] == "curl"
+    assert packages[0]["current"] == "7.0.0"
+    assert packages[0]["available"] == "8.0.0"
+
+def test_apt_parses_nginx():
+    pm = AptPackageManager()
+    packages, _ = pm.parse(APT_OUTPUT)
+    nginx = next(p for p in packages if p["name"] == "nginx")
+    assert nginx["available"] == "1.26.0-1"
+    assert nginx["current"] == "1.24.0-1"
+
+def test_apt_reboot_not_required():
+    pm = AptPackageManager()
+    _, reboot = pm.parse(APT_OUTPUT)
+    assert reboot is False
+
+def test_apt_reboot_required_by_flag():
+    pm = AptPackageManager()
+    _, reboot = pm.parse(APT_OUTPUT.replace("__REBOOT__\nno", "__REBOOT__\nyes"))
+    assert reboot is True
+
+def test_apt_reboot_required_by_kernel():
+    pm = AptPackageManager()
+    _, reboot = pm.parse(APT_REBOOT_OUTPUT)
+    # /var/run/reboot-required says yes AND kernel package
+    assert reboot is True
+
+def test_apt_kernel_triggers_reboot_even_without_file():
+    pm = AptPackageManager()
+    output = "linux-image-6.1.0/stable 6.1.0 amd64 [upgradable from: 6.0.0]\n__REBOOT__\nno\n"
+    _, reboot = pm.parse(output)
+    assert reboot is True  # kernel heuristic fires
+
+def test_apt_empty_output():
+    pm = AptPackageManager()
+    packages, reboot = pm.parse("__REBOOT__\nno\n")
+    assert packages == []
+    assert reboot is False
+
+def test_apt_no_reboot_sentinel():
+    pm = AptPackageManager()
+    packages, reboot = pm.parse("curl/stable 8.0.0 amd64 [upgradable from: 7.0.0]\n")
+    assert len(packages) == 1
+    assert reboot is False
+
+def test_apt_upgrade_cmd():
+    pm = AptPackageManager()
+    assert "apt-get upgrade" in pm.upgrade_cmd()
+    assert "DEBIAN_FRONTEND=noninteractive" in pm.upgrade_cmd()
+
+
+# ---------------------------------------------------------------------------
+# DNF
+# ---------------------------------------------------------------------------
+
+DNF_OUTPUT = (
+    "Last metadata expiration check: 0:01:00 ago.\n"
+    "\n"
+    "bash.x86_64                   5.1.8-6.el9     baseos\n"
+    "kernel.x86_64                 5.14.0-362.el9  baseos\n"
+    "curl.x86_64                   7.76.1-26.el9   baseos\n"
+    "__EXIT__100\n"
+    "__REBOOT__\n"
+    "0\n"
+)
+
+DNF_NO_UPDATES = "__EXIT__0\n__REBOOT__\n0\n"
+
+def test_dnf_parses_packages():
+    pm = DnfPackageManager()
+    packages, _ = pm.parse(DNF_OUTPUT)
+    names = [p["name"] for p in packages]
+    assert "bash" in names
+    assert "kernel" in names
+    assert "curl" in names
+
+def test_dnf_strips_arch():
+    pm = DnfPackageManager()
+    packages, _ = pm.parse(DNF_OUTPUT)
+    assert all("." not in p["name"] for p in packages)
+
+def test_dnf_reboot_by_needs_restarting():
+    pm = DnfPackageManager()
+    output = DNF_OUTPUT.replace("__REBOOT__\n0", "__REBOOT__\n1")
+    _, reboot = pm.parse(output)
+    assert reboot is True
+
+def test_dnf_reboot_by_kernel():
+    pm = DnfPackageManager()
+    _, reboot = pm.parse(DNF_OUTPUT)
+    assert reboot is True  # kernel.x86_64 in packages
+
+def test_dnf_no_updates_no_reboot():
+    pm = DnfPackageManager()
+    packages, reboot = pm.parse(DNF_NO_UPDATES)
+    assert packages == []
+    assert reboot is False
+
+def test_dnf_upgrade_cmd():
+    assert "dnf upgrade" in DnfPackageManager().upgrade_cmd()
+
+
+# ---------------------------------------------------------------------------
+# YUM (delegates to DNF parser)
+# ---------------------------------------------------------------------------
+
+def test_yum_parses_same_as_dnf():
+    yum = YumPackageManager()
+    dnf = DnfPackageManager()
+    yum_pkgs, yum_reboot = yum.parse(DNF_OUTPUT)
+    dnf_pkgs, dnf_reboot = dnf.parse(DNF_OUTPUT)
+    assert yum_pkgs == dnf_pkgs
+    assert yum_reboot == dnf_reboot
+
+def test_yum_upgrade_cmd():
+    assert "yum upgrade" in YumPackageManager().upgrade_cmd()
+
+
+# ---------------------------------------------------------------------------
+# Zypper
+# ---------------------------------------------------------------------------
+
+ZYPPER_OUTPUT = (
+    "Loading repository data...\n"
+    "Reading installed packages...\n"
+    "S | Repository   | Name           | Current Version | Available Version | Arch\n"
+    "--+-------------+----------------+-----------------+-------------------+-------\n"
+    "v | Main Update  | bash           | 4.4-19.9        | 5.1-1.1           | x86_64\n"
+    "v | Main Update  | kernel-default | 5.14.21         | 6.1.0             | x86_64\n"
+    "__REBOOT__\n"
+    "no\n"
+)
+
+def test_zypper_parses_packages():
+    pm = ZypperPackageManager()
+    packages, _ = pm.parse(ZYPPER_OUTPUT)
+    names = [p["name"] for p in packages]
+    assert "bash" in names
+    assert "kernel-default" in names
+
+def test_zypper_versions():
+    pm = ZypperPackageManager()
+    packages, _ = pm.parse(ZYPPER_OUTPUT)
+    bash = next(p for p in packages if p["name"] == "bash")
+    assert bash["current"] == "4.4-19.9"
+    assert bash["available"] == "5.1-1.1"
+
+def test_zypper_reboot_by_kernel():
+    pm = ZypperPackageManager()
+    _, reboot = pm.parse(ZYPPER_OUTPUT)
+    assert reboot is True  # kernel-default triggers heuristic
+
+def test_zypper_reboot_by_flag():
+    pm = ZypperPackageManager()
+    output = ZYPPER_OUTPUT.replace("__REBOOT__\nno", "__REBOOT__\nyes")
+    _, reboot = pm.parse(output)
+    assert reboot is True
+
+def test_zypper_upgrade_cmd():
+    assert "zypper" in ZypperPackageManager().upgrade_cmd()
+
+
+# ---------------------------------------------------------------------------
+# Pacman
+# ---------------------------------------------------------------------------
+
+PACMAN_OUTPUT = (
+    "bash 5.2.021-2 -> 5.2.026-1\n"
+    "linux 6.6.1.arch1-1 -> 6.7.0.arch1-1\n"
+    "curl 8.0.0-1 -> 8.1.0-1\n"
+)
+
+def test_pacman_parses_packages():
+    pm = PacmanPackageManager()
+    packages, _ = pm.parse(PACMAN_OUTPUT)
+    names = [p["name"] for p in packages]
+    assert "bash" in names
+    assert "linux" in names
+    assert "curl" in names
+
+def test_pacman_versions():
+    pm = PacmanPackageManager()
+    packages, _ = pm.parse(PACMAN_OUTPUT)
+    bash = next(p for p in packages if p["name"] == "bash")
+    assert bash["current"] == "5.2.021-2"
+    assert bash["available"] == "5.2.026-1"
+
+def test_pacman_reboot_by_linux():
+    pm = PacmanPackageManager()
+    _, reboot = pm.parse(PACMAN_OUTPUT)
+    assert reboot is True  # linux package
+
+def test_pacman_no_reboot_no_kernel():
+    pm = PacmanPackageManager()
+    output = "bash 5.2.021-2 -> 5.2.026-1\n"
+    _, reboot = pm.parse(output)
+    assert reboot is False
+
+def test_pacman_skips_informational_lines():
+    pm = PacmanPackageManager()
+    output = ":: Synchronizing package databases...\nbash 5.2.021-2 -> 5.2.026-1\n"
+    packages, _ = pm.parse(output)
+    assert len(packages) == 1
+
+def test_pacman_upgrade_cmd():
+    assert "pacman" in PacmanPackageManager().upgrade_cmd()
+
+
+# ---------------------------------------------------------------------------
+# APK
+# ---------------------------------------------------------------------------
+
+APK_OUTPUT = (
+    "bash-5.1.16-r2 < 5.2.0-r0 [community]\n"
+    "linux-lts-6.1.57-r0 < 6.1.63-r0 [community]\n"
+    "curl-8.1.2-r0 < 8.4.0-r0 [community]\n"
+)
+
+def test_apk_parses_packages():
+    pm = ApkPackageManager()
+    packages, _ = pm.parse(APK_OUTPUT)
+    names = [p["name"] for p in packages]
+    assert "bash" in names
+    assert "linux-lts" in names
+    assert "curl" in names
+
+def test_apk_versions():
+    pm = ApkPackageManager()
+    packages, _ = pm.parse(APK_OUTPUT)
+    bash = next(p for p in packages if p["name"] == "bash")
+    assert bash["current"] == "5.1.16-r2"
+    assert bash["available"] == "5.2.0-r0"
+
+def test_apk_reboot_by_linux_lts():
+    pm = ApkPackageManager()
+    _, reboot = pm.parse(APK_OUTPUT)
+    assert reboot is True
+
+def test_apk_no_reboot_no_kernel():
+    pm = ApkPackageManager()
+    _, reboot = pm.parse("bash-5.1.16-r2 < 5.2.0-r0 [community]\n")
+    assert reboot is False
+
+def test_apk_upgrade_cmd():
+    assert "apk upgrade" in ApkPackageManager().upgrade_cmd()
+
+
+# ---------------------------------------------------------------------------
+# UnknownPackageManager
+# ---------------------------------------------------------------------------
+
+def test_unknown_returns_empty():
+    pm = UnknownPackageManager("mystery")
+    packages, reboot = pm.parse("some output")
+    assert packages == []
+    assert reboot is False
+
+def test_unknown_list_cmd():
+    assert "not supported" in UnknownPackageManager().list_cmd()
+
+def test_unknown_upgrade_cmd():
+    assert "not supported" in UnknownPackageManager().upgrade_cmd()
+
+
+# ---------------------------------------------------------------------------
+# list_cmd coverage
+# ---------------------------------------------------------------------------
+
+def test_dnf_list_cmd():
+    assert "dnf check-update" in DnfPackageManager().list_cmd()
+    assert "__EXIT__" in DnfPackageManager().list_cmd()
+
+def test_yum_list_cmd():
+    assert "yum check-update" in YumPackageManager().list_cmd()
+
+def test_zypper_list_cmd():
+    assert "zypper" in ZypperPackageManager().list_cmd()
+
+def test_pacman_list_cmd():
+    assert "pacman" in PacmanPackageManager().list_cmd()
+
+def test_apk_list_cmd():
+    assert "apk" in ApkPackageManager().list_cmd()
+
+
+# ---------------------------------------------------------------------------
+# Edge case coverage
+# ---------------------------------------------------------------------------
+
+def test_dnf_parse_skips_obsoleting_line():
+    pm = DnfPackageManager()
+    # "Obsoleting Packages" header is skipped; package lines after it are still parsed
+    output = "bash.x86_64    5.1.8    baseos\nObsoleting Packages\n__EXIT__100\n__REBOOT__\n0\n"
+    packages, _ = pm.parse(output)
+    assert len(packages) == 1
+    assert packages[0]["name"] == "bash"
+
+def test_dnf_parse_skips_short_lines():
+    pm = DnfPackageManager()
+    output = "toolong\n__EXIT__100\n__REBOOT__\n0\n"
+    packages, _ = pm.parse(output)
+    assert packages == []
+
+def test_zypper_parse_no_reboot_sentinel():
+    pm = ZypperPackageManager()
+    output = "v | Main Update  | bash | 4.4-19.9 | 5.1-1.1 | x86_64\n"
+    packages, reboot = pm.parse(output)
+    assert len(packages) == 1
+    assert reboot is False
+
+def test_zypper_parse_skips_short_pipe_rows():
+    pm = ZypperPackageManager()
+    output = "v | only | three\n"
+    packages, _ = pm.parse(output)
+    assert packages == []
+
+def test_pacman_parse_skips_short_arrow_lines():
+    pm = PacmanPackageManager()
+    output = "name 1.0 ->\n"  # only 3 parts
+    packages, _ = pm.parse(output)
+    assert packages == []
+
+def test_apk_parse_skips_fetch_lines():
+    pm = ApkPackageManager()
+    output = "fetch http://dl-cdn.alpinelinux.org/alpine/edge/main\nbash-5.1-r2 < 5.2-r0 [community]\n"
+    packages, _ = pm.parse(output)
+    assert len(packages) == 1
+
+def test_apk_parse_skips_wrong_separator():
+    pm = ApkPackageManager()
+    output = "bash-5.1-r2 > 5.2-r0 [community]\n"  # > instead of <, but line has no <
+    packages, _ = pm.parse(output)
+    assert packages == []
+
+def test_apk_parse_no_regex_match():
+    pm = ApkPackageManager()
+    # pkg_ver with no leading digit after hyphen → regex fails
+    output = "pkgname < 1.0-r0 [community]\n"
+    packages, _ = pm.parse(output)
+    assert len(packages) == 1
+    assert packages[0]["name"] == "pkgname"
+    assert packages[0]["current"] == "?"
+
+
+# ---------------------------------------------------------------------------
+# Base class raises NotImplementedError
+# ---------------------------------------------------------------------------
+
+def test_base_list_cmd_not_implemented():
+    from app.package_managers import PackageManager
+    import pytest
+    pm = PackageManager()
+    with pytest.raises(NotImplementedError):
+        pm.list_cmd()
+
+def test_base_upgrade_cmd_not_implemented():
+    from app.package_managers import PackageManager
+    pm = PackageManager()
+    with pytest.raises(NotImplementedError):
+        pm.upgrade_cmd()
+
+def test_base_parse_not_implemented():
+    from app.package_managers import PackageManager
+    pm = PackageManager()
+    with pytest.raises(NotImplementedError):
+        pm.parse("")

--- a/tests/test_ssh_client.py
+++ b/tests/test_ssh_client.py
@@ -3,12 +3,16 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from app.package_managers import AptPackageManager
 from app.ssh_client import (
     check_host_updates,
     reboot_host,
     run_host_update_buffered,
     verify_connection,
 )
+
+_APT_PM = AptPackageManager()
+_DETECT_PM_PATCH = patch("app.ssh_client._detect_pm", new=AsyncMock(return_value=_APT_PM))
 
 HOST = {"name": "Test", "host": "10.0.0.1"}
 HOST_KEY = HOST  # alias used by key-auth tests
@@ -86,7 +90,7 @@ async def test_connection_uses_key_when_no_password():
 async def test_check_host_updates_no_packages():
     output = "__REBOOT__\nno\n"
     conn = _make_conn(stdout=output)
-    with patch("app.ssh_client.asyncssh.connect", new=AsyncMock(return_value=conn)):
+    with patch("app.ssh_client.asyncssh.connect", new=AsyncMock(return_value=conn)), _DETECT_PM_PATCH:
         result = await check_host_updates(HOST_KEY, SSH_CFG)
     assert result["packages"] == []
     assert result["reboot_required"] is False
@@ -100,7 +104,7 @@ async def test_check_host_updates_with_packages():
         "__REBOOT__\nno\n"
     )
     conn = _make_conn(stdout=output)
-    with patch("app.ssh_client.asyncssh.connect", new=AsyncMock(return_value=conn)):
+    with patch("app.ssh_client.asyncssh.connect", new=AsyncMock(return_value=conn)), _DETECT_PM_PATCH:
         result = await check_host_updates(HOST_KEY, SSH_CFG)
     assert len(result["packages"]) == 2
     assert result["packages"][0]["name"] == "nginx"
@@ -112,7 +116,7 @@ async def test_check_host_updates_with_packages():
 async def test_check_host_updates_reboot_required():
     output = "__REBOOT__\nyes\n"
     conn = _make_conn(stdout=output)
-    with patch("app.ssh_client.asyncssh.connect", new=AsyncMock(return_value=conn)):
+    with patch("app.ssh_client.asyncssh.connect", new=AsyncMock(return_value=conn)), _DETECT_PM_PATCH:
         result = await check_host_updates(HOST_KEY, SSH_CFG)
     assert result["reboot_required"] is True
 
@@ -121,7 +125,7 @@ async def test_check_host_updates_reboot_required():
 async def test_check_host_updates_no_reboot_marker():
     # Output without __REBOOT__ sentinel still works
     conn = _make_conn(stdout="nginx/stable 1.26.0-1 amd64 [upgradable from: 1.24.0-1]\n")
-    with patch("app.ssh_client.asyncssh.connect", new=AsyncMock(return_value=conn)):
+    with patch("app.ssh_client.asyncssh.connect", new=AsyncMock(return_value=conn)), _DETECT_PM_PATCH:
         result = await check_host_updates(HOST_KEY, SSH_CFG)
     assert result["reboot_required"] is False
     assert len(result["packages"]) == 1
@@ -132,7 +136,7 @@ async def test_check_host_updates_skips_non_package_lines():
     # Lines without [upgradable from: hit the continue branch
     output = "Listing... Done\nnginx/stable 1.26.0-1 amd64 [upgradable from: 1.24.0-1]\n__REBOOT__\nno\n"
     conn = _make_conn(stdout=output)
-    with patch("app.ssh_client.asyncssh.connect", new=AsyncMock(return_value=conn)):
+    with patch("app.ssh_client.asyncssh.connect", new=AsyncMock(return_value=conn)), _DETECT_PM_PATCH:
         result = await check_host_updates(HOST_KEY, SSH_CFG)
     assert len(result["packages"]) == 1  # Only the upgradable line counted
 
@@ -158,7 +162,7 @@ async def test_reboot_host_returns_message():
 async def test_run_host_update_returns_lines():
     output = "Reading package lists...\nUpgrading curl...\n"
     conn = _make_conn(stdout=output)
-    with patch("app.ssh_client.asyncssh.connect", new=AsyncMock(return_value=conn)):
+    with patch("app.ssh_client.asyncssh.connect", new=AsyncMock(return_value=conn)), _DETECT_PM_PATCH:
         lines = await run_host_update_buffered(HOST_KEY, SSH_CFG)
     assert "Reading package lists..." in lines
     assert "Upgrading curl..." in lines
@@ -167,7 +171,7 @@ async def test_run_host_update_returns_lines():
 @pytest.mark.asyncio
 async def test_run_host_update_includes_stderr_on_error():
     conn = _make_conn(stdout="some output\n", returncode=1, stderr="E: Could not lock\n")
-    with patch("app.ssh_client.asyncssh.connect", new=AsyncMock(return_value=conn)):
+    with patch("app.ssh_client.asyncssh.connect", new=AsyncMock(return_value=conn)), _DETECT_PM_PATCH:
         lines = await run_host_update_buffered(HOST_KEY, SSH_CFG)
     assert "E: Could not lock" in lines
 
@@ -177,6 +181,6 @@ async def test_run_host_update_respects_timeout():
     import asyncio
     conn = _make_conn()
     conn.run = AsyncMock(side_effect=asyncio.TimeoutError())
-    with patch("app.ssh_client.asyncssh.connect", new=AsyncMock(return_value=conn)):
+    with patch("app.ssh_client.asyncssh.connect", new=AsyncMock(return_value=conn)), _DETECT_PM_PATCH:
         with pytest.raises(asyncio.TimeoutError):
             await run_host_update_buffered(HOST_KEY, {"command_timeout": 1})


### PR DESCRIPTION
## Summary
- Detects the package manager on each host via a single shell command (`apt-get`, `dnf`, `yum`, `zypper`, `pacman`, `apk`)
- Each PM implements `list_cmd()`, `upgrade_cmd()`, and `parse()` — the SSH client detects and delegates automatically
- Reboot detection uses two independent signals OR-ed together: PM-specific indicator (e.g. `/var/run/reboot-required`, `needs-restarting -r` exit code, `zypper needs-rebooting`) and a kernel package name heuristic
- Shows "via \<pm\>" label next to the update status badge in the UI

## Test plan
- [x] 262 tests pass, 96% coverage (CI threshold: 95%)
- [x] `test_package_managers.py` — dedicated tests for all 6 PMs + edge cases (kernel heuristic, reboot flags, malformed lines, base class NotImplementedError)
- [x] `test_ssh_client.py` — updated to patch `_detect_pm` since detection is now a separate SSH call

🤖 Generated with [Claude Code](https://claude.com/claude-code)