### PR TITLE
feat: manage Portainer and DockerHub through the UI

### DIFF
--- a/app/admin.py
+++ b/app/admin.py
@@ -5,11 +5,16 @@ from fastapi import APIRouter, Form, Request
 from fastapi.responses import HTMLResponse
 from fastapi.templating import Jinja2Templates
 
+from .backend_loader import reload_backends
 from .config_manager import (
     add_host,
     delete_host,
+    get_dockerhub_config,
     get_hosts,
+    get_portainer_config,
     get_ssh_config,
+    save_dockerhub_config,
+    save_portainer_config,
     set_docker_monitoring,
     slugify,
     update_host,
@@ -18,8 +23,10 @@ from .config_manager import (
 from .credentials import (
     credential_status,
     delete_credentials,
+    get_integration_credentials,
     rename_credentials,
     save_credentials,
+    save_integration_credentials,
 )
 from .ssh_client import verify_connection
 
@@ -28,11 +35,30 @@ templates = Jinja2Templates(directory=Path(__file__).parent / "templates")
 
 
 def _connection_status() -> dict:
+    """Read connection status from credential store, fall back to env vars."""
+    port_cfg = get_portainer_config()
+    port_creds = get_integration_credentials("portainer")
+    dh_cfg = get_dockerhub_config()
+    dh_creds = get_integration_credentials("dockerhub")
+
+    portainer_url = port_cfg.get("url") or os.getenv("PORTAINER_URL", "")
+    portainer_key_set = bool(port_creds.get("api_key") or os.getenv("PORTAINER_API_KEY", ""))
+    portainer_verify_ssl = port_cfg.get("verify_ssl", False)
+    dockerhub_user = dh_cfg.get("username") or os.getenv("DOCKERHUB_USERNAME", "")
+    dockerhub_token_set = bool(dh_creds.get("token") or os.getenv("DOCKERHUB_TOKEN", ""))
+
+    # If values only exist in env vars, flag for migration nudge
+    portainer_env_only = (
+        not port_cfg.get("url") and bool(os.getenv("PORTAINER_URL", ""))
+    )
+
     return {
-        "portainer_url": os.getenv("PORTAINER_URL", ""),
-        "portainer_key_set": bool(os.getenv("PORTAINER_API_KEY", "")),
-        "dockerhub_user": os.getenv("DOCKERHUB_USERNAME", ""),
-        "dockerhub_token_set": bool(os.getenv("DOCKERHUB_TOKEN", "")),
+        "portainer_url": portainer_url,
+        "portainer_key_set": portainer_key_set,
+        "portainer_verify_ssl": portainer_verify_ssl,
+        "portainer_env_only": portainer_env_only,
+        "dockerhub_user": dockerhub_user,
+        "dockerhub_token_set": dockerhub_token_set,
     }
 
 
@@ -57,6 +83,14 @@ async def admin_page(request: Request) -> HTMLResponse:
             "ssh": get_ssh_config(),
             "conn": _connection_status(),
         },
+    )
+
+
+@router.get("/connections", response_class=HTMLResponse)
+async def admin_connections(request: Request) -> HTMLResponse:
+    return templates.TemplateResponse(
+        "partials/admin_connections.html",
+        {"request": request, "conn": _connection_status()},
     )
 
 
