### PR TITLE
Refactor setup wizard into 8-screen onboarding flow

### DIFF
--- a/app/auth_router.py
+++ b/app/auth_router.py
@@ -1,12 +1,17 @@
+import re
 import time
 from collections import defaultdict
+from zoneinfo import available_timezones
 
+import httpx
+import pyotp
 from fastapi import APIRouter, Form, Request
 from fastapi.responses import HTMLResponse, RedirectResponse
 
 from .auth import (
     admin_exists,
     create_admin,
+    enroll_mfa,
     get_totp_uri,
     mfa_enrolled,
     new_totp_secret,
@@ -18,11 +23,23 @@ from .config_manager import (
     add_host,
     delete_host,
     get_available_ssh_keys,
+    get_homeassistant_config,
     get_hosts,
+    get_opnsense_config,
+    get_pbs_config,
+    get_pfsense_config,
     get_portainer_config,
+    get_proxmox_config,
     get_ssh_config,
+    get_timezone,
     save_dockerhub_config,
+    save_homeassistant_config,
+    save_opnsense_config,
+    save_pbs_config,
+    save_pfsense_config,
     save_portainer_config,
+    save_proxmox_config,
+    save_timezone,
 )
 from .credentials import (
     delete_credentials,
@@ -30,12 +47,22 @@ from .credentials import (
     save_credentials,
     save_integration_credentials,
 )
+from .proxmox_client import ProxmoxClient
 from .ssh_client import detect_docker_stacks, verify_connection
 from .backend_loader import reload_backends
 from .templates_env import make_templates
 
 router = APIRouter()
 templates = make_templates()
+
+
+def _timezone_groups() -> list[tuple[str, list[str]]]:
+    groups: dict[str, list[str]] = {}
+    for zone in sorted(available_timezones()):
+        region = zone.split("/")[0]
+        groups.setdefault(region, []).append(zone)
+    return sorted(groups.items())
+
 
 # ---------------------------------------------------------------------------
 # Rate limiting (in-memory, resets on container restart)
@@ -70,36 +97,52 @@ def _client_ip(request: Request) -> str:
 
 
 # ---------------------------------------------------------------------------
-# Setup
+# Setup — screen 1: welcome + timezone
 # ---------------------------------------------------------------------------
 
 @router.get("/setup", response_class=HTMLResponse)
-async def setup_page(request: Request) -> HTMLResponse:
+async def setup_welcome(request: Request) -> HTMLResponse:
     if admin_exists():
-        return RedirectResponse("/", status_code=302)
-    # Generate a fresh TOTP secret each time the page loads
-    secret = new_totp_secret()
-    request.session["setup_totp_secret"] = secret
-    return templates.TemplateResponse("setup.html", {
+        return RedirectResponse("/login", status_code=302)
+    return templates.TemplateResponse("setup_welcome.html", {
         "request": request,
-        "totp_uri": get_totp_uri(secret),
-        "totp_secret": secret,
+        "timezone_groups": _timezone_groups(),
+        "current_tz": get_timezone(),
     })
 
 
 @router.post("/setup", response_class=HTMLResponse)
-async def setup_submit(
+async def setup_welcome_submit(
+    request: Request,
+    timezone: str = Form("UTC"),
+) -> HTMLResponse:
+    if admin_exists():
+        return RedirectResponse("/login", status_code=302)
+    save_timezone(timezone)
+    return RedirectResponse("/setup/account", status_code=303)
+
+
+# ---------------------------------------------------------------------------
+# Setup — screen 2: account credentials
+# ---------------------------------------------------------------------------
+
+@router.get("/setup/account", response_class=HTMLResponse)
+async def setup_account(request: Request) -> HTMLResponse:
+    if admin_exists():
+        return RedirectResponse("/login", status_code=302)
+    return templates.TemplateResponse("setup_account.html", {"request": request})
+
+
+@router.post("/setup/account", response_class=HTMLResponse)
+async def setup_account_submit(
     request: Request,
     username: str = Form(""),
     password: str = Form(""),
     password_confirm: str = Form(""),
-    totp_code: str = Form(""),
-    enable_mfa: str = Form(""),
 ) -> HTMLResponse:
     if admin_exists():
-        return RedirectResponse("/", status_code=302)
+        return RedirectResponse("/login", status_code=302)
 
-    import re
     errors: list[str] = []
     username = username.strip()
 
@@ -113,52 +156,404 @@ async def setup_submit(
     if password != password_confirm:
         errors.append("Passwords do not match.")
 
-    totp_secret = None
-    if enable_mfa == "on":
-        session_secret = request.session.get("setup_totp_secret", "")
-        if not session_secret:
-            errors.append("Session expired — please refresh and try again.")
-        else:
-            import pyotp
-            if not pyotp.TOTP(session_secret).verify(totp_code.strip(), valid_window=1):
-                errors.append("Authenticator code is incorrect. Make sure your phone's time is synced and try again.")
-            else:
-                totp_secret = session_secret
-
     if errors:
-        secret = request.session.get("setup_totp_secret", new_totp_secret())
-        request.session["setup_totp_secret"] = secret
-        return templates.TemplateResponse("setup.html", {
+        return templates.TemplateResponse("setup_account.html", {
             "request": request,
-            "totp_uri": get_totp_uri(secret),
-            "totp_secret": secret,
             "errors": errors,
-            "enable_mfa_checked": enable_mfa == "on",
             "username_value": username,
         })
 
-    backup_key = create_admin(username=username, password=password, totp_secret=totp_secret)
-    request.session.pop("setup_totp_secret", None)
+    backup_key = create_admin(username=username, password=password, totp_secret=None)
+    request.session["setup_account_done"] = True
     request.session["setup_backup_key"] = backup_key
+    return RedirectResponse("/setup/security", status_code=303)
 
-    return RedirectResponse("/setup/backup-key", status_code=303)
+
+# ---------------------------------------------------------------------------
+# Setup — screen 3: two-factor authentication
+# ---------------------------------------------------------------------------
+
+@router.get("/setup/security", response_class=HTMLResponse)
+async def setup_security(request: Request) -> HTMLResponse:
+    if not request.session.get("setup_account_done"):
+        return RedirectResponse("/login", status_code=302)
+    secret = new_totp_secret()
+    request.session["setup_totp_secret"] = secret
+    return templates.TemplateResponse("setup_security.html", {
+        "request": request,
+        "totp_uri": get_totp_uri(secret),
+        "totp_secret": secret,
+    })
 
 
-@router.get("/setup/backup-key", response_class=HTMLResponse)
-async def setup_backup_key(request: Request) -> HTMLResponse:
+@router.post("/setup/security", response_class=HTMLResponse)
+async def setup_security_submit(
+    request: Request,
+    enable_mfa: str = Form(""),
+    totp_code: str = Form(""),
+) -> HTMLResponse:
+    if not request.session.get("setup_account_done"):
+        return RedirectResponse("/login", status_code=302)
+
+    if enable_mfa == "on":
+        session_secret = request.session.get("setup_totp_secret", "")
+        if not session_secret or not pyotp.TOTP(session_secret).verify(totp_code.strip(), valid_window=1):
+            secret = session_secret or new_totp_secret()
+            request.session["setup_totp_secret"] = secret
+            return templates.TemplateResponse("setup_security.html", {
+                "request": request,
+                "totp_uri": get_totp_uri(secret),
+                "totp_secret": secret,
+                "errors": ["Authenticator code is incorrect. Make sure your phone's time is synced and try again."],
+                "enable_mfa_checked": True,
+            })
+        enroll_mfa(session_secret)
+        request.session.pop("setup_totp_secret", None)
+
+    return RedirectResponse("/setup/recovery-code", status_code=303)
+
+
+# ---------------------------------------------------------------------------
+# Setup — screen 4: recovery code
+# ---------------------------------------------------------------------------
+
+@router.get("/setup/recovery-code", response_class=HTMLResponse)
+async def setup_recovery_code(request: Request) -> HTMLResponse:
     backup_key = request.session.get("setup_backup_key")
     if not backup_key:
         return RedirectResponse("/login", status_code=302)
-    return templates.TemplateResponse("setup_backup_key.html", {
+    return templates.TemplateResponse("setup_recovery.html", {
         "request": request,
         "backup_key": backup_key,
     })
 
 
-@router.post("/setup/backup-key/confirm", response_class=HTMLResponse)
-async def setup_backup_key_confirm(request: Request) -> HTMLResponse:
+@router.post("/setup/recovery-code/confirm", response_class=HTMLResponse)
+async def setup_recovery_code_confirm(request: Request) -> HTMLResponse:
     request.session.pop("setup_backup_key", None)
-    return RedirectResponse("/setup/hosts", status_code=303)
+    request.session.pop("setup_account_done", None)
+    return RedirectResponse("/setup/connect", status_code=303)
+
+
+# ---------------------------------------------------------------------------
+# Setup — screen 5: connect integrations
+# ---------------------------------------------------------------------------
+
+@router.get("/setup/connect", response_class=HTMLResponse)
+async def setup_connect(request: Request) -> HTMLResponse:
+    if not admin_exists():
+        return RedirectResponse("/setup", status_code=302)
+
+    px_cfg = get_proxmox_config()
+    px_creds = get_integration_credentials("proxmox")
+    pbs_cfg = get_pbs_config()
+    pbs_creds = get_integration_credentials("proxmox_backup")
+    opn_cfg = get_opnsense_config()
+    opn_creds = get_integration_credentials("opnsense")
+    pf_cfg = get_pfsense_config()
+    pf_creds = get_integration_credentials("pfsense")
+    ha_cfg = get_homeassistant_config()
+    ha_creds = get_integration_credentials("homeassistant")
+    port_cfg = get_portainer_config()
+    port_creds = get_integration_credentials("portainer")
+    dh_cfg = get_integration_credentials("dockerhub")
+
+    return templates.TemplateResponse("setup_connect.html", {
+        "request": request,
+        "proxmox_url": px_cfg.get("url", ""),
+        "proxmox_connected": bool(px_cfg.get("url") and px_creds.get("api_token")),
+        "pbs_url": pbs_cfg.get("url", ""),
+        "pbs_connected": bool(pbs_cfg.get("url") and pbs_creds.get("api_token")),
+        "opnsense_url": opn_cfg.get("url", ""),
+        "opnsense_connected": bool(opn_cfg.get("url") and opn_creds.get("api_key")),
+        "pfsense_url": pf_cfg.get("url", ""),
+        "pfsense_connected": bool(pf_cfg.get("url") and pf_creds.get("api_key")),
+        "homeassistant_url": ha_cfg.get("url", ""),
+        "homeassistant_connected": bool(ha_cfg.get("url") and ha_creds.get("token")),
+        "portainer_url": port_cfg.get("url", ""),
+        "portainer_connected": bool(port_cfg.get("url") and port_creds.get("api_key")),
+        "dockerhub_connected": bool(dh_cfg.get("token")),
+    })
+
+
+# --- Proxmox ---
+
+@router.post("/setup/connect/proxmox/test", response_class=HTMLResponse)
+async def setup_test_proxmox(
+    request: Request,
+    proxmox_url: str = Form(""),
+    proxmox_api_token: str = Form(""),
+    proxmox_verify_ssl: str = Form(""),
+) -> HTMLResponse:
+    url = proxmox_url.strip().rstrip("/")
+    token = proxmox_api_token.strip()
+    verify_ssl = proxmox_verify_ssl == "on"
+    if not url or not token:
+        return HTMLResponse('<span class="text-amber-400 text-sm">Enter a URL and API token first.</span>')
+    try:
+        client = ProxmoxClient(url=url, api_token=token, verify_ssl=verify_ssl)
+        version = await client.get_version()
+        ver = version.get("version", "")
+        return HTMLResponse(
+            f'<span class="text-green-400 text-sm">&#10003; Connected — Proxmox VE {ver}. Click Save to continue.</span>'
+        )
+    except Exception as exc:
+        msg = str(exc)
+        if "401" in msg or "403" in msg:
+            hint = "Invalid API token."
+        elif "connect" in msg.lower() or "Name or service" in msg:
+            hint = "Can&#39;t reach that address — check the URL."
+        elif "SSL" in msg or "certificate" in msg.lower():
+            hint = "SSL error — try disabling SSL verification."
+        else:
+            hint = msg[:120]
+        return HTMLResponse(f'<span class="text-red-400 text-sm">&#10007; {hint}</span>')
+
+
+@router.post("/setup/connect/proxmox/save", response_class=HTMLResponse)
+async def setup_save_proxmox(
+    request: Request,
+    proxmox_url: str = Form(""),
+    proxmox_api_token: str = Form(""),
+    proxmox_verify_ssl: str = Form(""),
+) -> HTMLResponse:
+    url = proxmox_url.strip().rstrip("/")
+    token = proxmox_api_token.strip()
+    verify_ssl = proxmox_verify_ssl == "on"
+    save_proxmox_config(url=url, verify_ssl=verify_ssl)
+    if token:
+        save_integration_credentials("proxmox", api_token=token)
+    return templates.TemplateResponse("partials/setup_proxmox_section.html", {
+        "request": request,
+        "proxmox_url": url,
+        "proxmox_connected": True,
+        "proxmox_saved": True,
+    })
+
+
+@router.post("/setup/connect/proxmox/discover", response_class=HTMLResponse)
+async def setup_proxmox_discover(request: Request) -> HTMLResponse:
+    cfg = get_proxmox_config()
+    creds = get_integration_credentials("proxmox")
+    url = cfg.get("url", "")
+    token = creds.get("api_token", "")
+    verify_ssl = cfg.get("verify_ssl", False)
+    if not url or not token:
+        return HTMLResponse('<p class="text-sm text-red-400">Proxmox not configured.</p>')
+    try:
+        client = ProxmoxClient(url=url, api_token=token, verify_ssl=verify_ssl)
+        resources = await client.discover_resources()
+        return templates.TemplateResponse("partials/setup_proxmox_section.html", {
+            "request": request,
+            "proxmox_url": url,
+            "proxmox_connected": True,
+            "proxmox_resources": resources,
+        })
+    except Exception as exc:
+        return HTMLResponse(f'<p class="text-sm text-red-400">Discovery failed: {exc}</p>')
+
+
+@router.post("/setup/connect/proxmox/select-hosts", response_class=HTMLResponse)
+async def setup_proxmox_select_hosts(request: Request) -> HTMLResponse:
+    form = await request.form()
+    selected = form.getlist("selected_hosts")  # list of "node:vmid:name:type" strings
+    pending = []
+    for entry in selected:
+        parts = entry.split(":", 3)
+        if len(parts) == 4:
+            pending.append({"node": parts[0], "vmid": parts[1], "name": parts[3], "type": parts[2]})
+    request.session["setup_proxmox_pending"] = pending
+    count = len(pending)
+    label = f"{count} host{'s' if count != 1 else ''}"
+    return HTMLResponse(
+        f'<p class="text-sm text-green-400">&#10003; {label} queued for SSH setup in the next step.</p>'
+    )
+
+
+# --- Proxmox Backup Server ---
+
+@router.post("/setup/connect/pbs/test", response_class=HTMLResponse)
+async def setup_test_pbs(
+    request: Request,
+    pbs_url: str = Form(""),
+    pbs_api_token: str = Form(""),
+    pbs_verify_ssl: str = Form(""),
+) -> HTMLResponse:
+    url = pbs_url.strip().rstrip("/")
+    token = pbs_api_token.strip()
+    verify_ssl = pbs_verify_ssl == "on"
+    if not url or not token:
+        return HTMLResponse('<span class="text-amber-400 text-sm">Enter a URL and API token first.</span>')
+    try:
+        async with httpx.AsyncClient(verify=verify_ssl, timeout=10) as c:
+            resp = await c.get(
+                f"{url}/api2/json/version",
+                headers={"Authorization": f"PBSAPIToken={token}"},
+            )
+            resp.raise_for_status()
+            ver = resp.json().get("data", {}).get("version", "")
+        return HTMLResponse(
+            f'<span class="text-green-400 text-sm">&#10003; Connected — Proxmox Backup Server {ver}. Click Save to continue.</span>'
+        )
+    except Exception as exc:
+        msg = str(exc)
+        hint = "Invalid API token." if ("401" in msg or "403" in msg) else msg[:120]
+        return HTMLResponse(f'<span class="text-red-400 text-sm">&#10007; {hint}</span>')
+
+
+@router.post("/setup/connect/pbs/save", response_class=HTMLResponse)
+async def setup_save_pbs(
+    request: Request,
+    pbs_url: str = Form(""),
+    pbs_api_token: str = Form(""),
+    pbs_verify_ssl: str = Form(""),
+) -> HTMLResponse:
+    url = pbs_url.strip().rstrip("/")
+    token = pbs_api_token.strip()
+    verify_ssl = pbs_verify_ssl == "on"
+    save_pbs_config(url=url, verify_ssl=verify_ssl)
+    if token:
+        save_integration_credentials("proxmox_backup", api_token=token)
+    return HTMLResponse('<p class="text-sm text-green-400">&#10003; Proxmox Backup Server saved.</p>')
+
+
+# --- OPNsense ---
+
+@router.post("/setup/connect/opnsense/test", response_class=HTMLResponse)
+async def setup_test_opnsense(
+    request: Request,
+    opnsense_url: str = Form(""),
+    opnsense_api_key: str = Form(""),
+    opnsense_api_secret: str = Form(""),
+    opnsense_verify_ssl: str = Form(""),
+) -> HTMLResponse:
+    url = opnsense_url.strip().rstrip("/")
+    key = opnsense_api_key.strip()
+    secret = opnsense_api_secret.strip()
+    verify_ssl = opnsense_verify_ssl == "on"
+    if not url or not key or not secret:
+        return HTMLResponse('<span class="text-amber-400 text-sm">Enter URL, API key, and API secret first.</span>')
+    try:
+        async with httpx.AsyncClient(verify=verify_ssl, timeout=10) as c:
+            resp = await c.get(
+                f"{url}/api/core/firmware/info",
+                auth=(key, secret),
+            )
+            resp.raise_for_status()
+        return HTMLResponse('<span class="text-green-400 text-sm">&#10003; Connected. Click Save to continue.</span>')
+    except Exception as exc:
+        msg = str(exc)
+        hint = "Invalid API key or secret." if ("401" in msg or "403" in msg) else msg[:120]
+        return HTMLResponse(f'<span class="text-red-400 text-sm">&#10007; {hint}</span>')
+
+
+@router.post("/setup/connect/opnsense/save", response_class=HTMLResponse)
+async def setup_save_opnsense(
+    request: Request,
+    opnsense_url: str = Form(""),
+    opnsense_api_key: str = Form(""),
+    opnsense_api_secret: str = Form(""),
+    opnsense_verify_ssl: str = Form(""),
+) -> HTMLResponse:
+    url = opnsense_url.strip().rstrip("/")
+    key = opnsense_api_key.strip()
+    secret = opnsense_api_secret.strip()
+    verify_ssl = opnsense_verify_ssl == "on"
+    save_opnsense_config(url=url, verify_ssl=verify_ssl)
+    if key and secret:
+        save_integration_credentials("opnsense", api_key=key, api_secret=secret)
+    return HTMLResponse('<p class="text-sm text-green-400">&#10003; OPNsense saved.</p>')
+
+
+# --- pfSense ---
+
+@router.post("/setup/connect/pfsense/test", response_class=HTMLResponse)
+async def setup_test_pfsense(
+    request: Request,
+    pfsense_url: str = Form(""),
+    pfsense_api_key: str = Form(""),
+    pfsense_verify_ssl: str = Form(""),
+) -> HTMLResponse:
+    url = pfsense_url.strip().rstrip("/")
+    key = pfsense_api_key.strip()
+    verify_ssl = pfsense_verify_ssl == "on"
+    if not url or not key:
+        return HTMLResponse('<span class="text-amber-400 text-sm">Enter a URL and API key first.</span>')
+    try:
+        async with httpx.AsyncClient(verify=verify_ssl, timeout=10) as c:
+            resp = await c.get(
+                f"{url}/api/v1/system/version",
+                headers={"Authorization": key},
+            )
+            resp.raise_for_status()
+        return HTMLResponse('<span class="text-green-400 text-sm">&#10003; Connected. Click Save to continue.</span>')
+    except Exception as exc:
+        msg = str(exc)
+        hint = "Invalid API key." if ("401" in msg or "403" in msg) else msg[:120]
+        return HTMLResponse(f'<span class="text-red-400 text-sm">&#10007; {hint}</span>')
+
+
+@router.post("/setup/connect/pfsense/save", response_class=HTMLResponse)
+async def setup_save_pfsense(
+    request: Request,
+    pfsense_url: str = Form(""),
+    pfsense_api_key: str = Form(""),
+    pfsense_verify_ssl: str = Form(""),
+) -> HTMLResponse:
+    url = pfsense_url.strip().rstrip("/")
+    key = pfsense_api_key.strip()
+    verify_ssl = pfsense_verify_ssl == "on"
+    save_pfsense_config(url=url, verify_ssl=verify_ssl)
+    if key:
+        save_integration_credentials("pfsense", api_key=key)
+    return HTMLResponse('<p class="text-sm text-green-400">&#10003; pfSense saved.</p>')
+
+
+# --- Home Assistant ---
+
+@router.post("/setup/connect/homeassistant/test", response_class=HTMLResponse)
+async def setup_test_homeassistant(
+    request: Request,
+    ha_url: str = Form(""),
+    ha_token: str = Form(""),
+) -> HTMLResponse:
+    url = ha_url.strip().rstrip("/")
+    token = ha_token.strip()
+    if not url or not token:
+        return HTMLResponse('<span class="text-amber-400 text-sm">Enter a URL and access token first.</span>')
+    try:
+        async with httpx.AsyncClient(verify=False, timeout=10) as c:
+            resp = await c.get(
+                f"{url}/api/",
+                headers={"Authorization": f"Bearer {token}"},
+            )
+            resp.raise_for_status()
+            ver = resp.json().get("version", "")
+        msg = f"Connected — Home Assistant {ver}." if ver else "Connected."
+        return HTMLResponse(
+            f'<span class="text-green-400 text-sm">&#10003; {msg} Click Save to continue.</span>'
+        )
+    except Exception as exc:
+        msg = str(exc)
+        hint = "Invalid access token." if ("401" in msg or "403" in msg) else msg[:120]
+        return HTMLResponse(f'<span class="text-red-400 text-sm">&#10007; {hint}</span>')
+
+
+@router.post("/setup/connect/homeassistant/save", response_class=HTMLResponse)
+async def setup_save_homeassistant(
+    request: Request,
+    ha_url: str = Form(""),
+    ha_token: str = Form(""),
+) -> HTMLResponse:
+    url = ha_url.strip().rstrip("/")
+    token = ha_token.strip()
+    save_homeassistant_config(url=url)
+    if token:
+        save_integration_credentials("homeassistant", token=token)
+    return HTMLResponse(
+        '<p class="text-sm text-green-400">&#10003; Home Assistant saved. '
+        '<span class="text-slate-400">Note: Keepup can alert you to updates but cannot install them automatically.</span></p>'
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/app/config_manager.py
+++ b/app/config_manager.py
@@ -184,6 +184,71 @@ def save_dockerhub_config(username: str) -> None:
     save_config(config)
 
 
+def get_proxmox_config() -> dict:
+    return load_config().get("proxmox", {})
+
+
+def save_proxmox_config(url: str, verify_ssl: bool) -> None:
+    config = load_config()
+    if url:
+        config["proxmox"] = {"url": url.rstrip("/"), "verify_ssl": verify_ssl}
+    else:
+        config.pop("proxmox", None)
+    save_config(config)
+
+
+def get_pbs_config() -> dict:
+    return load_config().get("proxmox_backup", {})
+
+
+def save_pbs_config(url: str, verify_ssl: bool) -> None:
+    config = load_config()
+    if url:
+        config["proxmox_backup"] = {"url": url.rstrip("/"), "verify_ssl": verify_ssl}
+    else:
+        config.pop("proxmox_backup", None)
+    save_config(config)
+
+
+def get_opnsense_config() -> dict:
+    return load_config().get("opnsense", {})
+
+
+def save_opnsense_config(url: str, verify_ssl: bool) -> None:
+    config = load_config()
+    if url:
+        config["opnsense"] = {"url": url.rstrip("/"), "verify_ssl": verify_ssl}
+    else:
+        config.pop("opnsense", None)
+    save_config(config)
+
+
+def get_pfsense_config() -> dict:
+    return load_config().get("pfsense", {})
+
+
+def save_pfsense_config(url: str, verify_ssl: bool) -> None:
+    config = load_config()
+    if url:
+        config["pfsense"] = {"url": url.rstrip("/"), "verify_ssl": verify_ssl}
+    else:
+        config.pop("pfsense", None)
+    save_config(config)
+
+
+def get_homeassistant_config() -> dict:
+    return load_config().get("homeassistant", {})
+
+
+def save_homeassistant_config(url: str) -> None:
+    config = load_config()
+    if url:
+        config["homeassistant"] = {"url": url.rstrip("/")}
+    else:
+        config.pop("homeassistant", None)
+    save_config(config)
+
+
 # ---------------------------------------------------------------------------
 # Auto-update settings
 # ---------------------------------------------------------------------------
@@ -241,7 +306,8 @@ def get_available_ssh_keys() -> list[str]:
 def reset_config() -> None:
     """Remove all user-configured data (factory reset). Preserves the config file itself."""
     config = load_config()
-    for key in ("hosts", "portainer", "dockerhub", "stack_auto_update"):
+    for key in ("hosts", "portainer", "dockerhub", "stack_auto_update",
+                "proxmox", "proxmox_backup", "opnsense", "pfsense", "homeassistant"):
         config.pop(key, None)
     save_config(config)
 

--- a/app/main.py
+++ b/app/main.py
@@ -27,8 +27,7 @@ from .templates_env import make_templates
 # Auth middleware
 # ---------------------------------------------------------------------------
 
-_PUBLIC_PATHS = {"/", "/login", "/logout", "/setup", "/setup/backup-key",
-                 "/setup/backup-key/confirm", "/forgot-password",
+_PUBLIC_PATHS = {"/", "/login", "/logout", "/setup", "/forgot-password",
                  "/forgot-password/reset"}
 
 

--- a/app/proxmox_client.py
+++ b/app/proxmox_client.py
@@ -1,0 +1,70 @@
+"""
+Proxmox VE API client.
+
+Used during setup to verify credentials and discover VMs and LXC containers.
+API token format: user@realm!tokenname=uuid-value
+"""
+import httpx
+
+
+class ProxmoxClient:
+    def __init__(self, url: str, api_token: str, verify_ssl: bool = False):
+        self.base = url.rstrip("/")
+        self.headers = {"Authorization": f"PVEAPIToken={api_token}"}
+        self.verify_ssl = verify_ssl
+
+    def _client(self) -> httpx.AsyncClient:
+        return httpx.AsyncClient(
+            base_url=self.base,
+            headers=self.headers,
+            verify=self.verify_ssl,
+            timeout=15,
+        )
+
+    async def get_version(self) -> dict:
+        async with self._client() as c:
+            resp = await c.get("/api2/json/version")
+            resp.raise_for_status()
+            return resp.json()["data"]
+
+    async def discover_resources(self) -> list[dict]:
+        """Return all VMs and LXC containers across all nodes, sorted by node + vmid."""
+        async with self._client() as c:
+            nodes_resp = await c.get("/api2/json/nodes")
+            nodes_resp.raise_for_status()
+            nodes = nodes_resp.json()["data"]
+
+            resources: list[dict] = []
+
+            for node in nodes:
+                node_name = node["node"]
+
+                try:
+                    r = await c.get(f"/api2/json/nodes/{node_name}/qemu")
+                    r.raise_for_status()
+                    for vm in r.json()["data"]:
+                        resources.append({
+                            "type": "vm",
+                            "node": node_name,
+                            "vmid": vm["vmid"],
+                            "name": vm.get("name", f"vm-{vm['vmid']}"),
+                            "status": vm.get("status", "unknown"),
+                        })
+                except Exception:
+                    pass
+
+                try:
+                    r = await c.get(f"/api2/json/nodes/{node_name}/lxc")
+                    r.raise_for_status()
+                    for ct in r.json()["data"]:
+                        resources.append({
+                            "type": "lxc",
+                            "node": node_name,
+                            "vmid": ct["vmid"],
+                            "name": ct.get("name", f"ct-{ct['vmid']}"),
+                            "status": ct.get("status", "unknown"),
+                        })
+                except Exception:
+                    pass
+
+        return sorted(resources, key=lambda r: (r["node"], r["vmid"]))

--- a/app/templates/partials/setup_proxmox_section.html
+++ b/app/templates/partials/setup_proxmox_section.html
@@ -1,0 +1,122 @@
+<div id="proxmox-section" class="bg-slate-800/60 border border-slate-700 rounded-2xl overflow-hidden">
+  <div class="flex items-center justify-between px-5 py-4 border-b border-slate-700">
+    <div>
+      <h2 class="text-sm font-semibold text-slate-200">Proxmox VE <span class="text-xs font-normal text-slate-500 ml-1">optional</span></h2>
+      <p class="text-xs text-slate-500 mt-0.5">Monitor VMs and LXC containers via the Proxmox API.</p>
+    </div>
+    {% if proxmox_connected %}
+    <span class="flex items-center gap-1.5 text-xs text-green-400 font-medium flex-shrink-0 ml-4">
+      <span class="w-2 h-2 rounded-full bg-green-400"></span> Connected
+    </span>
+    {% endif %}
+  </div>
+
+  <div class="px-5 py-4 space-y-3">
+
+    {% if proxmox_saved %}
+    <p class="text-sm text-green-400">&#10003; Proxmox saved.</p>
+    {% endif %}
+
+    {% if proxmox_resources is defined %}
+
+      <!-- Discovered VMs/LXCs -->
+      {% if proxmox_resources %}
+      <form hx-post="/setup/connect/proxmox/select-hosts"
+            hx-target="#proxmox-select-result"
+            class="space-y-3">
+        <p class="text-xs text-slate-400">
+          Select which VMs and containers you want to configure SSH connections for. These will be set up in the next step.
+        </p>
+        <div class="space-y-1.5 max-h-64 overflow-y-auto pr-1">
+          {% for r in proxmox_resources %}
+          <label class="flex items-center gap-3 px-3 py-2 rounded-lg bg-slate-700/50 cursor-pointer hover:bg-slate-700 transition-colors">
+            <input type="checkbox" name="selected_hosts"
+              value="{{ r.node }}:{{ r.vmid }}:{{ r.type }}:{{ r.name }}"
+              class="w-4 h-4 rounded accent-blue-500 flex-shrink-0">
+            <div class="min-w-0">
+              <span class="text-sm text-slate-200 font-medium">{{ r.name }}</span>
+              <span class="text-xs text-slate-500 ml-2">{{ r.type | upper }} {{ r.vmid }} · {{ r.node }}</span>
+            </div>
+            <span class="ml-auto text-xs px-2 py-0.5 rounded-full flex-shrink-0
+              {% if r.status == 'running' %}bg-green-900/40 text-green-400
+              {% else %}bg-slate-700 text-slate-400{% endif %}">
+              {{ r.status }}
+            </span>
+          </label>
+          {% endfor %}
+        </div>
+        <div class="flex gap-2 items-center flex-wrap">
+          <button type="submit"
+            class="px-4 py-2 rounded-lg bg-blue-600 hover:bg-blue-500 text-sm font-medium text-white transition-colors">
+            Queue selected for SSH setup
+          </button>
+          <button type="button"
+            hx-post="/setup/connect/proxmox/select-hosts"
+            hx-target="#proxmox-select-result"
+            hx-vals='{"selected_hosts": ""}'
+            class="px-4 py-2 rounded-lg bg-slate-700 hover:bg-slate-600 text-sm font-medium text-slate-300 transition-colors">
+            Skip SSH setup
+          </button>
+        </div>
+      </form>
+      <div id="proxmox-select-result"></div>
+      {% else %}
+      <p class="text-xs text-slate-500 italic">No VMs or LXC containers found.</p>
+      {% endif %}
+
+    {% elif proxmox_connected %}
+
+      <!-- Connected state: offer discovery -->
+      <p class="text-xs text-slate-400">
+        Credentials saved. Discover VMs and LXC containers to optionally set up SSH monitoring for them.
+      </p>
+      <button
+        hx-post="/setup/connect/proxmox/discover"
+        hx-target="#proxmox-section"
+        hx-swap="outerHTML"
+        class="px-4 py-2 rounded-lg bg-slate-600 hover:bg-slate-500 text-sm font-medium text-slate-200 transition-colors">
+        Discover VMs &amp; LXCs
+      </button>
+
+    {% else %}
+
+      <!-- Initial form -->
+      <div id="proxmox-test-result"></div>
+      <div>
+        <label class="block text-xs font-medium text-slate-400 mb-1">Proxmox URL</label>
+        <input type="url" name="proxmox_url" value="{{ proxmox_url or '' }}"
+          placeholder="https://192.168.1.10:8006"
+          class="w-full bg-slate-700 border border-slate-600 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:border-blue-500 placeholder:text-slate-500">
+      </div>
+      <div>
+        <label class="block text-xs font-medium text-slate-400 mb-1">API token</label>
+        <input type="password" name="proxmox_api_token" placeholder="user@pam!tokenname=uuid"
+          class="w-full bg-slate-700 border border-slate-600 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:border-blue-500 placeholder:text-slate-500">
+        <p class="text-xs text-slate-500 mt-1">In Proxmox: Datacenter → Permissions → API Tokens.</p>
+      </div>
+      <label class="flex items-center gap-2 cursor-pointer select-none">
+        <input type="checkbox" name="proxmox_verify_ssl" value="on" class="w-4 h-4 rounded accent-blue-500">
+        <span class="text-sm text-slate-300">Verify SSL certificate</span>
+      </label>
+      <div class="flex gap-2 items-center flex-wrap">
+        <button
+          hx-post="/setup/connect/proxmox/test"
+          hx-include="[name='proxmox_url'],[name='proxmox_api_token'],[name='proxmox_verify_ssl']"
+          hx-target="#proxmox-test-result"
+          class="px-4 py-2 rounded-lg bg-slate-600 hover:bg-slate-500 text-sm font-medium text-slate-200 transition-colors">
+          Test connection
+        </button>
+        <button
+          hx-post="/setup/connect/proxmox/save"
+          hx-include="[name='proxmox_url'],[name='proxmox_api_token'],[name='proxmox_verify_ssl']"
+          hx-target="#proxmox-section"
+          hx-swap="outerHTML"
+          class="px-4 py-2 rounded-lg bg-blue-600 hover:bg-blue-500 text-sm font-medium text-white transition-colors">
+          Save
+        </button>
+      </div>
+
+    {% endif %}
+
+  </div>
+</div>

--- a/app/templates/setup_account.html
+++ b/app/templates/setup_account.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html lang="en" class="h-full">
+<head>
+  <meta charset="UTF-8" />
+  <link rel="icon" type="image/svg+xml" href="/static/favicon.svg" />
+  <link rel="apple-touch-icon" href="/static/icon-192.svg" />
+  <link rel="manifest" href="/static/manifest.json" />
+  <meta name="theme-color" content="#0d1117" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Create your account — Keepup</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <style>body { background-color: #0d1117; }</style>
+</head>
+<body class="min-h-full text-slate-200 font-sans flex items-center justify-center px-4 py-12">
+
+  <div class="w-full max-w-lg">
+
+    <!-- Header -->
+    <div class="text-center mb-6">
+      <img src="/static/logo.svg" alt="Keepup" class="w-16 h-16 mx-auto mb-4 rounded-2xl" />
+      <h1 class="text-2xl font-bold text-white">Create your account</h1>
+      <p class="text-sm text-slate-400 mt-1">This will be the only admin account for Keepup.</p>
+    </div>
+
+    <!-- Progress -->
+    <div class="mb-8">
+      <div class="flex justify-between items-center mb-2">
+        <span class="text-xs font-medium text-slate-300">Account</span>
+        <span class="text-xs text-slate-500">Step 2 of 8</span>
+      </div>
+      <div class="w-full bg-slate-700 rounded-full h-0.5">
+        <div class="bg-blue-600 h-0.5 rounded-full" style="width: 25%"></div>
+      </div>
+    </div>
+
+    {% if errors %}
+    <div class="mb-6 px-4 py-3 rounded-lg bg-red-900/30 border border-red-700/50 text-sm text-red-300 space-y-1">
+      {% for e in errors %}<p>{{ e }}</p>{% endfor %}
+    </div>
+    {% endif %}
+
+    <form method="post" action="/setup/account" class="space-y-5">
+      <div class="bg-slate-800/60 border border-slate-700 rounded-2xl p-5 space-y-4">
+
+        <div>
+          <label class="block text-xs font-medium text-slate-400 mb-1">Username</label>
+          <input type="text" name="username" value="{{ username_value or '' }}" required autofocus
+            autocomplete="username" placeholder="admin"
+            class="w-full bg-slate-700 border border-slate-600 rounded-lg px-3 py-2.5 text-sm text-slate-200 focus:outline-none focus:border-blue-500 placeholder:text-slate-500">
+          <p class="text-xs text-slate-500 mt-1">Letters, numbers, hyphens, and underscores only.</p>
+        </div>
+
+        <div>
+          <label class="block text-xs font-medium text-slate-400 mb-1">Password</label>
+          <input type="password" name="password" required minlength="8"
+            autocomplete="new-password"
+            class="w-full bg-slate-700 border border-slate-600 rounded-lg px-3 py-2.5 text-sm text-slate-200 focus:outline-none focus:border-blue-500">
+          <p class="text-xs text-slate-500 mt-1">At least 8 characters.</p>
+        </div>
+
+        <div>
+          <label class="block text-xs font-medium text-slate-400 mb-1">Confirm password</label>
+          <input type="password" name="password_confirm" required
+            autocomplete="new-password"
+            class="w-full bg-slate-700 border border-slate-600 rounded-lg px-3 py-2.5 text-sm text-slate-200 focus:outline-none focus:border-blue-500">
+        </div>
+
+      </div>
+
+      <button type="submit"
+        class="w-full py-3 rounded-xl bg-blue-600 hover:bg-blue-500 text-sm font-semibold text-white transition-colors">
+        Continue →
+      </button>
+    </form>
+
+  </div>
+
+</body>
+</html>

--- a/app/templates/setup_connect.html
+++ b/app/templates/setup_connect.html
@@ -1,0 +1,303 @@
+<!DOCTYPE html>
+<html lang="en" class="h-full">
+<head>
+  <meta charset="UTF-8" />
+  <link rel="icon" type="image/svg+xml" href="/static/favicon.svg" />
+  <link rel="apple-touch-icon" href="/static/icon-192.svg" />
+  <link rel="manifest" href="/static/manifest.json" />
+  <meta name="theme-color" content="#0d1117" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Connect your infrastructure — Keepup</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script src="https://unpkg.com/htmx.org@1.9.10"></script>
+  <style>body { background-color: #0d1117; }</style>
+</head>
+<body class="min-h-full text-slate-200 font-sans px-4 py-12">
+
+  <div class="w-full max-w-2xl mx-auto">
+
+    <!-- Header -->
+    <div class="text-center mb-6">
+      <img src="/static/logo.svg" alt="Keepup" class="w-16 h-16 mx-auto mb-4 rounded-2xl" />
+      <h1 class="text-2xl font-bold text-white">Connect your infrastructure</h1>
+      <p class="text-sm text-slate-400 mt-1">Add integrations to monitor. All are optional — configure them later in Admin.</p>
+    </div>
+
+    <!-- Progress -->
+    <div class="mb-8">
+      <div class="flex justify-between items-center mb-2">
+        <span class="text-xs font-medium text-slate-300">Integrations</span>
+        <span class="text-xs text-slate-500">Step 5 of 8</span>
+      </div>
+      <div class="w-full bg-slate-700 rounded-full h-0.5">
+        <div class="bg-blue-600 h-0.5 rounded-full" style="width: 62%"></div>
+      </div>
+    </div>
+
+    <div class="space-y-4">
+
+      <!-- Proxmox VE -->
+      <div id="proxmox-section">
+        {% include 'partials/setup_proxmox_section.html' %}
+      </div>
+
+      <!-- Proxmox Backup Server -->
+      <div class="bg-slate-800/60 border border-slate-700 rounded-2xl overflow-hidden">
+        <div class="flex items-center justify-between px-5 py-4 border-b border-slate-700">
+          <div>
+            <h2 class="text-sm font-semibold text-slate-200">Proxmox Backup Server <span class="text-xs font-normal text-slate-500 ml-1">optional</span></h2>
+            <p class="text-xs text-slate-500 mt-0.5">Monitor backup jobs and PBS version updates.</p>
+          </div>
+          {% if pbs_connected %}
+          <span class="flex items-center gap-1.5 text-xs text-green-400 font-medium flex-shrink-0 ml-4">
+            <span class="w-2 h-2 rounded-full bg-green-400"></span> Connected
+          </span>
+          {% endif %}
+        </div>
+        <div class="px-5 py-4 space-y-3">
+          <div id="pbs-result"></div>
+          <div>
+            <label class="block text-xs font-medium text-slate-400 mb-1">PBS URL</label>
+            <input type="url" id="pbs-url" name="pbs_url" value="{{ pbs_url or '' }}"
+              placeholder="https://192.168.1.11:8007"
+              class="w-full bg-slate-700 border border-slate-600 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:border-blue-500 placeholder:text-slate-500">
+          </div>
+          <div>
+            <label class="block text-xs font-medium text-slate-400 mb-1">API token</label>
+            <input type="password" id="pbs-token" name="pbs_api_token" placeholder="user@pbs!tokenname=uuid"
+              class="w-full bg-slate-700 border border-slate-600 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:border-blue-500 placeholder:text-slate-500">
+            <p class="text-xs text-slate-500 mt-1">In PBS: Configuration → Access Control → API Tokens.</p>
+          </div>
+          <label class="flex items-center gap-2 cursor-pointer select-none">
+            <input type="checkbox" id="pbs-ssl" name="pbs_verify_ssl" value="on" class="w-4 h-4 rounded accent-blue-500">
+            <span class="text-sm text-slate-300">Verify SSL certificate</span>
+          </label>
+          <div id="pbs-test-result"></div>
+          <div class="flex gap-2 items-center flex-wrap">
+            <button
+              hx-post="/setup/connect/pbs/test"
+              hx-include="#pbs-url,#pbs-token,#pbs-ssl"
+              hx-target="#pbs-test-result"
+              class="px-4 py-2 rounded-lg bg-slate-600 hover:bg-slate-500 text-sm font-medium text-slate-200 transition-colors">
+              Test connection
+            </button>
+            <button
+              hx-post="/setup/connect/pbs/save"
+              hx-include="#pbs-url,#pbs-token,#pbs-ssl"
+              hx-target="#pbs-result"
+              class="px-4 py-2 rounded-lg bg-blue-600 hover:bg-blue-500 text-sm font-medium text-white transition-colors">
+              Save
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <!-- OPNsense -->
+      <div class="bg-slate-800/60 border border-slate-700 rounded-2xl overflow-hidden">
+        <div class="flex items-center justify-between px-5 py-4 border-b border-slate-700">
+          <div>
+            <h2 class="text-sm font-semibold text-slate-200">OPNsense <span class="text-xs font-normal text-slate-500 ml-1">optional</span></h2>
+            <p class="text-xs text-slate-500 mt-0.5">Monitor firmware and package updates on your OPNsense firewall.</p>
+          </div>
+          {% if opnsense_connected %}
+          <span class="flex items-center gap-1.5 text-xs text-green-400 font-medium flex-shrink-0 ml-4">
+            <span class="w-2 h-2 rounded-full bg-green-400"></span> Connected
+          </span>
+          {% endif %}
+        </div>
+        <div class="px-5 py-4 space-y-3">
+          <div id="opnsense-result"></div>
+          <div>
+            <label class="block text-xs font-medium text-slate-400 mb-1">OPNsense URL</label>
+            <input type="url" id="opn-url" name="opnsense_url" value="{{ opnsense_url or '' }}"
+              placeholder="https://192.168.1.1"
+              class="w-full bg-slate-700 border border-slate-600 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:border-blue-500 placeholder:text-slate-500">
+          </div>
+          <div class="grid grid-cols-2 gap-3">
+            <div>
+              <label class="block text-xs font-medium text-slate-400 mb-1">API key</label>
+              <input type="text" id="opn-key" name="opnsense_api_key" placeholder="key"
+                class="w-full bg-slate-700 border border-slate-600 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:border-blue-500 placeholder:text-slate-500">
+            </div>
+            <div>
+              <label class="block text-xs font-medium text-slate-400 mb-1">API secret</label>
+              <input type="password" id="opn-secret" name="opnsense_api_secret" placeholder="secret"
+                class="w-full bg-slate-700 border border-slate-600 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:border-blue-500 placeholder:text-slate-500">
+            </div>
+          </div>
+          <p class="text-xs text-slate-500">In OPNsense: System → Access → Users → your user → API keys.</p>
+          <label class="flex items-center gap-2 cursor-pointer select-none">
+            <input type="checkbox" id="opn-ssl" name="opnsense_verify_ssl" value="on" class="w-4 h-4 rounded accent-blue-500">
+            <span class="text-sm text-slate-300">Verify SSL certificate</span>
+          </label>
+          <div id="opnsense-test-result"></div>
+          <div class="flex gap-2 items-center flex-wrap">
+            <button
+              hx-post="/setup/connect/opnsense/test"
+              hx-include="#opn-url,#opn-key,#opn-secret,#opn-ssl"
+              hx-target="#opnsense-test-result"
+              class="px-4 py-2 rounded-lg bg-slate-600 hover:bg-slate-500 text-sm font-medium text-slate-200 transition-colors">
+              Test connection
+            </button>
+            <button
+              hx-post="/setup/connect/opnsense/save"
+              hx-include="#opn-url,#opn-key,#opn-secret,#opn-ssl"
+              hx-target="#opnsense-result"
+              class="px-4 py-2 rounded-lg bg-blue-600 hover:bg-blue-500 text-sm font-medium text-white transition-colors">
+              Save
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <!-- pfSense -->
+      <div class="bg-slate-800/60 border border-slate-700 rounded-2xl overflow-hidden">
+        <div class="flex items-center justify-between px-5 py-4 border-b border-slate-700">
+          <div>
+            <h2 class="text-sm font-semibold text-slate-200">pfSense <span class="text-xs font-normal text-slate-500 ml-1">optional</span></h2>
+            <p class="text-xs text-slate-500 mt-0.5">Monitor firmware updates on your pfSense firewall. Requires pfSense 2.7+ or the pfSense API package.</p>
+          </div>
+          {% if pfsense_connected %}
+          <span class="flex items-center gap-1.5 text-xs text-green-400 font-medium flex-shrink-0 ml-4">
+            <span class="w-2 h-2 rounded-full bg-green-400"></span> Connected
+          </span>
+          {% endif %}
+        </div>
+        <div class="px-5 py-4 space-y-3">
+          <div id="pfsense-result"></div>
+          <div>
+            <label class="block text-xs font-medium text-slate-400 mb-1">pfSense URL</label>
+            <input type="url" id="pf-url" name="pfsense_url" value="{{ pfsense_url or '' }}"
+              placeholder="https://192.168.1.1"
+              class="w-full bg-slate-700 border border-slate-600 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:border-blue-500 placeholder:text-slate-500">
+          </div>
+          <div>
+            <label class="block text-xs font-medium text-slate-400 mb-1">API key</label>
+            <input type="password" id="pf-key" name="pfsense_api_key" placeholder="API key"
+              class="w-full bg-slate-700 border border-slate-600 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:border-blue-500 placeholder:text-slate-500">
+          </div>
+          <label class="flex items-center gap-2 cursor-pointer select-none">
+            <input type="checkbox" id="pf-ssl" name="pfsense_verify_ssl" value="on" class="w-4 h-4 rounded accent-blue-500">
+            <span class="text-sm text-slate-300">Verify SSL certificate</span>
+          </label>
+          <div id="pfsense-test-result"></div>
+          <div class="flex gap-2 items-center flex-wrap">
+            <button
+              hx-post="/setup/connect/pfsense/test"
+              hx-include="#pf-url,#pf-key,#pf-ssl"
+              hx-target="#pfsense-test-result"
+              class="px-4 py-2 rounded-lg bg-slate-600 hover:bg-slate-500 text-sm font-medium text-slate-200 transition-colors">
+              Test connection
+            </button>
+            <button
+              hx-post="/setup/connect/pfsense/save"
+              hx-include="#pf-url,#pf-key,#pf-ssl"
+              hx-target="#pfsense-result"
+              class="px-4 py-2 rounded-lg bg-blue-600 hover:bg-blue-500 text-sm font-medium text-white transition-colors">
+              Save
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <!-- Portainer -->
+      <div id="portainer-section">
+        {% include 'partials/setup_portainer_section.html' %}
+      </div>
+
+      <!-- Home Assistant -->
+      <div class="bg-slate-800/60 border border-slate-700 rounded-2xl overflow-hidden">
+        <div class="flex items-center justify-between px-5 py-4 border-b border-slate-700">
+          <div>
+            <h2 class="text-sm font-semibold text-slate-200">Home Assistant <span class="text-xs font-normal text-slate-500 ml-1">optional</span></h2>
+            <p class="text-xs text-slate-500 mt-0.5">Get notified when a Home Assistant update is available. Keepup cannot install HA updates automatically.</p>
+          </div>
+          {% if homeassistant_connected %}
+          <span class="flex items-center gap-1.5 text-xs text-green-400 font-medium flex-shrink-0 ml-4">
+            <span class="w-2 h-2 rounded-full bg-green-400"></span> Connected
+          </span>
+          {% endif %}
+        </div>
+        <div class="px-5 py-4 space-y-3">
+          <div id="ha-result"></div>
+          <div>
+            <label class="block text-xs font-medium text-slate-400 mb-1">Home Assistant URL</label>
+            <input type="url" id="ha-url" name="ha_url" value="{{ homeassistant_url or '' }}"
+              placeholder="http://homeassistant.local:8123"
+              class="w-full bg-slate-700 border border-slate-600 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:border-blue-500 placeholder:text-slate-500">
+          </div>
+          <div>
+            <label class="block text-xs font-medium text-slate-400 mb-1">Long-lived access token</label>
+            <input type="password" id="ha-token" name="ha_token" placeholder="eyJ…"
+              class="w-full bg-slate-700 border border-slate-600 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:border-blue-500 placeholder:text-slate-500">
+            <p class="text-xs text-slate-500 mt-1">In Home Assistant: Profile → Long-lived access tokens → Create token.</p>
+          </div>
+          <div id="ha-test-result"></div>
+          <div class="flex gap-2 items-center flex-wrap">
+            <button
+              hx-post="/setup/connect/homeassistant/test"
+              hx-include="#ha-url,#ha-token"
+              hx-target="#ha-test-result"
+              class="px-4 py-2 rounded-lg bg-slate-600 hover:bg-slate-500 text-sm font-medium text-slate-200 transition-colors">
+              Test connection
+            </button>
+            <button
+              hx-post="/setup/connect/homeassistant/save"
+              hx-include="#ha-url,#ha-token"
+              hx-target="#ha-result"
+              class="px-4 py-2 rounded-lg bg-blue-600 hover:bg-blue-500 text-sm font-medium text-white transition-colors">
+              Save
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <!-- DockerHub -->
+      <div class="bg-slate-800/60 border border-slate-700 rounded-2xl overflow-hidden">
+        <div class="flex items-center justify-between px-5 py-4 border-b border-slate-700">
+          <div>
+            <h2 class="text-sm font-semibold text-slate-200">Docker Hub <span class="text-xs font-normal text-slate-500 ml-1">optional</span></h2>
+            <p class="text-xs text-slate-500 mt-0.5">Authenticate to avoid rate limits and check private image updates.</p>
+          </div>
+          {% if dockerhub_connected %}
+          <span class="flex items-center gap-1.5 text-xs text-green-400 font-medium flex-shrink-0 ml-4">
+            <span class="w-2 h-2 rounded-full bg-green-400"></span> Saved
+          </span>
+          {% endif %}
+        </div>
+        <div class="px-5 py-4 space-y-3">
+          <div id="dockerhub-result"></div>
+          <form hx-post="/setup/dockerhub/save" hx-target="#dockerhub-result" class="space-y-3">
+            <div>
+              <label class="block text-xs font-medium text-slate-400 mb-1">Docker Hub username</label>
+              <input type="text" name="dockerhub_username" placeholder="myusername"
+                class="w-full bg-slate-700 border border-slate-600 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:border-blue-500 placeholder:text-slate-500">
+            </div>
+            <div>
+              <label class="block text-xs font-medium text-slate-400 mb-1">Access token</label>
+              <input type="password" name="dockerhub_token" placeholder="dckr_pat_…"
+                class="w-full bg-slate-700 border border-slate-600 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:border-blue-500 placeholder:text-slate-500">
+              <p class="text-xs text-slate-500 mt-1">In Docker Hub: Account Settings → Security → New access token.</p>
+            </div>
+            <button type="submit"
+              class="px-4 py-2 rounded-lg bg-blue-600 hover:bg-blue-500 text-sm font-medium text-white transition-colors">
+              Save
+            </button>
+          </form>
+        </div>
+      </div>
+
+      <!-- Navigation -->
+      <div class="flex justify-between items-center pt-2">
+        <a href="/setup/hosts" class="text-sm text-slate-500 hover:text-slate-300">Skip — configure later</a>
+        <a href="/setup/hosts"
+          class="px-6 py-2.5 rounded-xl bg-blue-600 hover:bg-blue-500 text-sm font-semibold text-white transition-colors">
+          Continue to SSH setup →
+        </a>
+      </div>
+
+    </div>
+  </div>
+
+</body>
+</html>

--- a/app/templates/setup_recovery.html
+++ b/app/templates/setup_recovery.html
@@ -1,0 +1,114 @@
+<!DOCTYPE html>
+<html lang="en" class="h-full">
+<head>
+  <meta charset="UTF-8" />
+  <link rel="icon" type="image/svg+xml" href="/static/favicon.svg" />
+  <link rel="apple-touch-icon" href="/static/icon-192.svg" />
+  <link rel="manifest" href="/static/manifest.json" />
+  <meta name="theme-color" content="#0d1117" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Save your recovery code — Keepup</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <style>body { background-color: #0d1117; }</style>
+</head>
+<body class="min-h-full text-slate-200 font-sans flex items-center justify-center px-4 py-12">
+
+  <div class="w-full max-w-lg">
+
+    <!-- Header -->
+    <div class="text-center mb-6">
+      <img src="/static/logo.svg" alt="Keepup" class="w-16 h-16 mx-auto mb-4 rounded-2xl" />
+      <h1 class="text-2xl font-bold text-white">Save your recovery code</h1>
+      <p class="text-sm text-slate-400 mt-1">The only way back in if you forget your password or lose your authenticator.</p>
+    </div>
+
+    <!-- Progress -->
+    <div class="mb-8">
+      <div class="flex justify-between items-center mb-2">
+        <span class="text-xs font-medium text-slate-300">Recovery code</span>
+        <span class="text-xs text-slate-500">Step 4 of 8</span>
+      </div>
+      <div class="w-full bg-slate-700 rounded-full h-0.5">
+        <div class="bg-blue-600 h-0.5 rounded-full" style="width: 50%"></div>
+      </div>
+    </div>
+
+    <div class="bg-slate-800/60 border border-slate-700 rounded-2xl p-6 space-y-5">
+
+      <!-- Warning -->
+      <div class="flex items-start gap-3 bg-amber-900/20 border border-amber-700/40 rounded-xl px-4 py-3">
+        <span class="text-amber-400 flex-shrink-0 mt-0.5">&#9888;</span>
+        <p class="text-xs text-amber-300">
+          <strong>This code is shown once and cannot be recovered.</strong> Store it somewhere safe —
+          a password manager, printed sheet, or encrypted notes app. Use it to reset your password
+          or regain access if your authenticator is lost.
+        </p>
+      </div>
+
+      <!-- Key display -->
+      <div>
+        <p class="text-xs font-medium text-slate-400 mb-2">Your recovery code</p>
+        <div class="bg-slate-900 border border-slate-600 rounded-xl px-5 py-4 text-center">
+          <span id="recovery-code" class="text-lg font-mono font-bold text-slate-100 tracking-widest select-all">
+            {{ backup_key }}
+          </span>
+        </div>
+      </div>
+
+      <!-- Actions -->
+      <div class="flex gap-3">
+        <button type="button" onclick="copyCode()" id="copy-btn"
+          class="flex-1 py-2.5 rounded-lg bg-slate-700 hover:bg-slate-600 text-sm font-medium text-slate-200 transition-colors">
+          Copy
+        </button>
+        <button type="button" onclick="downloadCode()"
+          class="flex-1 py-2.5 rounded-lg bg-slate-700 hover:bg-slate-600 text-sm font-medium text-slate-200 transition-colors">
+          Download .txt
+        </button>
+      </div>
+
+      <!-- Confirmation -->
+      <form method="post" action="/setup/recovery-code/confirm">
+        <label class="flex items-start gap-3 cursor-pointer select-none mb-4">
+          <input type="checkbox" id="saved-checkbox" required
+            onchange="document.getElementById('confirm-btn').disabled = !this.checked"
+            class="mt-0.5 w-4 h-4 rounded accent-blue-500 flex-shrink-0">
+          <span class="text-sm text-slate-300">
+            I've saved my recovery code in a safe place and understand I'll need it to reset my
+            password or regain access if I lose my authenticator.
+          </span>
+        </label>
+        <button type="submit" id="confirm-btn" disabled
+          class="w-full py-3 rounded-xl bg-blue-600 hover:bg-blue-500 disabled:opacity-40 disabled:cursor-not-allowed text-sm font-semibold text-white transition-colors">
+          I've saved it — continue →
+        </button>
+      </form>
+
+    </div>
+  </div>
+
+  <script>
+    const code = {{ backup_key | tojson }};
+
+    function copyCode() {
+      navigator.clipboard.writeText(code).then(() => {
+        const btn = document.getElementById('copy-btn');
+        btn.textContent = 'Copied!';
+        setTimeout(() => { btn.textContent = 'Copy'; }, 2000);
+      });
+    }
+
+    function downloadCode() {
+      const blob = new Blob(
+        ['Keepup — Recovery Code\n\n' + code + '\n\nStore this somewhere safe. You need it to reset your password or regain access if your authenticator is lost.\n'],
+        { type: 'text/plain' }
+      );
+      const a = document.createElement('a');
+      a.href = URL.createObjectURL(blob);
+      a.download = 'keepup-recovery-code.txt';
+      a.click();
+    }
+  </script>
+
+</body>
+</html>

--- a/app/templates/setup_security.html
+++ b/app/templates/setup_security.html
@@ -1,0 +1,120 @@
+<!DOCTYPE html>
+<html lang="en" class="h-full">
+<head>
+  <meta charset="UTF-8" />
+  <link rel="icon" type="image/svg+xml" href="/static/favicon.svg" />
+  <link rel="apple-touch-icon" href="/static/icon-192.svg" />
+  <link rel="manifest" href="/static/manifest.json" />
+  <meta name="theme-color" content="#0d1117" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Secure your account — Keepup</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/qrcodejs/1.0.0/qrcode.min.js"></script>
+  <style>body { background-color: #0d1117; }</style>
+</head>
+<body class="min-h-full text-slate-200 font-sans flex items-center justify-center px-4 py-12">
+
+  <div class="w-full max-w-lg">
+
+    <!-- Header -->
+    <div class="text-center mb-6">
+      <img src="/static/logo.svg" alt="Keepup" class="w-16 h-16 mx-auto mb-4 rounded-2xl" />
+      <h1 class="text-2xl font-bold text-white">Secure your account</h1>
+      <p class="text-sm text-slate-400 mt-1">Two-factor authentication adds a second layer of protection.</p>
+    </div>
+
+    <!-- Progress -->
+    <div class="mb-8">
+      <div class="flex justify-between items-center mb-2">
+        <span class="text-xs font-medium text-slate-300">Two-factor authentication</span>
+        <span class="text-xs text-slate-500">Step 3 of 8</span>
+      </div>
+      <div class="w-full bg-slate-700 rounded-full h-0.5">
+        <div class="bg-blue-600 h-0.5 rounded-full" style="width: 37%"></div>
+      </div>
+    </div>
+
+    {% if errors %}
+    <div class="mb-6 px-4 py-3 rounded-lg bg-red-900/30 border border-red-700/50 text-sm text-red-300 space-y-1">
+      {% for e in errors %}<p>{{ e }}</p>{% endfor %}
+    </div>
+    {% endif %}
+
+    <form method="post" action="/setup/security" class="space-y-5">
+
+      <div class="bg-slate-800/60 border border-slate-700 rounded-2xl p-5 space-y-4">
+
+        <!-- Toggle -->
+        <div class="flex items-start justify-between">
+          <div>
+            <p class="text-sm font-semibold text-slate-200">Enable 2FA</p>
+            <p class="text-xs text-slate-500 mt-0.5">Optional — you can set this up later in Admin → Account.</p>
+          </div>
+          <label class="flex items-center gap-2 cursor-pointer select-none flex-shrink-0 ml-4">
+            <input type="checkbox" name="enable_mfa" value="on" id="mfa-toggle"
+              {% if enable_mfa_checked %}checked{% endif %}
+              onchange="toggleMfa(this.checked)"
+              class="w-4 h-4 rounded accent-blue-500">
+            <span class="text-sm text-slate-300">Enable</span>
+          </label>
+        </div>
+
+        <!-- 2FA setup (shown when enabled) -->
+        <div id="mfa-section" class="{% if not enable_mfa_checked %}hidden{% endif %} space-y-4 border-t border-slate-700 pt-4">
+
+          <div class="bg-slate-900/50 rounded-xl p-4 space-y-3">
+            <p class="text-xs text-slate-400">
+              Install <strong class="text-slate-300">Google Authenticator</strong>, <strong class="text-slate-300">Authy</strong>,
+              or any TOTP app on your phone, then scan the QR code below.
+            </p>
+
+            <div class="flex justify-center py-2">
+              <div id="qrcode" class="rounded-lg overflow-hidden"></div>
+            </div>
+
+            <p class="text-xs text-slate-500 text-center">Can't scan? Enter this code manually:</p>
+            <p class="text-xs font-mono text-slate-300 text-center tracking-widest bg-slate-800 rounded px-3 py-2 break-all">
+              {{ totp_secret }}
+            </p>
+          </div>
+
+          <div>
+            <label class="block text-xs font-medium text-slate-400 mb-1">
+              Enter the 6-digit code from your app to confirm
+            </label>
+            <input type="text" name="totp_code" inputmode="numeric" autocomplete="one-time-code"
+              maxlength="6" placeholder="000000"
+              class="w-full bg-slate-700 border border-slate-600 rounded-lg px-3 py-2.5 text-sm text-slate-200 font-mono tracking-widest text-center focus:outline-none focus:border-blue-500 placeholder:tracking-normal">
+          </div>
+        </div>
+
+      </div>
+
+      <button type="submit"
+        class="w-full py-3 rounded-xl bg-blue-600 hover:bg-blue-500 text-sm font-semibold text-white transition-colors">
+        Continue →
+      </button>
+
+    </form>
+  </div>
+
+  <script>
+    const totpUri = {{ totp_uri | tojson }};
+
+    function toggleMfa(enabled) {
+      document.getElementById('mfa-section').classList.toggle('hidden', !enabled);
+    }
+
+    window.addEventListener('load', function() {
+      new QRCode(document.getElementById('qrcode'), {
+        text: totpUri,
+        width: 180,
+        height: 180,
+        colorDark: '#1e293b',
+        colorLight: '#f8fafc',
+      });
+    });
+  </script>
+
+</body>
+</html>

--- a/app/templates/setup_welcome.html
+++ b/app/templates/setup_welcome.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="en" class="h-full">
+<head>
+  <meta charset="UTF-8" />
+  <link rel="icon" type="image/svg+xml" href="/static/favicon.svg" />
+  <link rel="apple-touch-icon" href="/static/icon-192.svg" />
+  <link rel="manifest" href="/static/manifest.json" />
+  <meta name="theme-color" content="#0d1117" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Welcome — Keepup</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <style>body { background-color: #0d1117; }</style>
+</head>
+<body class="min-h-full text-slate-200 font-sans flex items-center justify-center px-4 py-12">
+
+  <div class="w-full max-w-lg">
+
+    <!-- Header -->
+    <div class="text-center mb-6">
+      <img src="/static/logo.svg" alt="Keepup" class="w-16 h-16 mx-auto mb-4 rounded-2xl" />
+      <h1 class="text-2xl font-bold text-white">Welcome to Keepup</h1>
+      <p class="text-sm text-slate-400 mt-1 max-w-sm mx-auto">
+        Monitor updates across your self-hosted infrastructure — OS packages, containers,
+        and connected services — from a single dashboard.
+      </p>
+    </div>
+
+    <!-- Progress -->
+    <div class="mb-8">
+      <div class="flex justify-between items-center mb-2">
+        <span class="text-xs font-medium text-slate-300">Welcome</span>
+        <span class="text-xs text-slate-500">Step 1 of 8</span>
+      </div>
+      <div class="w-full bg-slate-700 rounded-full h-0.5">
+        <div class="bg-blue-600 h-0.5 rounded-full" style="width: 12%"></div>
+      </div>
+    </div>
+
+    <!-- Feature highlights -->
+    <div class="bg-slate-800/60 border border-slate-700 rounded-2xl p-5 mb-6 space-y-3">
+      <div class="flex items-start gap-3">
+        <div class="w-8 h-8 rounded-lg bg-blue-600/20 flex items-center justify-center flex-shrink-0 mt-0.5">
+          <svg class="w-4 h-4 text-blue-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 12h14M12 5l7 7-7 7"/>
+          </svg>
+        </div>
+        <div>
+          <p class="text-sm font-medium text-slate-200">OS package updates</p>
+          <p class="text-xs text-slate-500 mt-0.5">Track pending updates on your Linux servers via SSH.</p>
+        </div>
+      </div>
+      <div class="flex items-start gap-3">
+        <div class="w-8 h-8 rounded-lg bg-blue-600/20 flex items-center justify-center flex-shrink-0 mt-0.5">
+          <svg class="w-4 h-4 text-blue-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20 7l-8-4-8 4m16 0l-8 4m8-4v10l-8 4m0-10L4 7m8 4v10"/>
+          </svg>
+        </div>
+        <div>
+          <p class="text-sm font-medium text-slate-200">Container image updates</p>
+          <p class="text-xs text-slate-500 mt-0.5">Check Docker Compose stacks and Portainer environments for newer images.</p>
+        </div>
+      </div>
+      <div class="flex items-start gap-3">
+        <div class="w-8 h-8 rounded-lg bg-blue-600/20 flex items-center justify-center flex-shrink-0 mt-0.5">
+          <svg class="w-4 h-4 text-blue-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6 6 0 10-12 0v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9"/>
+          </svg>
+        </div>
+        <div>
+          <p class="text-sm font-medium text-slate-200">Notifications</p>
+          <p class="text-xs text-slate-500 mt-0.5">Get alerted when updates are available — no need to check manually.</p>
+        </div>
+      </div>
+    </div>
+
+    <!-- Timezone form -->
+    <form method="post" action="/setup" class="space-y-5">
+      <div class="bg-slate-800/60 border border-slate-700 rounded-2xl p-5">
+        <label class="block text-sm font-semibold text-slate-200 mb-1">Your timezone</label>
+        <p class="text-xs text-slate-500 mb-3">Used for scheduling and displaying update times correctly.</p>
+        <select name="timezone"
+          class="w-full bg-slate-700 border border-slate-600 rounded-lg px-3 py-2.5 text-sm text-slate-200 focus:outline-none focus:border-blue-500">
+          {% for region, zones in timezone_groups %}
+          <optgroup label="{{ region }}">
+            {% for zone in zones %}
+            <option value="{{ zone }}" {% if zone == current_tz %}selected{% endif %}>{{ zone }}</option>
+            {% endfor %}
+          </optgroup>
+          {% endfor %}
+        </select>
+      </div>
+
+      <button type="submit"
+        class="w-full py-3 rounded-xl bg-blue-600 hover:bg-blue-500 text-sm font-semibold text-white transition-colors">
+        Get started →
+      </button>
+    </form>
+
+  </div>
+
+</body>
+</html>

--- a/tests/test_auth_router.py
+++ b/tests/test_auth_router.py
@@ -20,7 +20,7 @@ def _create_admin(username="alice", password="password123"):
 
 
 # ---------------------------------------------------------------------------
-# GET /setup
+# GET /setup  (screen 1 — welcome + timezone)
 # ---------------------------------------------------------------------------
 
 def test_setup_page_no_admin_returns_200(auth_client):
@@ -28,30 +28,69 @@ def test_setup_page_no_admin_returns_200(auth_client):
     assert response.status_code == 200
 
 
-def test_setup_page_with_admin_redirects(auth_client, data_dir):
+def test_setup_page_with_admin_redirects_to_login(auth_client, data_dir):
     _create_admin()
     response = auth_client.get("/setup", follow_redirects=False)
     assert response.status_code == 302
-    assert response.headers["location"] == "/"
+    assert response.headers["location"] == "/login"
+
+
+def test_setup_welcome_shows_timezone_select(auth_client):
+    response = auth_client.get("/setup")
+    assert response.status_code == 200
+    assert 'name="timezone"' in response.text
 
 
 # ---------------------------------------------------------------------------
-# POST /setup
+# POST /setup  (saves timezone, redirects to account)
 # ---------------------------------------------------------------------------
 
-def test_setup_submit_valid_redirects_to_backup_key(auth_client):
-    response = auth_client.post("/setup", data={
+def test_setup_welcome_submit_redirects_to_account(auth_client):
+    response = auth_client.post("/setup", data={"timezone": "America/New_York"}, follow_redirects=False)
+    assert response.status_code == 303
+    assert response.headers["location"] == "/setup/account"
+
+
+def test_setup_welcome_submit_with_admin_redirects_to_login(auth_client, data_dir):
+    _create_admin()
+    response = auth_client.post("/setup", data={"timezone": "UTC"}, follow_redirects=False)
+    assert response.status_code == 302
+    assert response.headers["location"] == "/login"
+
+
+# ---------------------------------------------------------------------------
+# GET /setup/account  (screen 2 — credentials)
+# ---------------------------------------------------------------------------
+
+def test_setup_account_page_no_admin_returns_200(auth_client):
+    response = auth_client.get("/setup/account", follow_redirects=False)
+    assert response.status_code == 200
+
+
+def test_setup_account_page_with_admin_redirects_to_login(auth_client, data_dir):
+    _create_admin()
+    response = auth_client.get("/setup/account", follow_redirects=False)
+    assert response.status_code == 302
+    assert response.headers["location"] == "/login"
+
+
+# ---------------------------------------------------------------------------
+# POST /setup/account  (creates admin, redirects to security)
+# ---------------------------------------------------------------------------
+
+def test_setup_account_valid_redirects_to_security(auth_client):
+    response = auth_client.post("/setup/account", data={
         "username": "alice",
         "password": "password123",
         "password_confirm": "password123",
     }, follow_redirects=False)
     assert response.status_code == 303
-    assert "/setup/backup-key" in response.headers["location"]
+    assert "/setup/security" in response.headers["location"]
 
 
-def test_setup_submit_creates_admin(auth_client, data_dir):
+def test_setup_account_creates_admin(auth_client, data_dir):
     from app.auth import admin_exists
-    auth_client.post("/setup", data={
+    auth_client.post("/setup/account", data={
         "username": "alice",
         "password": "password123",
         "password_confirm": "password123",
@@ -59,9 +98,9 @@ def test_setup_submit_creates_admin(auth_client, data_dir):
     assert admin_exists() is True
 
 
-def test_setup_submit_stores_username(auth_client, data_dir):
+def test_setup_account_stores_username(auth_client, data_dir):
     from app.auth import get_admin_username
-    auth_client.post("/setup", data={
+    auth_client.post("/setup/account", data={
         "username": "alice",
         "password": "password123",
         "password_confirm": "password123",
@@ -69,8 +108,8 @@ def test_setup_submit_stores_username(auth_client, data_dir):
     assert get_admin_username() == "alice"
 
 
-def test_setup_submit_short_username_shows_error(auth_client):
-    response = auth_client.post("/setup", data={
+def test_setup_account_short_username_shows_error(auth_client):
+    response = auth_client.post("/setup/account", data={
         "username": "a",
         "password": "password123",
         "password_confirm": "password123",
@@ -79,8 +118,8 @@ def test_setup_submit_short_username_shows_error(auth_client):
     assert "at least 2" in response.text.lower()
 
 
-def test_setup_submit_invalid_username_chars_shows_error(auth_client):
-    response = auth_client.post("/setup", data={
+def test_setup_account_invalid_username_chars_shows_error(auth_client):
+    response = auth_client.post("/setup/account", data={
         "username": "alice@bad",
         "password": "password123",
         "password_confirm": "password123",
@@ -89,8 +128,8 @@ def test_setup_submit_invalid_username_chars_shows_error(auth_client):
     assert "letters" in response.text.lower() or "only contain" in response.text.lower()
 
 
-def test_setup_submit_short_password_shows_error(auth_client):
-    response = auth_client.post("/setup", data={
+def test_setup_account_short_password_shows_error(auth_client):
+    response = auth_client.post("/setup/account", data={
         "username": "alice",
         "password": "short",
         "password_confirm": "short",
@@ -99,8 +138,8 @@ def test_setup_submit_short_password_shows_error(auth_client):
     assert "8 characters" in response.text.lower()
 
 
-def test_setup_submit_mismatched_passwords_shows_error(auth_client):
-    response = auth_client.post("/setup", data={
+def test_setup_account_mismatched_passwords_shows_error(auth_client):
+    response = auth_client.post("/setup/account", data={
         "username": "alice",
         "password": "password123",
         "password_confirm": "different456",
@@ -109,14 +148,241 @@ def test_setup_submit_mismatched_passwords_shows_error(auth_client):
     assert "do not match" in response.text.lower()
 
 
-def test_setup_submit_preserves_username_on_error(auth_client):
-    response = auth_client.post("/setup", data={
+def test_setup_account_preserves_username_on_error(auth_client):
+    response = auth_client.post("/setup/account", data={
         "username": "alice",
         "password": "short",
         "password_confirm": "short",
     })
     assert response.status_code == 200
     assert "alice" in response.text
+
+
+def test_setup_account_with_admin_redirects_to_login(auth_client, data_dir):
+    _create_admin()
+    response = auth_client.post("/setup/account", data={
+        "username": "bob",
+        "password": "password123",
+        "password_confirm": "password123",
+    }, follow_redirects=False)
+    assert response.status_code == 302
+    assert response.headers["location"] == "/login"
+
+
+# ---------------------------------------------------------------------------
+# GET /setup/security  (screen 3 — 2FA)
+# ---------------------------------------------------------------------------
+
+def test_setup_security_without_session_flag_redirects(auth_client, data_dir):
+    _create_admin()
+    response = auth_client.get("/setup/security", follow_redirects=False)
+    assert response.status_code == 302
+    assert response.headers["location"] == "/login"
+
+
+def test_setup_security_with_session_flag_returns_200(auth_client):
+    auth_client.post("/setup/account", data={
+        "username": "alice",
+        "password": "password123",
+        "password_confirm": "password123",
+    }, follow_redirects=False)
+    response = auth_client.get("/setup/security", follow_redirects=False)
+    assert response.status_code == 200
+
+
+def test_setup_security_skip_mfa_redirects_to_recovery(auth_client):
+    auth_client.post("/setup/account", data={
+        "username": "alice",
+        "password": "password123",
+        "password_confirm": "password123",
+    }, follow_redirects=False)
+    response = auth_client.post("/setup/security", data={}, follow_redirects=False)
+    assert response.status_code == 303
+    assert "/setup/recovery-code" in response.headers["location"]
+
+
+def test_setup_security_wrong_totp_code_shows_error(auth_client):
+    auth_client.post("/setup/account", data={
+        "username": "alice",
+        "password": "password123",
+        "password_confirm": "password123",
+    }, follow_redirects=False)
+    response = auth_client.post("/setup/security", data={
+        "enable_mfa": "on",
+        "totp_code": "000000",
+    })
+    assert response.status_code == 200
+    assert "incorrect" in response.text.lower()
+
+
+# ---------------------------------------------------------------------------
+# GET /setup/recovery-code  (screen 4)
+# ---------------------------------------------------------------------------
+
+def test_setup_recovery_code_without_session_key_redirects(auth_client, data_dir):
+    _create_admin()
+    response = auth_client.get("/setup/recovery-code", follow_redirects=False)
+    assert response.status_code == 302
+    assert response.headers["location"] == "/login"
+
+
+def test_setup_recovery_code_with_session_key_returns_200(auth_client):
+    auth_client.post("/setup/account", data={
+        "username": "alice",
+        "password": "password123",
+        "password_confirm": "password123",
+    }, follow_redirects=False)
+    response = auth_client.get("/setup/recovery-code", follow_redirects=False)
+    assert response.status_code == 200
+    assert "recovery" in response.text.lower() or "backup" in response.text.lower()
+
+
+def test_setup_recovery_code_confirm_redirects_to_connect(auth_client):
+    auth_client.post("/setup/account", data={
+        "username": "alice",
+        "password": "password123",
+        "password_confirm": "password123",
+    }, follow_redirects=False)
+    response = auth_client.post("/setup/recovery-code/confirm", follow_redirects=False)
+    assert response.status_code == 303
+    assert "/setup/connect" in response.headers["location"]
+
+
+# ---------------------------------------------------------------------------
+# GET /setup/connect  (screen 5 — integrations)
+# ---------------------------------------------------------------------------
+
+def test_setup_connect_no_admin_redirects(auth_client):
+    response = auth_client.get("/setup/connect", follow_redirects=False)
+    assert response.status_code == 302
+
+
+def test_setup_connect_with_admin_returns_200(auth_client, data_dir):
+    _create_admin()
+    response = auth_client.get("/setup/connect", follow_redirects=False)
+    assert response.status_code == 200
+
+
+def test_setup_connect_shows_all_integrations(auth_client, data_dir):
+    _create_admin()
+    response = auth_client.get("/setup/connect")
+    assert response.status_code == 200
+    assert "Proxmox" in response.text
+    assert "OPNsense" in response.text
+    assert "Portainer" in response.text
+    assert "Home Assistant" in response.text
+
+
+# ---------------------------------------------------------------------------
+# POST /setup/connect/proxmox/test
+# ---------------------------------------------------------------------------
+
+def test_setup_proxmox_test_missing_fields(auth_client, data_dir):
+    _create_admin()
+    response = auth_client.post("/setup/connect/proxmox/test", data={
+        "proxmox_url": "",
+        "proxmox_api_token": "",
+    })
+    assert response.status_code == 200
+    assert "enter" in response.text.lower()
+
+
+def test_setup_proxmox_test_connection_failure(auth_client, data_dir):
+    _create_admin()
+    response = auth_client.post("/setup/connect/proxmox/test", data={
+        "proxmox_url": "https://192.0.2.1:8006",
+        "proxmox_api_token": "user@pam!token=uuid",
+    })
+    assert response.status_code == 200
+    assert "✗" in response.text or "&#10007;" in response.text or "error" in response.text.lower() or "can" in response.text.lower()
+
+
+# ---------------------------------------------------------------------------
+# POST /setup/connect/opnsense/test
+# ---------------------------------------------------------------------------
+
+def test_setup_opnsense_test_missing_fields(auth_client, data_dir):
+    _create_admin()
+    response = auth_client.post("/setup/connect/opnsense/test", data={
+        "opnsense_url": "",
+        "opnsense_api_key": "",
+        "opnsense_api_secret": "",
+    })
+    assert response.status_code == 200
+    assert "enter" in response.text.lower()
+
+
+# ---------------------------------------------------------------------------
+# POST /setup/connect/homeassistant/test
+# ---------------------------------------------------------------------------
+
+def test_setup_homeassistant_test_missing_fields(auth_client, data_dir):
+    _create_admin()
+    response = auth_client.post("/setup/connect/homeassistant/test", data={
+        "ha_url": "",
+        "ha_token": "",
+    })
+    assert response.status_code == 200
+    assert "enter" in response.text.lower()
+
+
+# ---------------------------------------------------------------------------
+# POST /setup/connect/{integration}/save
+# ---------------------------------------------------------------------------
+
+def test_setup_save_proxmox(auth_client, data_dir):
+    _create_admin()
+    response = auth_client.post("/setup/connect/proxmox/save", data={
+        "proxmox_url": "https://192.168.1.10:8006",
+        "proxmox_api_token": "user@pam!token=abc123",
+        "proxmox_verify_ssl": "",
+    })
+    assert response.status_code == 200
+    assert "saved" in response.text.lower() or "connected" in response.text.lower()
+
+
+def test_setup_save_opnsense(auth_client, data_dir):
+    _create_admin()
+    response = auth_client.post("/setup/connect/opnsense/save", data={
+        "opnsense_url": "https://192.168.1.1",
+        "opnsense_api_key": "mykey",
+        "opnsense_api_secret": "mysecret",
+        "opnsense_verify_ssl": "",
+    })
+    assert response.status_code == 200
+    assert "saved" in response.text.lower()
+
+
+def test_setup_save_homeassistant(auth_client, data_dir):
+    _create_admin()
+    response = auth_client.post("/setup/connect/homeassistant/save", data={
+        "ha_url": "http://homeassistant.local:8123",
+        "ha_token": "eyJtoken",
+    })
+    assert response.status_code == 200
+    assert "saved" in response.text.lower()
+
+
+def test_setup_save_pbs(auth_client, data_dir):
+    _create_admin()
+    response = auth_client.post("/setup/connect/pbs/save", data={
+        "pbs_url": "https://192.168.1.11:8007",
+        "pbs_api_token": "user@pbs!token=abc",
+        "pbs_verify_ssl": "",
+    })
+    assert response.status_code == 200
+    assert "saved" in response.text.lower()
+
+
+def test_setup_save_pfsense(auth_client, data_dir):
+    _create_admin()
+    response = auth_client.post("/setup/connect/pfsense/save", data={
+        "pfsense_url": "https://192.168.1.1",
+        "pfsense_api_key": "mykey",
+        "pfsense_verify_ssl": "",
+    })
+    assert response.status_code == 200
+    assert "saved" in response.text.lower()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_auth_router_extra.py
+++ b/tests/test_auth_router_extra.py
@@ -31,40 +31,38 @@ def test_logout_redirects_to_login(auth_client, data_dir):
 
 
 # ---------------------------------------------------------------------------
-# GET /setup/backup-key
+# GET /setup/recovery-code
 # ---------------------------------------------------------------------------
 
-def test_setup_backup_key_no_session_redirects(auth_client):
-    response = auth_client.get("/setup/backup-key", follow_redirects=False)
+def test_setup_recovery_code_no_session_redirects(auth_client):
+    response = auth_client.get("/setup/recovery-code", follow_redirects=False)
     assert response.status_code == 302
     assert "/login" in response.headers["location"]
 
 
-def test_setup_backup_key_with_session_shows_key(auth_client):
-    """After setup, user is redirected to backup-key page."""
-    response = auth_client.post("/setup", data={
-        "username": "testuser",
-        "password": "password123",
-        "password_confirm": "password123",
-    }, follow_redirects=True)
-    # Should end up on backup-key page
-    assert response.status_code == 200
-    assert "backup" in response.text.lower() or "key" in response.text.lower()
-
-
-# ---------------------------------------------------------------------------
-# POST /setup/backup-key/confirm
-# ---------------------------------------------------------------------------
-
-def test_setup_backup_key_confirm_redirects(auth_client):
-    # Set up session
-    auth_client.post("/setup", data={
+def test_setup_recovery_code_after_account_shows_key(auth_client):
+    """After account creation, recovery code page shows the key."""
+    auth_client.post("/setup/account", data={
         "username": "testuser",
         "password": "password123",
         "password_confirm": "password123",
     }, follow_redirects=False)
-    # Confirm backup key
-    response = auth_client.post("/setup/backup-key/confirm", follow_redirects=False)
+    response = auth_client.get("/setup/recovery-code")
+    assert response.status_code == 200
+    assert "recovery" in response.text.lower() or "key" in response.text.lower()
+
+
+# ---------------------------------------------------------------------------
+# POST /setup/recovery-code/confirm
+# ---------------------------------------------------------------------------
+
+def test_setup_recovery_code_confirm_redirects(auth_client):
+    auth_client.post("/setup/account", data={
+        "username": "testuser",
+        "password": "password123",
+        "password_confirm": "password123",
+    }, follow_redirects=False)
+    response = auth_client.post("/setup/recovery-code/confirm", follow_redirects=False)
     assert response.status_code == 303
 
 

--- a/tests/test_proxmox_client.py
+++ b/tests/test_proxmox_client.py
@@ -1,0 +1,157 @@
+"""Tests for ProxmoxClient — connection and discovery logic."""
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+import httpx
+
+
+@pytest.fixture
+def mock_client():
+    """Return a ProxmoxClient with httpx calls mocked."""
+    from app.proxmox_client import ProxmoxClient
+    return ProxmoxClient(url="https://192.168.1.10:8006", api_token="user@pam!token=abc", verify_ssl=False)
+
+
+def _make_response(data, status_code=200):
+    resp = MagicMock(spec=httpx.Response)
+    resp.status_code = status_code
+    resp.json.return_value = {"data": data}
+    resp.raise_for_status = MagicMock()
+    return resp
+
+
+@pytest.mark.asyncio
+async def test_get_version_returns_data(mock_client):
+    version_data = {"version": "8.1.4", "release": "8"}
+    with patch("httpx.AsyncClient.get", new_callable=AsyncMock) as mock_get:
+        mock_get.return_value = _make_response(version_data)
+        result = await mock_client.get_version()
+    assert result["version"] == "8.1.4"
+
+
+@pytest.mark.asyncio
+async def test_discover_resources_returns_vms_and_lxc(mock_client):
+    nodes = [{"node": "pve"}]
+    vms = [{"vmid": 100, "name": "ubuntu-vm", "status": "running"}]
+    containers = [{"vmid": 101, "name": "debian-ct", "status": "running"}]
+
+    responses = [
+        _make_response(nodes),
+        _make_response(vms),
+        _make_response(containers),
+    ]
+    call_count = 0
+
+    async def fake_get(path, **kwargs):
+        nonlocal call_count
+        resp = responses[call_count]
+        call_count += 1
+        return resp
+
+    with patch("httpx.AsyncClient.get", new_callable=AsyncMock, side_effect=fake_get):
+        result = await mock_client.discover_resources()
+
+    assert len(result) == 2
+    names = {r["name"] for r in result}
+    assert "ubuntu-vm" in names
+    assert "debian-ct" in names
+
+
+@pytest.mark.asyncio
+async def test_discover_resources_handles_vm_failure_gracefully(mock_client):
+    """If VM listing fails, LXC listing still works."""
+    nodes = [{"node": "pve"}]
+    containers = [{"vmid": 200, "name": "web-ct", "status": "stopped"}]
+
+    call_count = 0
+
+    async def fake_get(path, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            return _make_response(nodes)
+        elif call_count == 2:
+            raise httpx.ConnectError("timeout")
+        else:
+            return _make_response(containers)
+
+    with patch("httpx.AsyncClient.get", new_callable=AsyncMock, side_effect=fake_get):
+        result = await mock_client.discover_resources()
+
+    assert len(result) == 1
+    assert result[0]["name"] == "web-ct"
+    assert result[0]["type"] == "lxc"
+
+
+@pytest.mark.asyncio
+async def test_discover_resources_empty_node(mock_client):
+    """Handles a node with no VMs or LXCs."""
+    nodes = [{"node": "pve"}]
+
+    call_count = 0
+
+    async def fake_get(path, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            return _make_response(nodes)
+        return _make_response([])  # empty VMs and LXCs
+
+    with patch("httpx.AsyncClient.get", new_callable=AsyncMock, side_effect=fake_get):
+        result = await mock_client.discover_resources()
+
+    assert result == []
+
+
+@pytest.mark.asyncio
+async def test_discover_resources_multiple_nodes(mock_client):
+    """Resources from multiple nodes are all returned."""
+    nodes = [{"node": "pve1"}, {"node": "pve2"}]
+    vms_node1 = [{"vmid": 100, "name": "vm-1", "status": "running"}]
+    vms_node2 = [{"vmid": 200, "name": "vm-2", "status": "stopped"}]
+
+    call_count = 0
+
+    async def fake_get(path, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            return _make_response(nodes)
+        elif call_count == 2:
+            return _make_response(vms_node1)
+        elif call_count == 3:
+            return _make_response([])   # no LXC on node1
+        elif call_count == 4:
+            return _make_response(vms_node2)
+        else:
+            return _make_response([])   # no LXC on node2
+
+    with patch("httpx.AsyncClient.get", new_callable=AsyncMock, side_effect=fake_get):
+        result = await mock_client.discover_resources()
+
+    assert len(result) == 2
+    vmids = {r["vmid"] for r in result}
+    assert 100 in vmids
+    assert 200 in vmids
+
+
+@pytest.mark.asyncio
+async def test_discover_resources_uses_vmid_as_fallback_name(mock_client):
+    """VMs/LXCs without a 'name' field fall back to 'vm-{vmid}'."""
+    nodes = [{"node": "pve"}]
+    vms = [{"vmid": 101, "status": "running"}]  # no 'name' key
+
+    call_count = 0
+
+    async def fake_get(path, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            return _make_response(nodes)
+        elif call_count == 2:
+            return _make_response(vms)
+        return _make_response([])
+
+    with patch("httpx.AsyncClient.get", new_callable=AsyncMock, side_effect=fake_get):
+        result = await mock_client.discover_resources()
+
+    assert result[0]["name"] == "vm-101"

--- a/tests/test_setup_connect.py
+++ b/tests/test_setup_connect.py
@@ -1,0 +1,343 @@
+"""Tests for setup wizard Screen 5 — connect integrations."""
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture
+def setup_client(config_file, data_dir, monkeypatch):
+    monkeypatch.setenv("PORTAINER_URL", "")
+    monkeypatch.setenv("PORTAINER_API_KEY", "")
+    from app.main import app
+    return TestClient(app, raise_server_exceptions=True)
+
+
+def _create_admin():
+    from app.auth import create_admin
+    return create_admin(username="admin", password="password123", totp_secret=None)
+
+
+def _mock_httpx(status=200, json_data=None, exc=None):
+    """Context manager that mocks httpx.AsyncClient used in auth_router."""
+    resp = MagicMock()
+    resp.status_code = status
+    resp.json.return_value = json_data or {"message": "ok"}
+    if exc:
+        resp.raise_for_status.side_effect = exc
+    else:
+        resp.raise_for_status = MagicMock()
+
+    inner = AsyncMock()
+    if exc:
+        inner.get = AsyncMock(side_effect=exc)
+    else:
+        inner.get = AsyncMock(return_value=resp)
+
+    ctx = MagicMock()
+    ctx.__aenter__ = AsyncMock(return_value=inner)
+    ctx.__aexit__ = AsyncMock(return_value=None)
+
+    return patch("app.auth_router.httpx.AsyncClient", return_value=ctx)
+
+
+# ---------------------------------------------------------------------------
+# POST /setup/security — no session flag
+# ---------------------------------------------------------------------------
+
+def test_setup_security_post_no_session_redirects(setup_client, data_dir):
+    _create_admin()
+    response = setup_client.post("/setup/security", data={}, follow_redirects=False)
+    assert response.status_code == 302
+    assert response.headers["location"] == "/login"
+
+
+# ---------------------------------------------------------------------------
+# POST /setup/security — correct TOTP enrolls MFA
+# ---------------------------------------------------------------------------
+
+def test_setup_security_correct_totp_enrolls_mfa(setup_client):
+    import pyotp
+    from app.auth import mfa_enrolled
+
+    setup_client.post("/setup/account", data={
+        "username": "alice",
+        "password": "password123",
+        "password_confirm": "password123",
+    }, follow_redirects=False)
+
+    # Load security page to get secret stored in session
+    setup_client.get("/setup/security", follow_redirects=False)
+
+    # Peek at the session secret via the credential store (we can't easily read session)
+    # Instead, patch new_totp_secret to return a known secret and re-load the page
+    known_secret = pyotp.random_base32()
+
+    with patch("app.auth_router.new_totp_secret", return_value=known_secret):
+        setup_client.get("/setup/security", follow_redirects=False)
+
+    code = pyotp.TOTP(known_secret).now()
+    response = setup_client.post("/setup/security", data={
+        "enable_mfa": "on",
+        "totp_code": code,
+    }, follow_redirects=False)
+
+    assert response.status_code == 303
+    assert "/setup/recovery-code" in response.headers["location"]
+    assert mfa_enrolled() is True
+
+
+# ---------------------------------------------------------------------------
+# POST /setup/connect/proxmox/test
+# ---------------------------------------------------------------------------
+
+def test_proxmox_test_success(setup_client, data_dir):
+    _create_admin()
+    with patch("app.auth_router.ProxmoxClient") as MockClient:
+        instance = AsyncMock()
+        instance.get_version = AsyncMock(return_value={"version": "8.1.4"})
+        MockClient.return_value = instance
+        response = setup_client.post("/setup/connect/proxmox/test", data={
+            "proxmox_url": "https://192.168.1.10:8006",
+            "proxmox_api_token": "user@pam!token=abc",
+        })
+    assert response.status_code == 200
+    assert "8.1.4" in response.text
+
+
+def test_proxmox_test_auth_error(setup_client, data_dir):
+    _create_admin()
+    with patch("app.auth_router.ProxmoxClient") as MockClient:
+        instance = AsyncMock()
+        instance.get_version = AsyncMock(side_effect=Exception("401 Unauthorized"))
+        MockClient.return_value = instance
+        response = setup_client.post("/setup/connect/proxmox/test", data={
+            "proxmox_url": "https://192.168.1.10:8006",
+            "proxmox_api_token": "badtoken",
+        })
+    assert response.status_code == 200
+    assert "Invalid API token" in response.text
+
+
+def test_proxmox_test_connect_error(setup_client, data_dir):
+    _create_admin()
+    with patch("app.auth_router.ProxmoxClient") as MockClient:
+        instance = AsyncMock()
+        instance.get_version = AsyncMock(side_effect=Exception("Failed to connect to host"))
+        MockClient.return_value = instance
+        response = setup_client.post("/setup/connect/proxmox/test", data={
+            "proxmox_url": "https://192.0.2.1:8006",
+            "proxmox_api_token": "token",
+        })
+    assert response.status_code == 200
+    assert "reach" in response.text.lower() or "connect" in response.text.lower()
+
+
+def test_proxmox_test_ssl_error(setup_client, data_dir):
+    _create_admin()
+    with patch("app.auth_router.ProxmoxClient") as MockClient:
+        instance = AsyncMock()
+        instance.get_version = AsyncMock(side_effect=Exception("SSL certificate verify failed"))
+        MockClient.return_value = instance
+        response = setup_client.post("/setup/connect/proxmox/test", data={
+            "proxmox_url": "https://192.168.1.10:8006",
+            "proxmox_api_token": "token",
+        })
+    assert response.status_code == 200
+    assert "SSL" in response.text
+
+
+# ---------------------------------------------------------------------------
+# POST /setup/connect/proxmox/discover
+# ---------------------------------------------------------------------------
+
+def test_proxmox_discover_not_configured(setup_client, data_dir):
+    _create_admin()
+    response = setup_client.post("/setup/connect/proxmox/discover")
+    assert response.status_code == 200
+    assert "not configured" in response.text.lower()
+
+
+def test_proxmox_discover_success(setup_client, data_dir):
+    _create_admin()
+    from app.config_manager import save_proxmox_config
+    from app.credentials import save_integration_credentials
+    save_proxmox_config(url="https://192.168.1.10:8006", verify_ssl=False)
+    save_integration_credentials("proxmox", api_token="user@pam!token=abc")
+
+    with patch("app.auth_router.ProxmoxClient") as MockClient:
+        instance = AsyncMock()
+        instance.discover_resources = AsyncMock(return_value=[
+            {"type": "vm", "node": "pve", "vmid": 100, "name": "ubuntu", "status": "running"},
+        ])
+        MockClient.return_value = instance
+        response = setup_client.post("/setup/connect/proxmox/discover")
+
+    assert response.status_code == 200
+    assert "ubuntu" in response.text
+
+
+def test_proxmox_discover_failure(setup_client, data_dir):
+    _create_admin()
+    from app.config_manager import save_proxmox_config
+    from app.credentials import save_integration_credentials
+    save_proxmox_config(url="https://192.168.1.10:8006", verify_ssl=False)
+    save_integration_credentials("proxmox", api_token="token")
+
+    with patch("app.auth_router.ProxmoxClient") as MockClient:
+        instance = AsyncMock()
+        instance.discover_resources = AsyncMock(side_effect=Exception("timeout"))
+        MockClient.return_value = instance
+        response = setup_client.post("/setup/connect/proxmox/discover")
+
+    assert response.status_code == 200
+    assert "failed" in response.text.lower()
+
+
+# ---------------------------------------------------------------------------
+# POST /setup/connect/proxmox/select-hosts
+# ---------------------------------------------------------------------------
+
+def test_proxmox_select_hosts(setup_client, data_dir):
+    _create_admin()
+    response = setup_client.post("/setup/connect/proxmox/select-hosts", data={
+        "selected_hosts": ["pve:100:vm:ubuntu-vm", "pve:101:lxc:debian-ct"],
+    })
+    assert response.status_code == 200
+    assert "2 hosts" in response.text or "queued" in response.text.lower()
+
+
+def test_proxmox_select_hosts_empty(setup_client, data_dir):
+    _create_admin()
+    response = setup_client.post("/setup/connect/proxmox/select-hosts", data={})
+    assert response.status_code == 200
+    assert "0 hosts" in response.text or "queued" in response.text.lower()
+
+
+# ---------------------------------------------------------------------------
+# POST /setup/connect/pbs/test
+# ---------------------------------------------------------------------------
+
+def test_pbs_test_success(setup_client, data_dir):
+    _create_admin()
+    with _mock_httpx(json_data={"data": {"version": "3.1.0"}}):
+        response = setup_client.post("/setup/connect/pbs/test", data={
+            "pbs_url": "https://192.168.1.11:8007",
+            "pbs_api_token": "user@pbs!token=abc",
+        })
+    assert response.status_code == 200
+    assert "Connected" in response.text
+
+
+def test_pbs_test_auth_failure(setup_client, data_dir):
+    _create_admin()
+    import httpx as _httpx
+    with _mock_httpx(exc=Exception("401 Unauthorized")):
+        response = setup_client.post("/setup/connect/pbs/test", data={
+            "pbs_url": "https://192.168.1.11:8007",
+            "pbs_api_token": "badtoken",
+        })
+    assert response.status_code == 200
+    assert "Invalid" in response.text
+
+
+# ---------------------------------------------------------------------------
+# POST /setup/connect/opnsense/test
+# ---------------------------------------------------------------------------
+
+def test_opnsense_test_success(setup_client, data_dir):
+    _create_admin()
+    with _mock_httpx():
+        response = setup_client.post("/setup/connect/opnsense/test", data={
+            "opnsense_url": "https://192.168.1.1",
+            "opnsense_api_key": "mykey",
+            "opnsense_api_secret": "mysecret",
+        })
+    assert response.status_code == 200
+    assert "Connected" in response.text
+
+
+def test_opnsense_test_auth_failure(setup_client, data_dir):
+    _create_admin()
+    with _mock_httpx(exc=Exception("403 Forbidden")):
+        response = setup_client.post("/setup/connect/opnsense/test", data={
+            "opnsense_url": "https://192.168.1.1",
+            "opnsense_api_key": "badkey",
+            "opnsense_api_secret": "badsecret",
+        })
+    assert response.status_code == 200
+    assert "Invalid" in response.text
+
+
+def test_opnsense_test_generic_failure(setup_client, data_dir):
+    _create_admin()
+    with _mock_httpx(exc=Exception("Something went wrong with the request")):
+        response = setup_client.post("/setup/connect/opnsense/test", data={
+            "opnsense_url": "https://192.168.1.1",
+            "opnsense_api_key": "key",
+            "opnsense_api_secret": "secret",
+        })
+    assert response.status_code == 200
+    assert "&#10007;" in response.text or "error" in response.text.lower() or "wrong" in response.text.lower()
+
+
+# ---------------------------------------------------------------------------
+# POST /setup/connect/pfsense/test
+# ---------------------------------------------------------------------------
+
+def test_pfsense_test_success(setup_client, data_dir):
+    _create_admin()
+    with _mock_httpx():
+        response = setup_client.post("/setup/connect/pfsense/test", data={
+            "pfsense_url": "https://192.168.1.1",
+            "pfsense_api_key": "mykey",
+        })
+    assert response.status_code == 200
+    assert "Connected" in response.text
+
+
+def test_pfsense_test_failure(setup_client, data_dir):
+    _create_admin()
+    with _mock_httpx(exc=Exception("401 Unauthorized")):
+        response = setup_client.post("/setup/connect/pfsense/test", data={
+            "pfsense_url": "https://192.168.1.1",
+            "pfsense_api_key": "badkey",
+        })
+    assert response.status_code == 200
+    assert "Invalid" in response.text
+
+
+# ---------------------------------------------------------------------------
+# POST /setup/connect/homeassistant/test
+# ---------------------------------------------------------------------------
+
+def test_homeassistant_test_success(setup_client, data_dir):
+    _create_admin()
+    with _mock_httpx(json_data={"message": "API running.", "version": "2024.1.0"}):
+        response = setup_client.post("/setup/connect/homeassistant/test", data={
+            "ha_url": "http://homeassistant.local:8123",
+            "ha_token": "mytoken",
+        })
+    assert response.status_code == 200
+    assert "Connected" in response.text
+
+
+def test_homeassistant_test_auth_failure(setup_client, data_dir):
+    _create_admin()
+    with _mock_httpx(exc=Exception("401 Unauthorized")):
+        response = setup_client.post("/setup/connect/homeassistant/test", data={
+            "ha_url": "http://homeassistant.local:8123",
+            "ha_token": "badtoken",
+        })
+    assert response.status_code == 200
+    assert "Invalid" in response.text
+
+
+def test_homeassistant_test_generic_failure(setup_client, data_dir):
+    _create_admin()
+    with _mock_httpx(exc=Exception("connection refused")):
+        response = setup_client.post("/setup/connect/homeassistant/test", data={
+            "ha_url": "http://192.0.2.1:8123",
+            "ha_token": "token",
+        })
+    assert response.status_code == 200
+    assert "&#10007;" in response.text


### PR DESCRIPTION
## Summary

- Replaces the old single-page setup with a structured 8-screen wizard: Welcome/timezone → Account → 2FA (optional) → Recovery code → Connect integrations → SSH hosts → Notifications → Summary
- Adds `ProxmoxClient` with async VM/LXC discovery across multiple nodes, plus HTMX-driven connect/discover/select flow for Screen 5
- Screen 5 covers all 7 integrations: Proxmox, PBS, OPNsense, pfSense, Home Assistant, Portainer, DockerHub — each with test and save routes
- Single recovery code now covers both password reset and 2FA lockout (replaces old backup key)
- Progress bar indicator (Step N of 8) replaces the old 3-step circle

## Test plan

- [ ] All 573 tests pass (`pytest tests/ -q`)
- [ ] Coverage ≥ 95% (`--cov-fail-under=95` passes at 96%)
- [ ] Ruff linting passes
- [ ] Manual: run through the wizard in a browser from `/setup` through `/setup/connect`
- [ ] Manual: test each integration's "Test connection" button with valid and invalid credentials
- [ ] Manual: Proxmox discover flow — connect → discover VMs/LXCs → select hosts

🤖 Generated with [Claude Code](https://claude.com/claude-code)