### PR TITLE
Screen 6: SSH hosts refactor — session-based docker confirm, auto-update

### DIFF
--- a/app/auth_router.py
+++ b/app/auth_router.py
@@ -40,6 +40,7 @@ from .config_manager import (
     save_portainer_config,
     save_proxmox_config,
     save_timezone,
+    set_host_auto_update,
 )
 from .credentials import (
     delete_credentials,
@@ -693,23 +694,18 @@ async def forgot_password_reset(
 
 
 # ---------------------------------------------------------------------------
-# Setup — hosts & connections (step 3)
+# Setup — SSH hosts (Screen 6)
 # ---------------------------------------------------------------------------
 
 @router.get("/setup/hosts", response_class=HTMLResponse)
 async def setup_hosts_page(request: Request) -> HTMLResponse:
     if not admin_exists():
         return RedirectResponse("/setup", status_code=302)
-    port_cfg = get_portainer_config()
-    port_creds = get_integration_credentials("portainer")
-    portainer_connected = bool(port_cfg.get("url") and port_creds.get("api_key"))
     return templates.TemplateResponse("setup_hosts.html", {
         "request": request,
         "hosts": get_hosts(),
         "available_keys": get_available_ssh_keys(),
-        "portainer_url": port_cfg.get("url", ""),
-        "portainer_connected": portainer_connected,
-        "step": 3,
+        "proxmox_pending": request.session.get("setup_proxmox_pending", []),
     })
 
 
@@ -723,12 +719,14 @@ async def setup_add_host(
     auth_method: str = Form("password"),
     ssh_password: str = Form(""),
     key_file: str = Form(""),
+    enable_auto_update: str = Form(""),
 ) -> HTMLResponse:
     name = name.strip()
     host_addr = host.strip()
     user_val = user.strip() or None
     port_val = int(port) if port.strip().isdigit() else None
     key_path = f"/app/keys/{key_file}" if auth_method == "key" and key_file else None
+    auto_update = enable_auto_update == "on"
 
     if not name or not host_addr:
         return templates.TemplateResponse("partials/setup_ssh_section.html", {
@@ -739,7 +737,7 @@ async def setup_add_host(
             "form": {"name": name, "host": host_addr, "user": user_val or "", "port": port or "", "auth_method": auth_method, "key_file": key_file},
         })
 
-    host_entry = {"name": name, "host": host_addr}
+    host_entry: dict = {"name": name, "host": host_addr}
     if user_val:
         host_entry["user"] = user_val
     if port_val:
@@ -765,28 +763,31 @@ async def setup_add_host(
     stack_count = await detect_docker_stacks(host_entry, get_ssh_config(), creds)
 
     if stack_count > 0:
-        # Docker found — ask user before adding
+        # Store pending host in session (avoids putting credentials in HTML hidden fields)
         label = f"{stack_count} stack{'s' if stack_count != 1 else ''}"
+        request.session["pending_ssh_host"] = {
+            "name": name,
+            "host": host_addr,
+            "user": user_val or "",
+            "port": port,
+            "auth_method": auth_method,
+            "ssh_password": creds.get("ssh_password", ""),
+            "key_file": key_file,
+            "auto_update": auto_update,
+        }
         return templates.TemplateResponse("partials/setup_ssh_section.html", {
             "request": request,
             "hosts": get_hosts(),
             "available_keys": get_available_ssh_keys(),
-            "docker_prompt": {
-                "name": name,
-                "host": host_addr,
-                "user": user_val or "",
-                "port": port,
-                "auth_method": auth_method,
-                "ssh_password": ssh_password.strip(),
-                "key_file": key_file,
-                "stack_label": label,
-            },
+            "docker_prompt": {"name": name, "stack_label": label},
         })
 
-    # No Docker (or detection failed) — add host directly
+    # No Docker — add host directly
     slug = add_host(name=name, host=host_addr, user=user_val, port=port_val, key_path=key_path)
     if auth_method == "password" and ssh_password.strip():
         save_credentials(slug, ssh_password=ssh_password.strip())
+    if auto_update:
+        set_host_auto_update(slug, os_enabled=True, os_schedule="weekly", auto_reboot=False)
 
     return templates.TemplateResponse("partials/setup_ssh_section.html", {
         "request": request,
@@ -799,32 +800,41 @@ async def setup_add_host(
 @router.post("/setup/hosts/confirm-add", response_class=HTMLResponse)
 async def setup_confirm_add_host(
     request: Request,
-    name: str = Form(""),
-    host: str = Form(""),
-    user: str = Form(""),
-    port: str = Form(""),
-    auth_method: str = Form("password"),
-    ssh_password: str = Form(""),
-    key_file: str = Form(""),
     enable_docker: str = Form("no"),
 ) -> HTMLResponse:
-    name = name.strip()
-    host_addr = host.strip()
-    user_val = user.strip() or None
-    port_val = int(port) if port.strip().isdigit() else None
+    pending = request.session.pop("pending_ssh_host", None)
+    if not pending:
+        return templates.TemplateResponse("partials/setup_ssh_section.html", {
+            "request": request,
+            "hosts": get_hosts(),
+            "available_keys": get_available_ssh_keys(),
+            "add_error": "Session expired — please add the host again.",
+        })
+
+    name = pending["name"]
+    host_addr = pending["host"]
+    user_val = pending["user"] or None
+    port_str = pending.get("port", "")
+    port_val = int(port_str) if str(port_str).strip().isdigit() else None
+    auth_method = pending["auth_method"]
+    ssh_password = pending.get("ssh_password", "")
+    key_file = pending.get("key_file", "")
+    auto_update = pending.get("auto_update", False)
     key_path = f"/app/keys/{key_file}" if auth_method == "key" and key_file else None
     docker_mode = "all" if enable_docker == "yes" else None
 
     slug = add_host(name=name, host=host_addr, user=user_val, port=port_val,
                     key_path=key_path, docker_mode=docker_mode)
-    if auth_method == "password" and ssh_password.strip():
-        save_credentials(slug, ssh_password=ssh_password.strip())
+    if auth_method == "password" and ssh_password:
+        save_credentials(slug, ssh_password=ssh_password)
+    if auto_update:
+        set_host_auto_update(slug, os_enabled=True, os_schedule="weekly", auto_reboot=False)
 
     return templates.TemplateResponse("partials/setup_ssh_section.html", {
         "request": request,
         "hosts": get_hosts(),
         "available_keys": get_available_ssh_keys(),
-        "add_success": f"{name} added successfully.",
+        "add_success": f"{name} added{' with container monitoring' if docker_mode else ''} successfully.",
     })
 
 

--- a/app/templates/partials/setup_ssh_section.html
+++ b/app/templates/partials/setup_ssh_section.html
@@ -1,15 +1,10 @@
 <div id="ssh-hosts-section" class="bg-slate-800/60 border border-slate-700 rounded-2xl overflow-hidden">
   <!-- header -->
   <div class="px-5 py-4 border-b border-slate-700">
-    <h2 class="text-sm font-semibold text-slate-200">SSH hosts</h2>
-    <p class="text-xs text-slate-500 mt-0.5">Add Linux servers to monitor OS package updates. Requires SSH access.</p>
+    <h2 class="text-sm font-semibold text-slate-200">SSH hosts <span class="text-xs font-normal text-slate-500 ml-1">optional</span></h2>
+    <p class="text-xs text-slate-500 mt-0.5">Monitor OS package updates on Linux servers. Requires SSH access.</p>
   </div>
   <div class="px-5 py-4 space-y-4">
-
-    <!-- note about docker-only -->
-    <div class="text-xs text-slate-500">
-      Only need Docker/container monitoring? Skip this section and configure Portainer below.
-    </div>
 
     <!-- host list -->
     {% if hosts %}
@@ -20,7 +15,8 @@
           <span class="text-sm text-slate-200 font-medium">{{ h.name }}</span>
           <span class="text-xs text-slate-500 ml-2">{{ h.host }}</span>
           {% if h.get('user') %}<span class="text-xs text-slate-500"> · {{ h.user }}</span>{% endif %}
-          {% if h.get('docker_mode') %}<span class="text-xs text-blue-400 ml-1"> · Docker: on</span>{% endif %}
+          {% if h.get('docker_mode') %}<span class="text-xs text-blue-400 ml-1"> · containers: on</span>{% endif %}
+          {% if h.get('auto_update') %}<span class="text-xs text-green-400 ml-1"> · auto-update: on</span>{% endif %}
         </div>
         <button
           hx-post="/setup/hosts/{{ h.slug }}/remove"
@@ -33,7 +29,7 @@
       {% endfor %}
     </div>
     {% else %}
-    <p class="text-xs text-slate-500 italic">No hosts added yet.</p>
+    <p class="text-xs text-slate-500 italic">No hosts added yet. Skip this step if you only need container monitoring via Portainer.</p>
     {% endif %}
 
     <!-- success/error messages -->
@@ -44,7 +40,7 @@
     <p class="text-sm text-green-400">&#10003; {{ add_success }}</p>
     {% endif %}
 
-    <!-- Docker discovery prompt -->
+    <!-- Docker discovery prompt — credentials are in session, not hidden fields -->
     {% if docker_prompt %}
     <div class="rounded-xl border border-blue-500/40 bg-blue-900/20 px-4 py-4 space-y-3">
       <div class="flex items-start gap-3">
@@ -55,19 +51,12 @@
         <div>
           <p class="text-sm font-medium text-blue-300">Docker detected on {{ docker_prompt.name }}</p>
           <p class="text-xs text-slate-400 mt-0.5">
-            We found {{ docker_prompt.stack_label }} running. Want to monitor them for image updates?
+            We found {{ docker_prompt.stack_label }} running. Enable container monitoring?
           </p>
         </div>
       </div>
       <div class="flex gap-2">
         <form hx-post="/setup/hosts/confirm-add" hx-target="#ssh-hosts-section" hx-swap="outerHTML">
-          <input type="hidden" name="name" value="{{ docker_prompt.name }}">
-          <input type="hidden" name="host" value="{{ docker_prompt.host }}">
-          <input type="hidden" name="user" value="{{ docker_prompt.user }}">
-          <input type="hidden" name="port" value="{{ docker_prompt.port }}">
-          <input type="hidden" name="auth_method" value="{{ docker_prompt.auth_method }}">
-          <input type="hidden" name="ssh_password" value="{{ docker_prompt.ssh_password }}">
-          <input type="hidden" name="key_file" value="{{ docker_prompt.key_file }}">
           <input type="hidden" name="enable_docker" value="yes">
           <button type="submit"
             class="px-4 py-2 rounded-lg bg-blue-600 hover:bg-blue-500 text-sm font-medium text-white transition-colors">
@@ -75,13 +64,6 @@
           </button>
         </form>
         <form hx-post="/setup/hosts/confirm-add" hx-target="#ssh-hosts-section" hx-swap="outerHTML">
-          <input type="hidden" name="name" value="{{ docker_prompt.name }}">
-          <input type="hidden" name="host" value="{{ docker_prompt.host }}">
-          <input type="hidden" name="user" value="{{ docker_prompt.user }}">
-          <input type="hidden" name="port" value="{{ docker_prompt.port }}">
-          <input type="hidden" name="auth_method" value="{{ docker_prompt.auth_method }}">
-          <input type="hidden" name="ssh_password" value="{{ docker_prompt.ssh_password }}">
-          <input type="hidden" name="key_file" value="{{ docker_prompt.key_file }}">
           <input type="hidden" name="enable_docker" value="no">
           <button type="submit"
             class="px-4 py-2 rounded-lg bg-slate-700 hover:bg-slate-600 text-sm font-medium text-slate-300 transition-colors">
@@ -170,6 +152,13 @@
             </div>
           </div>
         </div>
+
+        <!-- Auto-update -->
+        <label class="flex items-center gap-2 cursor-pointer">
+          <input type="checkbox" name="enable_auto_update" value="on"
+            class="w-4 h-4 rounded accent-blue-500">
+          <span class="text-sm text-slate-300">Enable automatic OS updates <span class="text-xs text-slate-500">(weekly, no auto-reboot)</span></span>
+        </label>
 
         <button type="submit"
           class="w-full py-2 rounded-lg bg-blue-600 hover:bg-blue-500 text-sm font-medium text-white transition-colors">

--- a/app/templates/setup_hosts.html
+++ b/app/templates/setup_hosts.html
@@ -7,7 +7,7 @@
   <link rel="manifest" href="/static/manifest.json" />
   <meta name="theme-color" content="#0d1117" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Connect your servers — Keepup</title>
+  <title>SSH Hosts — Keepup Setup</title>
   <script src="https://cdn.tailwindcss.com"></script>
   <script src="https://unpkg.com/htmx.org@1.9.10"></script>
   <style>body { background-color: #0d1117; }</style>
@@ -19,76 +19,61 @@
     <!-- Header -->
     <div class="text-center mb-6">
       <img src="/static/logo.svg" alt="Keepup" class="w-16 h-16 mx-auto mb-4 rounded-2xl" />
-      <h1 class="text-2xl font-bold text-white">Connect your servers</h1>
-      <p class="text-sm text-slate-400 mt-1">Add hosts and integrations to monitor. You can change these later in Admin.</p>
+      <h1 class="text-2xl font-bold text-white">SSH Hosts</h1>
+      <p class="text-sm text-slate-400 mt-1">Add Linux servers to monitor OS package updates via SSH.</p>
     </div>
 
-    <!-- Step indicator -->
-    <div class="flex items-center justify-center gap-3 mb-8 text-xs">
-      <div class="flex items-center gap-2">
-        <div class="w-6 h-6 rounded-full bg-blue-600 flex items-center justify-center text-white font-bold text-xs">1</div>
-        <span class="text-slate-300 font-medium">Account</span>
+    <!-- Progress bar -->
+    <div class="mb-8">
+      <div class="flex justify-between text-xs text-slate-500 mb-1">
+        <span>Step 6 of 8</span>
+        <span>SSH Hosts</span>
       </div>
-      <div class="w-8 h-px bg-slate-700"></div>
-      <div class="flex items-center gap-2">
-        <div class="w-6 h-6 rounded-full bg-blue-600 flex items-center justify-center text-white font-bold text-xs">2</div>
-        <span class="text-slate-300 font-medium">Backup Key</span>
-      </div>
-      <div class="w-8 h-px bg-slate-700"></div>
-      <div class="flex items-center gap-2">
-        <div class="w-6 h-6 rounded-full bg-blue-600 flex items-center justify-center text-white font-bold text-xs">3</div>
-        <span class="text-slate-300 font-medium">Connect</span>
+      <div class="w-full bg-slate-700 rounded-full h-1.5">
+        <div class="bg-blue-500 h-1.5 rounded-full" style="width: 75%"></div>
       </div>
     </div>
 
     <div class="space-y-6">
 
-      <!-- SSH Hosts -->
+      <!-- Proxmox pending callout -->
+      {% if proxmox_pending %}
+      <div class="rounded-2xl border border-blue-500/30 bg-blue-900/15 px-5 py-4">
+        <div class="flex items-start gap-3">
+          <svg class="w-5 h-5 text-blue-400 mt-0.5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+              d="M13 16h-1v-4h-1m1-4h.01M12 2a10 10 0 110 20A10 10 0 0112 2z"/>
+          </svg>
+          <div>
+            <p class="text-sm font-medium text-blue-300">{{ proxmox_pending|length }} Proxmox host{{ 's' if proxmox_pending|length != 1 else '' }} queued</p>
+            <p class="text-xs text-slate-400 mt-1">
+              Add SSH credentials below for each VM or LXC to enable OS package update monitoring.
+            </p>
+            <ul class="mt-2 space-y-1">
+              {% for h in proxmox_pending %}
+              <li class="text-xs text-slate-300">
+                <span class="font-medium">{{ h.name }}</span>
+                <span class="text-slate-500 ml-1">{{ h.node }} · {{ h.type }}</span>
+              </li>
+              {% endfor %}
+            </ul>
+          </div>
+        </div>
+      </div>
+      {% endif %}
+
+      <!-- SSH section -->
       <div id="ssh-hosts-section">
         {% include 'partials/setup_ssh_section.html' %}
       </div>
 
-      <!-- Portainer -->
-      <div id="portainer-section">
-        {% include 'partials/setup_portainer_section.html' %}
-      </div>
-
-      <!-- DockerHub -->
-      <div class="bg-slate-800/60 border border-slate-700 rounded-2xl overflow-hidden">
-        <div class="px-5 py-4 border-b border-slate-700">
-          <h2 class="text-sm font-semibold text-slate-200">DockerHub <span class="text-xs font-normal text-slate-500 ml-1">optional</span></h2>
-          <p class="text-xs text-slate-500 mt-0.5">Check for newer image versions on Docker Hub.</p>
-        </div>
-        <div class="px-5 py-4 space-y-3">
-          <div id="dockerhub-result"></div>
-          <form hx-post="/setup/dockerhub/save" hx-target="#dockerhub-result" class="space-y-3">
-            <div>
-              <label class="block text-xs font-medium text-slate-400 mb-1">DockerHub username</label>
-              <input type="text" name="dockerhub_username" placeholder="myusername"
-                class="w-full bg-slate-700 border border-slate-600 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:border-blue-500 placeholder:text-slate-500">
-            </div>
-            <div>
-              <label class="block text-xs font-medium text-slate-400 mb-1">Access token</label>
-              <input type="password" name="dockerhub_token" placeholder="dckr_pat_…"
-                class="w-full bg-slate-700 border border-slate-600 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:border-blue-500 placeholder:text-slate-500">
-              <p class="text-xs text-slate-500 mt-1">In DockerHub: Account Settings → Security → New access token.</p>
-            </div>
-            <button type="submit"
-              class="px-4 py-2 rounded-lg bg-blue-600 hover:bg-blue-500 text-sm font-medium text-white transition-colors">
-              Save
-            </button>
-          </form>
-        </div>
-      </div>
-
       <!-- Bottom buttons -->
       <div class="flex justify-between items-center mt-2">
-        <a href="/login" class="text-sm text-slate-500 hover:text-slate-300">Skip — I'll configure this later</a>
-        <form method="post" action="/setup/finish">
-          <button type="submit" class="px-6 py-2.5 rounded-xl bg-blue-600 hover:bg-blue-500 text-sm font-semibold text-white transition-colors">
-            Finish setup →
-          </button>
-        </form>
+        <a href="/setup/connect" class="text-sm text-slate-500 hover:text-slate-300">← Back</a>
+        <a href="/setup/notifications"
+          class="px-6 py-2.5 rounded-xl bg-blue-600 hover:bg-blue-500 text-sm font-semibold text-white transition-colors">
+          Continue to Notifications →
+        </a>
       </div>
 
     </div>

--- a/tests/test_setup_hosts.py
+++ b/tests/test_setup_hosts.py
@@ -34,11 +34,11 @@ def test_setup_hosts_with_admin_returns_200(setup_client, data_dir):
     assert response.status_code == 200
 
 
-def test_setup_hosts_shows_step_3_indicator(setup_client, data_dir):
+def test_setup_hosts_shows_step_6_indicator(setup_client, data_dir):
     _create_admin()
     response = setup_client.get("/setup/hosts")
     assert response.status_code == 200
-    assert "Connect" in response.text
+    assert "Step 6" in response.text or "SSH" in response.text
 
 
 # ---------------------------------------------------------------------------
@@ -114,18 +114,27 @@ def test_setup_add_host_docker_detected_shows_prompt(setup_client, data_dir, con
     assert "monitor" in response.text.lower()
 
 
+def _add_host_via_session(setup_client, name, host, ssh_password="pass", enable_auto_update=False):
+    """Drive the add flow to populate session, then confirm. Returns confirm response."""
+    mock_result = {"ok": True, "message": "Connected"}
+    with patch("app.auth_router.verify_connection", new=AsyncMock(return_value=mock_result)), \
+         patch("app.auth_router.detect_docker_stacks", new=AsyncMock(return_value=3)):
+        setup_client.post("/setup/hosts/add", data={
+            "name": name,
+            "host": host,
+            "auth_method": "password",
+            "ssh_password": ssh_password,
+            "enable_auto_update": "on" if enable_auto_update else "",
+        })
+
+
 def test_setup_confirm_add_with_docker(setup_client, data_dir, config_file):
     import yaml
     _create_admin()
-    response = setup_client.post("/setup/hosts/confirm-add", data={
-        "name": "Docker Host",
-        "host": "192.168.1.20",
-        "auth_method": "password",
-        "ssh_password": "pass",
-        "enable_docker": "yes",
-    })
+    _add_host_via_session(setup_client, "Docker Host", "192.168.1.20")
+    response = setup_client.post("/setup/hosts/confirm-add", data={"enable_docker": "yes"})
     assert response.status_code == 200
-    assert "added successfully" in response.text.lower()
+    assert "docker host" in response.text.lower() and "successfully" in response.text.lower()
     raw = yaml.safe_load(config_file.read_text())
     host = next(h for h in raw["hosts"] if h["name"] == "Docker Host")
     assert host.get("docker_mode") == "all"
@@ -134,17 +143,41 @@ def test_setup_confirm_add_with_docker(setup_client, data_dir, config_file):
 def test_setup_confirm_add_without_docker(setup_client, data_dir, config_file):
     import yaml
     _create_admin()
-    response = setup_client.post("/setup/hosts/confirm-add", data={
-        "name": "Plain Host",
-        "host": "192.168.1.30",
-        "auth_method": "password",
-        "enable_docker": "no",
-    })
+    _add_host_via_session(setup_client, "Plain Host", "192.168.1.30")
+    response = setup_client.post("/setup/hosts/confirm-add", data={"enable_docker": "no"})
     assert response.status_code == 200
     assert "added successfully" in response.text.lower()
     raw = yaml.safe_load(config_file.read_text())
     host = next(h for h in raw["hosts"] if h["name"] == "Plain Host")
     assert "docker_mode" not in host
+
+
+def test_setup_confirm_add_no_session_shows_error(setup_client, data_dir):
+    _create_admin()
+    # No prior add call — session has no pending_ssh_host
+    response = setup_client.post("/setup/hosts/confirm-add", data={"enable_docker": "yes"})
+    assert response.status_code == 200
+    assert "session expired" in response.text.lower() or "add the host again" in response.text.lower()
+
+
+def test_setup_add_host_auto_update_saved(setup_client, data_dir, config_file):
+    import yaml
+    _create_admin()
+    mock_result = {"ok": True, "message": "Connected"}
+    with patch("app.auth_router.verify_connection", new=AsyncMock(return_value=mock_result)), \
+         patch("app.auth_router.detect_docker_stacks", new=AsyncMock(return_value=0)):
+        response = setup_client.post("/setup/hosts/add", data={
+            "name": "Auto Server",
+            "host": "192.168.1.99",
+            "auth_method": "password",
+            "ssh_password": "pass",
+            "enable_auto_update": "on",
+        })
+    assert response.status_code == 200
+    assert "added successfully" in response.text.lower()
+    raw = yaml.safe_load(config_file.read_text())
+    host = next(h for h in raw["hosts"] if h["name"] == "Auto Server")
+    assert host.get("auto_update", {}).get("os_enabled") is True
 
 
 # ---------------------------------------------------------------------------
@@ -154,13 +187,9 @@ def test_setup_confirm_add_without_docker(setup_client, data_dir, config_file):
 def test_setup_remove_host(setup_client, data_dir, config_file):
     import yaml
     _create_admin()
-    # Add host via confirm-add (bypasses connection test)
-    setup_client.post("/setup/hosts/confirm-add", data={
-        "name": "Remove Me",
-        "host": "192.168.1.50",
-        "auth_method": "password",
-        "enable_docker": "no",
-    })
+    # Add host via the add flow (bypasses connection test)
+    _add_host_via_session(setup_client, "Remove Me", "192.168.1.50")
+    setup_client.post("/setup/hosts/confirm-add", data={"enable_docker": "no"})
     response = setup_client.post("/setup/hosts/remove-me/remove")
     assert response.status_code == 200
     raw = yaml.safe_load(config_file.read_text())


### PR DESCRIPTION
## Summary

- **Security fix**: SSH credentials no longer passed in hidden HTML form fields for the Docker container monitoring confirm step. Pending host data is now stored server-side in the Starlette session and popped by `confirm-add` — no sensitive data in the response HTML
- Adds an "Enable automatic OS updates" checkbox to the SSH add form (weekly schedule, no auto-reboot by default)
- New `setup_hosts.html` design: Step 6 of 8 progress bar, Proxmox pending hosts callout (from session), navigation to `/setup/notifications`
- Session-expired graceful error if `confirm-add` is called without a prior `add` (e.g. page refresh)

## Test plan

- [ ] All 575 tests pass (`pytest tests/ -q`)
- [ ] Coverage ≥ 95% (96% total)
- [ ] `test_setup_confirm_add_with_docker` — verifies session round-trip
- [ ] `test_setup_confirm_add_no_session_shows_error` — verifies expired session handling
- [ ] `test_setup_add_host_auto_update_saved` — verifies auto-update flag saved to config
- [ ] Manual: add an SSH host, see Docker prompt, confirm with "Yes" — verify container monitoring is set
- [ ] Manual: add an SSH host with auto-update on — verify `auto_update.os_enabled: true` in config

🤖 Generated with [Claude Code](https://claude.com/claude-code)