@@ -281,6 +315,99 @@ async def admin_save_docker_monitoring(
     return templates.TemplateResponse(
         "partials/admin_hosts.html",
         {"request": request, "hosts": _hosts_with_status()},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Connections — Portainer
+# ---------------------------------------------------------------------------
+
+@router.post("/connections/portainer/test", response_class=HTMLResponse)
+async def admin_test_portainer(
+    request: Request,
+    portainer_url: str = Form(""),
+    portainer_api_key: str = Form(""),
+    portainer_verify_ssl: str = Form(""),
+) -> HTMLResponse:
+    """Test Portainer connection with provided (unsaved) values."""
+    url = portainer_url.strip().rstrip("/")
+    key = portainer_api_key.strip()
+    verify_ssl = portainer_verify_ssl == "on"
+
+    if not url or not key:
+        return HTMLResponse(
+            '<span class="text-amber-400 text-sm">Enter a URL and API token first.</span>'
+        )
+    try:
+        from .portainer_client import PortainerClient
+        client = PortainerClient(url=url, api_key=key, verify_ssl=verify_ssl)
+        endpoints = await client.get_endpoints()
+        count = len(endpoints)
+        return HTMLResponse(
+            f'<span class="text-green-400 text-sm">&#10003; Connected — '
+            f'{count} environment{"s" if count != 1 else ""} found. '
+            f'Click Save to apply.</span>'
+        )
+    except Exception as exc:
+        msg = str(exc)
+        if "401" in msg or "403" in msg:
+            hint = "Invalid API token — check you copied it correctly."
+        elif "Name or service not known" in msg or "ConnectionRefused" in msg.lower() or "connect" in msg.lower():
+            hint = "Can't reach that address — check the URL and that Portainer is running."
+        elif "SSL" in msg or "certificate" in msg.lower():
+            hint = "SSL error — try enabling &ldquo;Ignore SSL warnings&rdquo; below."
+        else:
+            hint = msg
+        return HTMLResponse(f'<span class="text-red-400 text-sm">&#10007; {hint}</span>')
+
+
+@router.post("/connections/portainer", response_class=HTMLResponse)
+async def admin_save_portainer(
+    request: Request,
+    portainer_url: str = Form(""),
+    portainer_api_key: str = Form(""),
+    portainer_verify_ssl: str = Form(""),
+) -> HTMLResponse:
+    url = portainer_url.strip().rstrip("/")
+    key = portainer_api_key.strip()
+    verify_ssl = portainer_verify_ssl == "on"
+
+    save_portainer_config(url=url, verify_ssl=verify_ssl)
+    if key:
+        save_integration_credentials("portainer", api_key=key)
+
+    await reload_backends()
+
+    return templates.TemplateResponse(
+        "partials/admin_connections.html",
+        {"request": request, "conn": _connection_status(), "portainer_saved": True},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Connections — DockerHub
+# ---------------------------------------------------------------------------
+
+@router.post("/connections/dockerhub", response_class=HTMLResponse)
+async def admin_save_dockerhub(
+    request: Request,
+    dockerhub_username: str = Form(""),
+    dockerhub_token: str = Form(""),
+) -> HTMLResponse:
+    username = dockerhub_username.strip()
+    token = dockerhub_token.strip()
+
+    save_dockerhub_config(username=username)
+    if token:
+        save_integration_credentials("dockerhub", token=token)
+    elif not username:
+        save_integration_credentials("dockerhub", token="")
+
+    await reload_backends()
+
+    return templates.TemplateResponse(
+        "partials/admin_connections.html",
+        {"request": request, "conn": _connection_status(), "dockerhub_saved": True},
     )
 
 

--- a/app/backend_loader.py
+++ b/app/backend_loader.py
@@ -1,0 +1,61 @@
+"""
+Centralised backend initialisation.
+
+Both the app startup and admin save routes call reload_backends() so that
+connection changes take effect immediately without a container restart.
+"""
+import os
+
+from .config_manager import get_dockerhub_config, get_portainer_config
+from .credentials import get_integration_credentials
+
+_backends: list = []
+
+
+def get_backends() -> list:
+    return _backends
+
+
+def get_dockerhub_creds() -> dict | None:
+    """Read DockerHub creds from store, fall back to env vars."""
+    dh_cfg = get_dockerhub_config()
+    dh_creds = get_integration_credentials("dockerhub")
+    user = dh_cfg.get("username") or os.getenv("DOCKERHUB_USERNAME", "")
+    token = dh_creds.get("token") or os.getenv("DOCKERHUB_TOKEN", "")
+    return {"username": user, "token": token} if user and token else None
+
+
+async def reload_backends() -> list:
+    """
+    Build the backends list from config + credential store (env var fallback).
+    Updates all modules that hold a reference to the backends list.
+    """
+    global _backends
+    backends = []
+
+    # Portainer — credential store first, env var fallback
+    port_cfg = get_portainer_config()
+    port_creds = get_integration_credentials("portainer")
+    url = port_cfg.get("url") or os.getenv("PORTAINER_URL", "")
+    key = port_creds.get("api_key") or os.getenv("PORTAINER_API_KEY", "")
+    verify_ssl = port_cfg.get("verify_ssl", False) or (
+        os.getenv("PORTAINER_VERIFY_SSL", "false").lower() == "true"
+    )
+
+    if url and key:
+        from .portainer_client import PortainerClient
+        from .backends import PortainerBackend
+        backends.append(PortainerBackend(PortainerClient(url=url, api_key=key, verify_ssl=verify_ssl)))
+
+    from .backends import SSHDockerBackend
+    backends.append(SSHDockerBackend())
+
+    _backends = backends
+
+    # Propagate to modules that cache the list
+    from .auto_update_scheduler import set_backends
+    from .auto_updates_router import set_backends as set_auto_updates_backends
+    set_backends(_backends)
+    set_auto_updates_backends(_backends)
+
+    return _backends

--- a/app/config_manager.py
+++ b/app/config_manager.py
@@ -117,6 +117,36 @@ def get_ssh_config() -> dict:
 
 
 # ---------------------------------------------------------------------------
+# Integration settings (non-sensitive — URLs/usernames only)
+# ---------------------------------------------------------------------------
+
+def get_portainer_config() -> dict:
+    return load_config().get("portainer", {})
+
+
+def save_portainer_config(url: str, verify_ssl: bool) -> None:
+    config = load_config()
+    if url:
+        config["portainer"] = {"url": url.rstrip("/"), "verify_ssl": verify_ssl}
+    else:
+        config.pop("portainer", None)
+    save_config(config)
+
+
+def get_dockerhub_config() -> dict:
+    return load_config().get("dockerhub", {})
+
+
+def save_dockerhub_config(username: str) -> None:
+    config = load_config()
+    if username:
+        config["dockerhub"] = {"username": username}
+    else:
+        config.pop("dockerhub", None)
+    save_config(config)
+
+
+# ---------------------------------------------------------------------------
 # Auto-update settings
 # ---------------------------------------------------------------------------
 

--- a/app/credentials.py
+++ b/app/credentials.py
@@ -105,6 +105,33 @@ def rename_credentials(old_slug: str, new_slug: str) -> None:
         _save_store(store)
 
 
+# ---------------------------------------------------------------------------
+# Integration credentials (Portainer, DockerHub, etc.)
+# ---------------------------------------------------------------------------
+
+def get_integration_credentials(key: str) -> dict:
+    """Return stored credentials for a named integration. Never raises."""
+    return _load_store().get(f"__integration_{key}__", {})
+
+
+def save_integration_credentials(key: str, **fields) -> None:
+    """
+    Save credentials for a named integration.
+    Pass None to leave an existing value unchanged; "" to clear it.
+    """
+    store = _load_store()
+    entry = store.get(f"__integration_{key}__", {})
+    for field, value in fields.items():
+        if value is None:
+            continue
+        if value == "":
+            entry.pop(field, None)
+        else:
+            entry[field] = value
+    store[f"__integration_{key}__"] = entry
+    _save_store(store)
+
+
 def credential_status(slug: str) -> dict:
     """Returns which credentials are configured for a host (no secrets exposed)."""
     creds = get_credentials(slug)

--- a/app/main.py
+++ b/app/main.py
@@ -9,9 +9,9 @@ from fastapi.templating import Jinja2Templates
 
 from .admin import router as admin_router
 from .auto_update_log import get_recent, get_unread_error_count, mark_all_read
-from .auto_update_scheduler import apply_all_schedules, scheduler, set_backends
+from .auto_update_scheduler import apply_all_schedules, scheduler
 from .auto_updates_router import router as auto_updates_router
-from .auto_updates_router import set_backends as set_auto_updates_backends
+from .backend_loader import get_backends, get_dockerhub_creds, reload_backends
 from .config_manager import get_hosts, get_ssh_config
 from .credentials import get_credentials, save_sudo_password
 from .ssh_client import _needs_sudo, check_host_updates, reboot_host, run_host_update_buffered
@@ -25,43 +25,9 @@ app.include_router(admin_router)
 app.include_router(auto_updates_router)
 templates = Jinja2Templates(directory=Path(__file__).parent / "templates")
 
-# ---------------------------------------------------------------------------
-# Config
-# ---------------------------------------------------------------------------
-
-_backends: list = []
-
-_dockerhub_user = os.getenv("DOCKERHUB_USERNAME", "")
-_dockerhub_token = os.getenv("DOCKERHUB_TOKEN", "")
-dockerhub_creds: dict | None = (
-    {"username": _dockerhub_user, "token": _dockerhub_token}
-    if _dockerhub_user and _dockerhub_token
-    else None
-)
-
-
 @app.on_event("startup")
 async def _startup() -> None:
-    global _backends
-    backends = []
-
-    # Portainer backend — opt-in via env vars
-    url = os.getenv("PORTAINER_URL", "")
-    key = os.getenv("PORTAINER_API_KEY", "")
-    verify_ssl = os.getenv("PORTAINER_VERIFY_SSL", "false").lower() == "true"
-    if url and key:
-        from .portainer_client import PortainerClient
-        from .backends import PortainerBackend
-        backends.append(PortainerBackend(PortainerClient(url=url, api_key=key, verify_ssl=verify_ssl)))
-
-    # SSH Docker backend — always registered; only activates for hosts with docker_mode set
-    from .backends import SSHDockerBackend
-    backends.append(SSHDockerBackend())
-
-    _backends = backends
-
-    set_backends(_backends)
-    set_auto_updates_backends(_backends)
+    await reload_backends()
     apply_all_schedules()
     scheduler.start()
 
@@ -78,6 +44,7 @@ def _get_host(slug: str) -> dict:
 
 
 _jobs: dict[str, dict] = {}
+
 
 
 # ---------------------------------------------------------------------------
@@ -110,7 +77,7 @@ async def _job_run_host_restart(job_id: str, host: dict, creds: dict) -> None:
 
 async def _job_run_stack_update(job_id: str, backend_key: str, ref: str) -> None:
     try:
-        backend = next((b for b in _backends if b.BACKEND_KEY == backend_key), None)
+        backend = next((b for b in get_backends() if b.BACKEND_KEY == backend_key), None)
         if backend is None:
             raise ValueError(f"Backend {backend_key!r} not available")
         await backend.update_stack(ref)
@@ -130,8 +97,9 @@ async def _job_run_stack_update(job_id: str, backend_key: str, ref: str) -> None
 @app.get("/", response_class=HTMLResponse)
 async def dashboard(request: Request) -> HTMLResponse:
     hosts = get_hosts()
+    backends = get_backends()
     docker_configured = (
-        any(b.BACKEND_KEY == "portainer" for b in _backends)
+        any(b.BACKEND_KEY == "portainer" for b in backends)
         or any(h.get("docker_mode") for h in hosts)
     )
     return templates.TemplateResponse(
@@ -248,8 +216,9 @@ async def host_restart(
 @app.get("/api/docker/check", response_class=HTMLResponse)
 async def docker_check(request: Request) -> HTMLResponse:
     hosts = get_hosts()
+    backends = get_backends()
     active = [
-        b for b in _backends
+        b for b in backends
         if b.BACKEND_KEY != "ssh" or any(h.get("docker_mode") for h in hosts)
     ]
     if not active:
@@ -259,7 +228,7 @@ async def docker_check(request: Request) -> HTMLResponse:
         )
     try:
         results = await asyncio.gather(
-            *[b.get_stacks_with_update_status(dockerhub_creds) for b in active],
+            *[b.get_stacks_with_update_status(get_dockerhub_creds()) for b in active],
             return_exceptions=True,
         )
         stacks = []
@@ -284,7 +253,7 @@ async def stack_update(
     ref: str,
     background_tasks: BackgroundTasks,
 ) -> HTMLResponse:
-    backend = next((b for b in _backends if b.BACKEND_KEY == backend_key), None)
+    backend = next((b for b in get_backends() if b.BACKEND_KEY == backend_key), None)
     if not backend:
         return templates.TemplateResponse(
             "partials/error.html",
@@ -352,3 +321,10 @@ async def notifications_read(request: Request) -> HTMLResponse:
         '<span id="notif-badge" hx-get="/api/notifications/badge" '
         'hx-trigger="every 60s" hx-swap="outerHTML"></span>'
     )
+
+
+@app.post("/api/reload-connections", response_class=HTMLResponse)
+async def reload_connections(request: Request) -> HTMLResponse:
+    """Reinitialise backends after connection settings change."""
+    await reload_backends()
+    return HTMLResponse("")

--- a/app/templates/admin.html
+++ b/app/templates/admin.html
@@ -50,60 +50,10 @@
       </div>
     </div>
 
-    <!-- Connection Status -->
+    <!-- Connection Settings -->
     <section class="mb-8">
-      <h2 class="text-base font-semibold text-slate-300 mb-3">Connection Settings</h2>
-      <div class="bg-slate-800/50 rounded-xl border border-slate-700 p-5 space-y-4">
-        <p class="text-xs text-slate-500">These are set via environment variables in your <code class="text-slate-300 bg-slate-700 px-1 rounded">docker-compose.yml</code>.</p>
-
-        <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
-          <!-- Portainer -->
-          <div class="space-y-2">
-            <p class="text-xs font-medium text-slate-400 uppercase tracking-wider">Portainer</p>
-            <div class="flex items-center gap-2 text-sm">
-              {% if conn.portainer_url %}
-              <span class="w-2 h-2 rounded-full bg-green-400 flex-shrink-0"></span>
-              <span class="text-slate-300 font-mono text-xs truncate">{{ conn.portainer_url }}</span>
-              {% else %}
-              <span class="w-2 h-2 rounded-full bg-slate-600 flex-shrink-0"></span>
-              <span class="text-slate-500 text-xs">PORTAINER_URL not set</span>
-              {% endif %}
-            </div>
-            <div class="flex items-center gap-2 text-sm">
-              {% if conn.portainer_key_set %}
-              <span class="w-2 h-2 rounded-full bg-green-400 flex-shrink-0"></span>
-              <span class="text-slate-300 text-xs">API key configured</span>
-              {% else %}
-              <span class="w-2 h-2 rounded-full bg-amber-500 flex-shrink-0"></span>
-              <span class="text-slate-400 text-xs">PORTAINER_API_KEY not set</span>
-              {% endif %}
-            </div>
-          </div>
-
-          <!-- DockerHub -->
-          <div class="space-y-2">
-            <p class="text-xs font-medium text-slate-400 uppercase tracking-wider">Docker Hub <span class="normal-case font-normal text-slate-500">(optional)</span></p>
-            <div class="flex items-center gap-2 text-sm">
-              {% if conn.dockerhub_user %}
-              <span class="w-2 h-2 rounded-full bg-green-400 flex-shrink-0"></span>
-              <span class="text-slate-300 text-xs">{{ conn.dockerhub_user }}</span>
-              {% else %}
-              <span class="w-2 h-2 rounded-full bg-slate-600 flex-shrink-0"></span>
-              <span class="text-slate-500 text-xs">DOCKERHUB_USERNAME not set</span>
-              {% endif %}
-            </div>
-            <div class="flex items-center gap-2 text-sm">
-              {% if conn.dockerhub_token_set %}
-              <span class="w-2 h-2 rounded-full bg-green-400 flex-shrink-0"></span>
-              <span class="text-slate-300 text-xs">Token configured</span>
-              {% else %}
-              <span class="w-2 h-2 rounded-full bg-slate-600 flex-shrink-0"></span>
-              <span class="text-slate-500 text-xs">DOCKERHUB_TOKEN not set</span>
-              {% endif %}
-            </div>
-          </div>
-        </div>
-      </div>
+      <h2 class="text-base font-semibold text-slate-300 mb-3">Connections</h2>
+      {% include "partials/admin_connections.html" %}
     </section>
 
     <!-- Hosts -->

--- a/app/templates/partials/admin_connections.html
+++ b/app/templates/partials/admin_connections.html
@@ -1,0 +1,233 @@
+<!-- =====================================================================
+     Portainer
+     ===================================================================== -->
+<div class="space-y-6" id="admin-connections">
+
+  <!-- Portainer card -->
+  <div class="bg-slate-800/50 rounded-xl border border-slate-700 overflow-hidden">
+
+    <!-- Card header -->
+    <div class="flex items-center justify-between px-5 py-4 border-b border-slate-700">
+      <div class="flex items-center gap-3">
+        <span class="text-base font-semibold text-white">Portainer</span>
+        <span class="text-xs text-slate-500">Docker management API</span>
+      </div>
+      {% if conn.portainer_url and conn.portainer_key_set %}
+        <span class="flex items-center gap-1.5 text-xs text-green-400 font-medium">
+          <span class="w-2 h-2 rounded-full bg-green-400"></span> Configured
+        </span>
+      {% else %}
+        <span class="flex items-center gap-1.5 text-xs text-slate-500">
+          <span class="w-2 h-2 rounded-full bg-slate-600"></span> Not set up
+        </span>
+      {% endif %}
+    </div>
+
+    <div class="px-5 py-4 space-y-5">
+
+      <!-- What is Portainer -->
+      <p class="text-sm text-slate-400">
+        Portainer is a web UI for managing Docker on your home servers.
+        This dashboard uses its API to detect when your container images have
+        updates available and to trigger redeployments.
+        <strong class="text-slate-300">You only need this if you run Docker containers.</strong>
+      </p>
+
+      {% if conn.portainer_env_only %}
+      <!-- Migration nudge -->
+      <div class="flex items-start gap-2 bg-amber-900/20 border border-amber-700/40 rounded-lg px-4 py-3">
+        <span class="text-amber-400 mt-0.5 flex-shrink-0">&#9888;</span>
+        <p class="text-xs text-amber-300">
+          Your Portainer credentials are currently set via environment variables in
+          <code class="bg-slate-800 px-1 rounded">docker-compose.yml</code>.
+          Save them here to manage everything through the UI instead.
+          The URL field will be pre-filled — you just need to paste your API token again.
+        </p>
+      </div>
+      {% endif %}
+
+      <!-- How to get values -->
+      <details class="group">
+        <summary class="cursor-pointer text-sm text-blue-400 hover:text-blue-300 transition-colors select-none list-none flex items-center gap-1">
+          <svg class="w-4 h-4 transition-transform group-open:rotate-90" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/>
+          </svg>
+          How to find these values in Portainer
+        </summary>
+        <ol class="mt-3 ml-5 space-y-1.5 text-sm text-slate-400 list-decimal">
+          <li>Open Portainer in your browser (usually <code class="bg-slate-700 px-1 rounded text-slate-300">https://your-server-ip:9443</code>)</li>
+          <li>Click your <strong class="text-slate-300">username</strong> in the top-right corner → <strong class="text-slate-300">Account Settings</strong></li>
+          <li>Scroll down to <strong class="text-slate-300">Access Tokens</strong> → click <strong class="text-slate-300">Add access token</strong></li>
+          <li>Give it a name like <code class="bg-slate-700 px-1 rounded text-slate-300">update-dashboard</code> and click Generate</li>
+          <li>Copy the token — <strong class="text-slate-300">you won't be able to see it again</strong></li>
+        </ol>
+      </details>
+
+      <!-- Form -->
+      <form class="space-y-4"
+        id="portainer-form"
+        hx-post="/admin/connections/portainer"
+        hx-target="#admin-connections"
+        hx-swap="outerHTML">
+
+        <!-- URL -->
+        <div>
+          <label class="block text-xs font-medium text-slate-400 mb-1">Portainer URL</label>
+          <input type="url" name="portainer_url"
+            value="{{ conn.portainer_url }}"
+            placeholder="https://192.168.x.x:9443"
+            class="w-full bg-slate-700 border border-slate-600 rounded-lg px-3 py-2 text-sm text-slate-200 font-mono focus:outline-none focus:border-blue-500 placeholder:text-slate-500">
+          <p class="text-xs text-slate-500 mt-1">Include <code class="bg-slate-700 px-1 rounded">https://</code> and the port number (usually 9443)</p>
+        </div>
+
+        <!-- API token -->
+        <div>
+          <label class="block text-xs font-medium text-slate-400 mb-1">
+            API Token
+            {% if conn.portainer_key_set %}<span class="text-green-400 font-normal ml-1">(saved — paste a new one to replace)</span>{% endif %}
+          </label>
+          <input type="password" name="portainer_api_key"
+            placeholder="{% if conn.portainer_key_set %}Leave blank to keep existing token{% else %}Paste token here{% endif %}"
+            class="w-full bg-slate-700 border border-slate-600 rounded-lg px-3 py-2 text-sm text-slate-200 font-mono focus:outline-none focus:border-blue-500 placeholder:text-slate-500">
+        </div>
+
+        <!-- SSL toggle -->
+        <div>
+          <label class="flex items-start gap-3 cursor-pointer select-none">
+            <input type="checkbox" name="portainer_verify_ssl" value="on"
+              {% if conn.portainer_verify_ssl %}checked{% endif %}
+              class="mt-0.5 w-4 h-4 rounded accent-blue-500 flex-shrink-0">
+            <div>
+              <span class="text-sm text-slate-300">Verify SSL certificate</span>
+              <p class="text-xs text-slate-500 mt-0.5">
+                Leave <strong>unchecked</strong> for most home setups — Portainer uses a self-signed
+                certificate by default, which browsers and tools flag as untrusted. This is normal
+                and safe on a private network.
+              </p>
+            </div>
+          </label>
+        </div>
+
+        <!-- Test result area -->
+        <div id="portainer-test-result" class="min-h-[1.5rem]">
+          {% if portainer_saved %}
+          <span class="text-green-400 text-sm">&#10003; Settings saved and connections reloaded.</span>
+          {% endif %}
+        </div>
+
+        <!-- Actions -->
+        <div class="flex items-center gap-3 pt-1">
+          <button type="button"
+            hx-post="/admin/connections/portainer/test"
+            hx-target="#portainer-test-result"
+            hx-swap="innerHTML"
+            hx-include="#portainer-form"
+            class="px-4 py-2 rounded-lg bg-slate-600 hover:bg-slate-500 text-sm font-medium text-slate-200 transition-colors">
+            Test Connection
+          </button>
+          <button type="submit"
+            class="px-4 py-2 rounded-lg bg-blue-600 hover:bg-blue-500 text-sm font-medium text-white transition-colors">
+            Save
+          </button>
+        </div>
+      </form>
+
+    </div>
+  </div>
+
+  <!-- ===================================================================
+       Docker Hub
+       =================================================================== -->
+  <div class="bg-slate-800/50 rounded-xl border border-slate-700 overflow-hidden">
+
+    <!-- Card header -->
+    <div class="flex items-center justify-between px-5 py-4 border-b border-slate-700">
+      <div class="flex items-center gap-3">
+        <span class="text-base font-semibold text-white">Docker Hub</span>
+        <span class="text-xs text-amber-400 bg-amber-900/30 px-2 py-0.5 rounded-full">Optional</span>
+      </div>
+      {% if conn.dockerhub_user and conn.dockerhub_token_set %}
+        <span class="flex items-center gap-1.5 text-xs text-green-400 font-medium">
+          <span class="w-2 h-2 rounded-full bg-green-400"></span> Configured
+        </span>
+      {% else %}
+        <span class="flex items-center gap-1.5 text-xs text-slate-500">
+          <span class="w-2 h-2 rounded-full bg-slate-600"></span> Not set up
+        </span>
+      {% endif %}
+    </div>
+
+    <div class="px-5 py-4 space-y-5">
+
+      <!-- What and why -->
+      <p class="text-sm text-slate-400">
+        When this dashboard checks if your container images have newer versions available,
+        it asks Docker Hub. Without an account, Docker Hub limits this to
+        <strong class="text-slate-300">100 checks per hour</strong> shared across everyone
+        on your IP address. With a free account you get
+        <strong class="text-slate-300">200 checks per hour</strong> just for you.
+        If you run more than a handful of containers, you'll want this set up.
+      </p>
+
+      <!-- How to get values -->
+      <details class="group">
+        <summary class="cursor-pointer text-sm text-blue-400 hover:text-blue-300 transition-colors select-none list-none flex items-center gap-1">
+          <svg class="w-4 h-4 transition-transform group-open:rotate-90" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/>
+          </svg>
+          How to create a Docker Hub access token
+        </summary>
+        <ol class="mt-3 ml-5 space-y-1.5 text-sm text-slate-400 list-decimal">
+          <li>Sign in at <strong class="text-slate-300">hub.docker.com</strong> (free account is enough)</li>
+          <li>Click your username (top-right) → <strong class="text-slate-300">Account Settings</strong></li>
+          <li>Go to <strong class="text-slate-300">Personal access tokens</strong> → <strong class="text-slate-300">Generate new token</strong></li>
+          <li>Give it a name like <code class="bg-slate-700 px-1 rounded text-slate-300">update-dashboard</code>, set access to <strong class="text-slate-300">Public Repo Read-only</strong></li>
+          <li>Copy the token — you won't see it again</li>
+        </ol>
+        <p class="mt-3 ml-5 text-xs text-amber-300">
+          Use an access token, not your Docker Hub password. Tokens are scoped and can be revoked individually if they ever leak.
+        </p>
+      </details>
+
+      <!-- Form -->
+      <form class="space-y-4"
+        hx-post="/admin/connections/dockerhub"
+        hx-target="#admin-connections"
+        hx-swap="outerHTML">
+
+        <!-- Username -->
+        <div>
+          <label class="block text-xs font-medium text-slate-400 mb-1">Docker Hub Username</label>
+          <input type="text" name="dockerhub_username"
+            value="{{ conn.dockerhub_user }}"
+            placeholder="your-dockerhub-username"
+            class="w-full bg-slate-700 border border-slate-600 rounded-lg px-3 py-2 text-sm text-slate-200 font-mono focus:outline-none focus:border-blue-500 placeholder:text-slate-500">
+        </div>
+
+        <!-- Token -->
+        <div>
+          <label class="block text-xs font-medium text-slate-400 mb-1">
+            Access Token
+            {% if conn.dockerhub_token_set %}<span class="text-green-400 font-normal ml-1">(saved — paste a new one to replace)</span>{% endif %}
+          </label>
+          <input type="password" name="dockerhub_token"
+            placeholder="{% if conn.dockerhub_token_set %}Leave blank to keep existing token{% else %}Paste access token here{% endif %}"
+            class="w-full bg-slate-700 border border-slate-600 rounded-lg px-3 py-2 text-sm text-slate-200 font-mono focus:outline-none focus:border-blue-500 placeholder:text-slate-500">
+        </div>
+
+        {% if dockerhub_saved %}
+        <p class="text-green-400 text-sm">&#10003; Settings saved and connections reloaded.</p>
+        {% endif %}
+
+        <div class="pt-1">
+          <button type="submit"
+            class="px-4 py-2 rounded-lg bg-blue-600 hover:bg-blue-500 text-sm font-medium text-white transition-colors">
+            Save
+          </button>
+        </div>
+      </form>
+
+    </div>
+  </div>
+
+</div>


### PR DESCRIPTION
## Summary

- **Portainer and DockerHub credentials** are now fully manageable through the Admin UI — no more editing `docker-compose.yml` or env vars
- **Test-then-save flow** for Portainer: test the connection with your entered values before committing, with plain-English error hints
- **Newbie-friendly UX**: each card explains what the integration is for, why you need it, and includes expandable step-by-step instructions to find the required values
- **Live reload**: saving credentials reinitialises the backends immediately — no container restart needed
- **Env var fallback preserved**: existing deployments continue to work unchanged; a migration nudge appears if values are still env-var-only

## Implementation notes

- Non-sensitive values (URL, username) stored in `config.yml`
- Secrets (API key, token) stored in the existing Fernet-encrypted credential store
- Extracted backend init into `backend_loader.py` to avoid circular imports between `main.py` and `admin.py`

## Test plan

- [ ] Open Admin → verify Portainer and DockerHub cards show current status
- [ ] Enter a wrong Portainer URL → Test → verify "can't reach" error message
- [ ] Enter a wrong API token → Test → verify "invalid token" message
- [ ] Enter correct values → Test → verify "Connected — N environments found"
- [ ] Click Save → verify "Settings saved" confirmation and dashboard Docker check still works
- [ ] Enter DockerHub credentials → Save → verify configured status
- [ ] Verify existing env-var-configured deployment shows migration nudge
- [ ] Verify removing URL clears the Portainer backend without restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)