### PR TITLE
feat: /home route — sections 1 & 3a of master brief

### DIFF
--- a/app/auth_router.py
+++ b/app/auth_router.py
@@ -637,7 +637,7 @@ async def login_submit(
     if remember_me == "on":
         request.session["remember_me"] = True
 
-    next_url = request.query_params.get("next", "/dashboard")
+    next_url = request.query_params.get("next", "/home")
     return RedirectResponse(next_url, status_code=303)
 
 

--- a/app/main.py
+++ b/app/main.py
@@ -179,12 +179,12 @@ async def _job_run_stack_update(job_id: str, backend_key: str, ref: str) -> None
 @app.get("/", response_class=HTMLResponse)
 async def home(request: Request) -> HTMLResponse:
     if request.session.get("authenticated"):
-        return RedirectResponse("/dashboard", status_code=302)
+        return RedirectResponse("/home", status_code=302)
     return templates.TemplateResponse("home.html", {"request": request})
 
 
-@app.get("/dashboard", response_class=HTMLResponse)
-async def dashboard(request: Request) -> HTMLResponse:
+@app.get("/home", response_class=HTMLResponse)
+async def main_home(request: Request) -> HTMLResponse:
     hosts = get_hosts()
     backends = get_backends()
     docker_configured = (
@@ -195,6 +195,11 @@ async def dashboard(request: Request) -> HTMLResponse:
         "index.html",
         {"request": request, "hosts": hosts, "docker_configured": docker_configured, "app_version": APP_VERSION},
     )
+
+
+@app.get("/dashboard", response_class=HTMLResponse)
+async def dashboard_redirect(request: Request) -> HTMLResponse:
+    return RedirectResponse("/home", status_code=301)
 
 
 # ---------------------------------------------------------------------------

--- a/app/templates/admin_auto_update_history.html
+++ b/app/templates/admin_auto_update_history.html
@@ -17,7 +17,7 @@
   <!-- Top bar -->
   <div class="flex flex-wrap items-center justify-between gap-2 px-4 md:px-5 py-2.5 border-b border-[#21262d] bg-[#0d1117]">
     <div class="flex items-center gap-2.5">
-      <a href="/dashboard" class="flex items-center gap-1.5 text-[12px] font-medium px-3 py-1.5 rounded-md bg-[#0a1f10] border border-[#2d4a3e] text-[#3fb950] flex-shrink-0">
+      <a href="/home" class="flex items-center gap-1.5 text-[12px] font-medium px-3 py-1.5 rounded-md bg-[#0a1f10] border border-[#2d4a3e] text-[#3fb950] flex-shrink-0">
         <svg width="13" height="13" viewBox="0 0 16 16" fill="none"><path d="M2 6.5L8 2l6 4.5V14a.5.5 0 01-.5.5h-4V10h-3v4.5h-4A.5.5 0 012 14V6.5z" stroke="currentColor" stroke-width="1.3" stroke-linejoin="round"/></svg>
         Home
       </a>

--- a/app/templates/admin_logs.html
+++ b/app/templates/admin_logs.html
@@ -17,7 +17,7 @@
   <!-- Top bar -->
   <div class="flex flex-wrap items-center justify-between gap-2 px-4 md:px-5 py-2.5 border-b border-[#21262d] bg-[#0d1117] shrink-0">
     <div class="flex items-center gap-2.5">
-      <a href="/dashboard" class="flex items-center gap-1.5 text-[12px] font-medium px-3 py-1.5 rounded-md bg-[#0a1f10] border border-[#2d4a3e] text-[#3fb950] flex-shrink-0">
+      <a href="/home" class="flex items-center gap-1.5 text-[12px] font-medium px-3 py-1.5 rounded-md bg-[#0a1f10] border border-[#2d4a3e] text-[#3fb950] flex-shrink-0">
         <svg width="13" height="13" viewBox="0 0 16 16" fill="none"><path d="M2 6.5L8 2l6 4.5V14a.5.5 0 01-.5.5h-4V10h-3v4.5h-4A.5.5 0 012 14V6.5z" stroke="currentColor" stroke-width="1.3" stroke-linejoin="round"/></svg>
         Home
       </a>

--- a/app/templates/auto_updates.html
+++ b/app/templates/auto_updates.html
@@ -21,7 +21,7 @@
     <!-- Top bar -->
     <div class="flex flex-wrap items-center justify-between gap-2 -mx-4 md:-mx-6 px-4 md:px-5 py-2.5 mb-8 border-b border-[#21262d] bg-[#0d1117]">
       <div class="flex items-center gap-2.5">
-        <a href="/dashboard" class="flex items-center gap-1.5 text-[12px] font-medium px-3 py-1.5 rounded-md bg-[#0a1f10] border border-[#2d4a3e] text-[#3fb950] flex-shrink-0">
+        <a href="/home" class="flex items-center gap-1.5 text-[12px] font-medium px-3 py-1.5 rounded-md bg-[#0a1f10] border border-[#2d4a3e] text-[#3fb950] flex-shrink-0">
           <svg width="13" height="13" viewBox="0 0 16 16" fill="none"><path d="M2 6.5L8 2l6 4.5V14a.5.5 0 01-.5.5h-4V10h-3v4.5h-4A.5.5 0 012 14V6.5z" stroke="currentColor" stroke-width="1.3" stroke-linejoin="round"/></svg>
           Home
         </a>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -55,7 +55,7 @@
 
     <!-- Left: Home (active) + sep + brand -->
     <div class="flex items-center gap-2.5">
-      <a href="/dashboard" class="flex items-center gap-1.5 text-[12px] font-medium px-3 py-1.5 rounded-md bg-[#0f2b17] border border-[#3fb950] text-[#3fb950] flex-shrink-0">
+      <a href="/home" class="flex items-center gap-1.5 text-[12px] font-medium px-3 py-1.5 rounded-md bg-[#0f2b17] border border-[#3fb950] text-[#3fb950] flex-shrink-0">
         <svg width="13" height="13" viewBox="0 0 16 16" fill="none"><path d="M2 6.5L8 2l6 4.5V14a.5.5 0 01-.5.5h-4V10h-3v4.5h-4A.5.5 0 012 14V6.5z" stroke="currentColor" stroke-width="1.3" stroke-linejoin="round"/></svg>
         Home
       </a>

--- a/app/templates/partials/admin_nav.html
+++ b/app/templates/partials/admin_nav.html
@@ -1,7 +1,7 @@
 <!-- Shared admin topbar + tab nav. Requires: active_tab in context. -->
 <div class="flex flex-wrap items-center justify-between gap-2 px-4 md:px-5 py-2.5 border-b border-[#21262d] bg-[#0d1117]">
   <div class="flex items-center gap-2.5">
-    <a href="/dashboard" class="flex items-center gap-1.5 text-[12px] font-medium px-3 py-1.5 rounded-md bg-[#0a1f10] border border-[#2d4a3e] text-[#3fb950] flex-shrink-0">
+    <a href="/home" class="flex items-center gap-1.5 text-[12px] font-medium px-3 py-1.5 rounded-md bg-[#0a1f10] border border-[#2d4a3e] text-[#3fb950] flex-shrink-0">
       <svg width="13" height="13" viewBox="0 0 16 16" fill="none"><path d="M2 6.5L8 2l6 4.5V14a.5.5 0 01-.5.5h-4V10h-3v4.5h-4A.5.5 0 012 14V6.5z" stroke="currentColor" stroke-width="1.3" stroke-linejoin="round"/></svg>
       Home
     </a>

--- a/tests/test_main_routes.py
+++ b/tests/test_main_routes.py
@@ -14,32 +14,39 @@ def test_home_unauthenticated_returns_landing(anon_client):
     assert "keepup" in response.text.lower()
 
 
-def test_home_authenticated_redirects_to_dashboard(client):
-    """Authenticated / redirects to /dashboard."""
+def test_home_authenticated_redirects_to_home(client):
+    """Authenticated / redirects to /home."""
     response = client.get("/", follow_redirects=False)
     assert response.status_code in (302, 303)
-    assert response.headers["location"] == "/dashboard"
+    assert response.headers["location"] == "/home"
 
 
-def test_dashboard_returns_200(client):
-    response = client.get("/dashboard")
+def test_home_returns_200(client):
+    response = client.get("/home")
     assert response.status_code == 200
 
 
-def test_dashboard_lists_hosts(client):
-    response = client.get("/dashboard")
+def test_home_lists_hosts(client):
+    response = client.get("/home")
     assert "Test Host" in response.text
     assert "Custom User Host" in response.text
 
 
-def test_dashboard_has_admin_link(client):
-    response = client.get("/dashboard")
+def test_home_has_admin_link(client):
+    response = client.get("/home")
     assert "/admin" in response.text
+
+
+def test_dashboard_redirects_to_home(client):
+    """/dashboard now 301-redirects to /home."""
+    response = client.get("/dashboard", follow_redirects=False)
+    assert response.status_code == 301
+    assert response.headers["location"] == "/home"
 
 
 def test_unauthenticated_protected_route_redirects_to_login(anon_client):
     """Unauthenticated access to a protected route redirects to /login."""
-    response = anon_client.get("/dashboard", follow_redirects=False)
+    response = anon_client.get("/home", follow_redirects=False)
     assert response.status_code in (302, 303)
     assert "/login" in response.headers["location"]
 


### PR DESCRIPTION
## Summary
- `/home` is now the canonical URL for the main page
- `/` redirects to `/home` when authenticated, shows landing page when not
- `/dashboard` issues a permanent 301 → `/home` for backwards compat
- All topbar "Home" buttons updated across every template

## Test plan
- [x] `test_home_authenticated_redirects_to_home` — / → /home when authed
- [x] `test_dashboard_redirects_to_home` — 301 from old URL
- [x] Full suite: 624 passed, 95.67% coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)