### PR TITLE
feat: wizard step 7 — container monitoring (section 9)

### DIFF
--- a/app/auth_router.py
+++ b/app/auth_router.py
@@ -47,6 +47,7 @@ from .config_manager import (
     save_pushover_config,
     save_timezone,
     save_update_check_schedule,
+    save_wizard_container_selection,
     set_host_auto_update,
 )
 from .credentials import (
@@ -56,7 +57,7 @@ from .credentials import (
     save_integration_credentials,
 )
 from .proxmox_client import ProxmoxClient
-from .ssh_client import detect_docker_stacks, verify_connection
+from .ssh_client import detect_docker_stacks, discover_containers, verify_connection
 from .backend_loader import reload_backends
 from .templates_env import make_templates
 
@@ -1063,7 +1064,46 @@ async def setup_summary_page(request: Request) -> HTMLResponse:
 
 
 # ---------------------------------------------------------------------------
-# Setup — Notifications + update check schedule (Screen 7)
+# ---------------------------------------------------------------------------
+# Setup — Container monitoring (Screen 7)
+# ---------------------------------------------------------------------------
+
+@router.get("/setup/containers", response_class=HTMLResponse)
+async def setup_containers_page(request: Request) -> HTMLResponse:
+    if not admin_exists():
+        return RedirectResponse("/setup", status_code=302)
+    hosts = get_hosts()
+    ssh_cfg = get_ssh_config()
+
+    host_data = []
+    for h in hosts:
+        from .credentials import get_credentials
+        creds = get_credentials(h["slug"])
+        containers = await discover_containers(h, ssh_cfg, creds)
+        host_data.append({
+            "id": h["slug"],
+            "name": h["name"],
+            "ip": h.get("host", ""),
+            "containers": containers,
+        })
+
+    return templates.TemplateResponse("setup_containers.html", {
+        "request": request,
+        "hosts": host_data,
+    })
+
+
+@router.post("/setup/containers/save", response_class=HTMLResponse)
+async def setup_containers_save(
+    request: Request,
+    containers: list[str] = Form(default=[]),
+) -> HTMLResponse:
+    save_wizard_container_selection(containers)
+    return RedirectResponse("/setup/notifications", status_code=303)
+
+
+# ---------------------------------------------------------------------------
+# Setup — Notifications + update check schedule (Screen 8)
 # ---------------------------------------------------------------------------
 
 @router.get("/setup/notifications", response_class=HTMLResponse)

--- a/app/auth_router.py
+++ b/app/auth_router.py
@@ -24,6 +24,7 @@ from .config_manager import (
     delete_host,
     get_available_ssh_keys,
     get_dockerhub_config,
+    get_email_config,
     get_homeassistant_config,
     get_hosts,
     get_opnsense_config,
@@ -36,6 +37,7 @@ from .config_manager import (
     get_timezone,
     get_update_check_schedule,
     save_dockerhub_config,
+    save_email_config,
     save_homeassistant_config,
     save_opnsense_config,
     save_pbs_config,
@@ -1070,11 +1072,21 @@ async def setup_notifications_page(request: Request) -> HTMLResponse:
         return RedirectResponse("/setup", status_code=302)
     pushover_creds = get_integration_credentials("pushover")
     pushover_cfg = get_pushover_config()
+    email_cfg = get_email_config()
+    email_creds = get_integration_credentials("email")
     return templates.TemplateResponse("setup_notifications.html", {
         "request": request,
         "pushover_token_set": bool(pushover_creds.get("api_token")),
         "pushover_user_set": bool(pushover_creds.get("user_key")),
         "pushover_enabled": pushover_cfg.get("enabled", False),
+        "email_configured": bool(email_cfg.get("smtp_host")),
+        "email_sender": email_cfg.get("sender_address", ""),
+        "email_recipient": email_cfg.get("recipient_address", ""),
+        "email_smtp_host": email_cfg.get("smtp_host", ""),
+        "email_smtp_port": email_cfg.get("smtp_port", 587),
+        "email_tls": email_cfg.get("tls", True),
+        "email_sender_name": email_cfg.get("sender_name", ""),
+        "email_password_set": bool(email_creds.get("smtp_password")),
         "update_schedule": get_update_check_schedule(),
     })
 
@@ -1131,3 +1143,93 @@ async def setup_save_schedule(
     labels = {"6h": "every 6 hours", "12h": "every 12 hours", "24h": "daily", "manual": "manual only"}
     label = labels.get(update_schedule, "manual only")
     return HTMLResponse(f'<span class="text-green-400 text-sm">&#10003; Update checks set to {label}.</span>')
+
+
+@router.post("/setup/notifications/email/save", response_class=HTMLResponse)
+async def setup_save_email(
+    request: Request,
+    sender_name: str = Form(""),
+    sender_address: str = Form(""),
+    recipient_address: str = Form(""),
+    smtp_host: str = Form(""),
+    smtp_port: int = Form(587),
+    smtp_password: str = Form(""),
+    tls: str = Form(""),
+) -> HTMLResponse:
+    if not smtp_host.strip():
+        return HTMLResponse('<span class="text-amber-400 text-sm">SMTP host is required.</span>')
+    save_email_config(
+        sender_name=sender_name.strip(),
+        sender_address=sender_address.strip(),
+        recipient_address=recipient_address.strip(),
+        smtp_host=smtp_host.strip(),
+        smtp_port=smtp_port,
+        tls=(tls == "on"),
+    )
+    if smtp_password.strip():
+        save_integration_credentials("email", smtp_password=smtp_password.strip())
+    return HTMLResponse('<span class="text-green-400 text-sm">&#10003; Email settings saved.</span>')
+
+
+@router.post("/setup/notifications/email/test", response_class=HTMLResponse)
+async def setup_test_email(
+    request: Request,
+    sender_name: str = Form(""),
+    sender_address: str = Form(""),
+    recipient_address: str = Form(""),
+    smtp_host: str = Form(""),
+    smtp_port: int = Form(587),
+    smtp_password: str = Form(""),
+    tls: str = Form(""),
+) -> HTMLResponse:
+    import smtplib
+    import ssl
+    from email.mime.text import MIMEText
+
+    host = smtp_host.strip()
+    if not host or not sender_address.strip() or not recipient_address.strip():
+        return HTMLResponse('<span class="text-amber-400 text-sm">Fill in SMTP host, sender and recipient first.</span>')
+
+    # Fall back to saved password if none entered
+    if not smtp_password.strip():
+        creds = get_integration_credentials("email")
+        smtp_password = creds.get("smtp_password", "")
+
+    try:
+        msg = MIMEText("This is a test email from Keepup to verify your SMTP configuration.")
+        msg["Subject"] = "Keepup test email"
+        msg["From"] = f"{sender_name.strip()} <{sender_address.strip()}>" if sender_name.strip() else sender_address.strip()
+        msg["To"] = recipient_address.strip()
+
+        use_tls = (tls == "on")
+        if use_tls:
+            context = ssl.create_default_context()
+            with smtplib.SMTP_SSL(host, smtp_port, context=context, timeout=10) as server:
+                if smtp_password:
+                    server.login(sender_address.strip(), smtp_password)
+                server.sendmail(sender_address.strip(), [recipient_address.strip()], msg.as_string())
+        else:
+            with smtplib.SMTP(host, smtp_port, timeout=10) as server:
+                server.ehlo()
+                server.starttls()
+                if smtp_password:
+                    server.login(sender_address.strip(), smtp_password)
+                server.sendmail(sender_address.strip(), [recipient_address.strip()], msg.as_string())
+
+        return HTMLResponse('<span class="text-green-400 text-sm">&#10003; Test email sent.</span>')
+    except Exception as exc:
+        return HTMLResponse(f'<span class="text-red-400 text-sm">&#10007; {str(exc)[:160]}</span>')
+
+
+@router.post("/setup/notifications/email/delete", response_class=HTMLResponse)
+async def setup_delete_email(request: Request) -> HTMLResponse:
+    from .config_manager import load_config, save_config
+    config = load_config()
+    config.pop("email", None)
+    save_config(config)
+    from .credentials import delete_credentials
+    try:
+        delete_credentials("email")
+    except Exception:
+        pass
+    return HTMLResponse('<div class="config-section" id="config-email"></div>')

--- a/app/config_manager.py
+++ b/app/config_manager.py
@@ -161,6 +161,30 @@ def save_pushover_config(enabled: bool) -> None:
     save_config(cfg)
 
 
+def get_email_config() -> dict:
+    return load_config().get("email", {})
+
+
+def save_email_config(
+    sender_name: str,
+    sender_address: str,
+    recipient_address: str,
+    smtp_host: str,
+    smtp_port: int,
+    tls: bool,
+) -> None:
+    cfg = load_config()
+    cfg["email"] = {
+        "sender_name": sender_name,
+        "sender_address": sender_address,
+        "recipient_address": recipient_address,
+        "smtp_host": smtp_host,
+        "smtp_port": smtp_port,
+        "tls": tls,
+    }
+    save_config(cfg)
+
+
 def get_timezone() -> str:
     return load_config().get("timezone", "UTC")
 

--- a/app/config_manager.py
+++ b/app/config_manager.py
@@ -126,6 +126,29 @@ def set_docker_monitoring(
     save_config(config)
 
 
+def save_wizard_container_selection(selections: list[str]) -> None:
+    """Save wizard container selections (list of 'slug:container_name' values).
+
+    For each host slug, set docker_mode='selected' with the chosen containers.
+    Hosts with no containers selected get docker_mode cleared.
+    """
+    # Group by slug
+    by_slug: dict[str, list[str]] = {}
+    for item in selections:
+        if ":" in item:
+            slug, container = item.split(":", 1)
+            by_slug.setdefault(slug, []).append(container)
+
+    config = load_config()
+    for h in config.get("hosts", []):
+        slug = slugify(h["name"])
+        if slug in by_slug:
+            h["docker_mode"] = "selected"
+            h["docker_stacks"] = by_slug[slug]
+        # Hosts not in selections are left unchanged (user may not have docker)
+    save_config(config)
+
+
 # ---------------------------------------------------------------------------
 # SSH settings
 # ---------------------------------------------------------------------------

--- a/app/main.py
+++ b/app/main.py
@@ -1,5 +1,6 @@
 import asyncio
 import os
+import time
 import uuid
 from pathlib import Path
 
@@ -22,6 +23,55 @@ from .credentials import get_credentials, save_sudo_password
 from .ssh_client import _needs_sudo, check_host_updates, reboot_host, run_host_update_buffered
 from .__version__ import APP_VERSION
 from .templates_env import make_templates
+
+# ---------------------------------------------------------------------------
+# GitHub version check (cached 1 hour)
+# ---------------------------------------------------------------------------
+
+_version_cache: dict = {"ts": 0.0, "latest": None, "url": None}
+_GITHUB_REPO = "d4vastu/Keepup"
+_VERSION_CACHE_TTL = 3600
+
+
+async def _fetch_latest_version() -> tuple[str | None, str | None]:
+    """Return (latest_tag, release_url) or (None, None) on failure."""
+    try:
+        import httpx
+        async with httpx.AsyncClient(timeout=5) as c:
+            resp = await c.get(
+                f"https://api.github.com/repos/{_GITHUB_REPO}/releases/latest",
+                headers={"Accept": "application/vnd.github+json"},
+            )
+            if resp.status_code != 200:
+                return None, None
+            data = resp.json()
+            tag = data.get("tag_name", "").lstrip("v")
+            url = data.get("html_url", "")
+            return tag or None, url or None
+    except Exception:
+        return None, None
+
+
+async def _get_latest_version() -> tuple[str | None, str | None]:
+    """Return cached (latest_version, release_url); refresh if stale."""
+    now = time.time()
+    if now - _version_cache["ts"] > _VERSION_CACHE_TTL:
+        tag, url = await _fetch_latest_version()
+        _version_cache.update({"ts": now, "latest": tag, "url": url})
+    return _version_cache["latest"], _version_cache["url"]
+
+
+def _newer_version(latest: str | None) -> bool:
+    """True if latest tag is strictly newer than APP_VERSION."""
+    if not latest:
+        return False
+    try:
+        def _parts(v: str) -> tuple:
+            return tuple(int(x) for x in v.split("."))
+        return _parts(latest) > _parts(APP_VERSION)
+    except Exception:
+        return False
+
 
 # ---------------------------------------------------------------------------
 # Auth middleware
@@ -191,9 +241,18 @@ async def dashboard(request: Request) -> HTMLResponse:
         any(b.BACKEND_KEY == "portainer" for b in backends)
         or any(h.get("docker_mode") for h in hosts)
     )
+    latest_tag, latest_url = await _get_latest_version()
+    show_update = _newer_version(latest_tag)
     return templates.TemplateResponse(
         "index.html",
-        {"request": request, "hosts": hosts, "docker_configured": docker_configured, "app_version": APP_VERSION},
+        {
+            "request": request,
+            "hosts": hosts,
+            "docker_configured": docker_configured,
+            "app_version": APP_VERSION,
+            "latest_version": latest_tag if show_update else None,
+            "latest_release_url": latest_url if show_update else None,
+        },
     )
 
 

--- a/app/ssh_client.py
+++ b/app/ssh_client.py
@@ -70,6 +70,33 @@ async def verify_connection(host: dict, ssh_cfg: dict, creds: dict | None = None
         return {"ok": False, "message": str(exc)}
 
 
+async def discover_containers(host: dict, ssh_cfg: dict, creds: dict | None = None) -> list[dict]:
+    """Return list of running containers as [{"id": name, "name": name, "image": image}, ...].
+    Returns empty list on error or if Docker not available."""
+    try:
+        async with await _connect(host, ssh_cfg, creds) as conn:
+            result = await conn.run(
+                "docker ps --format '{\"name\":\"{{.Names}}\",\"image\":\"{{.Image}}\"}'",
+                check=False,
+            )
+        containers = []
+        for line in result.stdout.strip().splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                import json
+                obj = json.loads(line)
+                name = obj.get("name", "")
+                if name:
+                    containers.append({"id": name, "name": name, "image": obj.get("image", "")})
+            except Exception:
+                pass
+        return containers
+    except Exception:
+        return []
+
+
 async def detect_docker_stacks(host: dict, ssh_cfg: dict, creds: dict | None = None) -> int:
     """Return the number of Docker Compose stacks found on the host, or -1 on error."""
     try:

--- a/app/templates/home.html
+++ b/app/templates/home.html
@@ -16,7 +16,7 @@
   <!-- Nav -->
   <div class="flex items-center justify-between px-6 py-4 border-b border-[#21262d]">
     <div class="flex items-center gap-2.5">
-      <img src="/static/logo.svg" alt="Keepup" class="w-7 h-7 rounded-lg flex-shrink-0" />
+      <svg width="26" height="26" viewBox="0 0 28 28" fill="none" class="flex-shrink-0"><rect width="28" height="28" rx="7" fill="#0f1923"/><rect x="7" y="13" width="14" height="3.5" rx="1" fill="#2d3a4a"/><rect x="7" y="17.5" width="14" height="3.5" rx="1" fill="#2d3a4a"/><rect x="7" y="22" width="14" height="3.5" rx="1" fill="#2d3a4a"/><path d="M14 12.5 L14 5" stroke="#3fb950" stroke-width="2.2" stroke-linecap="round"/><path d="M10.5 8.2 L14 4.5 L17.5 8.2" fill="none" stroke="#3fb950" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"/><circle cx="9" cy="14.75" r="1.1" fill="#3fb950"/><circle cx="9" cy="19.25" r="1.1" fill="#3fb950"/><circle cx="9" cy="23.75" r="1.1" fill="#253a2d"/></svg>
       <span class="text-[15px] font-medium text-slate-100 tracking-tight">keepup</span>
     </div>
     <a href="/login"
@@ -28,7 +28,9 @@
   <!-- Hero -->
   <div class="flex-1 flex flex-col items-center justify-center px-4 py-20 text-center">
 
-    <img src="/static/logo.svg" alt="Keepup" class="w-20 h-20 rounded-2xl mb-8 shadow-2xl" />
+    <div class="w-20 h-20 rounded-2xl mb-8 shadow-2xl flex items-center justify-center" style="background:#0d1117;border:1px solid #21262d;">
+      <svg width="56" height="56" viewBox="0 0 28 28" fill="none"><rect width="28" height="28" rx="7" fill="#0f1923"/><rect x="7" y="13" width="14" height="3.5" rx="1" fill="#2d3a4a"/><rect x="7" y="17.5" width="14" height="3.5" rx="1" fill="#2d3a4a"/><rect x="7" y="22" width="14" height="3.5" rx="1" fill="#2d3a4a"/><path d="M14 12.5 L14 5" stroke="#3fb950" stroke-width="2.2" stroke-linecap="round"/><path d="M10.5 8.2 L14 4.5 L17.5 8.2" fill="none" stroke="#3fb950" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"/><circle cx="9" cy="14.75" r="1.1" fill="#3fb950"/><circle cx="9" cy="19.25" r="1.1" fill="#3fb950"/><circle cx="9" cy="23.75" r="1.1" fill="#253a2d"/></svg>
+    </div>
 
     <h1 class="text-4xl sm:text-5xl font-bold text-white tracking-tight mb-4">
       Keep your homelab<br class="hidden sm:block" /> up to date.

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -61,7 +61,7 @@
       </a>
       <div class="w-px h-[18px] bg-[#21262d] flex-shrink-0"></div>
       <div class="flex items-center gap-2">
-        <img src="/static/logo.svg" alt="Keepup" class="w-7 h-7 rounded-lg flex-shrink-0" />
+        <svg width="26" height="26" viewBox="0 0 28 28" fill="none" class="flex-shrink-0"><rect width="28" height="28" rx="7" fill="#0f1923"/><rect x="7" y="13" width="14" height="3.5" rx="1" fill="#2d3a4a"/><rect x="7" y="17.5" width="14" height="3.5" rx="1" fill="#2d3a4a"/><rect x="7" y="22" width="14" height="3.5" rx="1" fill="#2d3a4a"/><path d="M14 12.5 L14 5" stroke="#3fb950" stroke-width="2.2" stroke-linecap="round"/><path d="M10.5 8.2 L14 4.5 L17.5 8.2" fill="none" stroke="#3fb950" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"/><circle cx="9" cy="14.75" r="1.1" fill="#3fb950"/><circle cx="9" cy="19.25" r="1.1" fill="#3fb950"/><circle cx="9" cy="23.75" r="1.1" fill="#253a2d"/></svg>
         <span class="text-[14px] font-medium tracking-tight text-slate-100">keep<span class="text-[#3fb950]">up</span></span>
       </div>
     </div>
@@ -94,6 +94,10 @@
           class="hidden absolute right-0 top-full mt-2 w-80 sm:w-96 max-w-[calc(100vw-1rem)] bg-[#161b22] border border-[#30363d] rounded-xl shadow-2xl z-50 overflow-hidden">
         </div>
       </div>
+      <a href="/logout" class="flex items-center gap-1.5 text-[12px] font-medium px-3 py-1.5 rounded-md border border-[#30363d] bg-transparent text-[#8b949e] hover:text-[#f85149] hover:border-[#4a1515] hover:bg-[#1a0808] transition-colors">
+        <svg width="13" height="13" viewBox="0 0 16 16" fill="none"><path d="M6 14H3a1 1 0 01-1-1V3a1 1 0 011-1h3M10 11l3-3-3-3M13 8H6" stroke="currentColor" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"/></svg>
+        Sign out
+      </a>
     </div>
   </div>
 
@@ -187,6 +191,9 @@
   <div style="position:fixed;bottom:0;right:0;padding:8px 16px;background:#0a0e13;border-top:0.5px solid #1e2631;border-left:0.5px solid #1e2631;border-radius:8px 0 0 0;display:flex;align-items:center;gap:8px;z-index:100;">
     <svg width="18" height="18" viewBox="0 0 28 28" fill="none"><rect width="28" height="28" rx="7" fill="#0f1923"/><rect x="7" y="13" width="14" height="3.5" rx="1" fill="#2d3a4a"/><rect x="7" y="17.5" width="14" height="3.5" rx="1" fill="#2d3a4a"/><rect x="7" y="22" width="14" height="3.5" rx="1" fill="#2d3a4a"/><path d="M14 12.5 L14 5" stroke="#3fb950" stroke-width="2.2" stroke-linecap="round"/><path d="M10.5 8.2 L14 4.5 L17.5 8.2" fill="none" stroke="#3fb950" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"/><circle cx="9" cy="14.75" r="1.1" fill="#3fb950"/><circle cx="9" cy="19.25" r="1.1" fill="#3fb950"/><circle cx="9" cy="23.75" r="1.1" fill="#253a2d"/></svg>
     <div>
+      {% if latest_version %}
+      <a href="{{ latest_release_url }}" target="_blank" style="font-size:10px;font-weight:500;color:#3fb950;text-decoration:none;display:block;margin-bottom:2px;" onmouseover="this.style.textDecoration='underline'" onmouseout="this.style.textDecoration='none'">{{ latest_version }} available ↑</a>
+      {% endif %}
       <span class="text-[12px] font-medium text-[#484f58] tracking-tight">keep<span class="text-[#3fb950]">up</span></span>
       <span class="text-[11px] text-[#30363d] font-mono ml-2">v{{ app_version }}</span>
     </div>

--- a/app/templates/login.html
+++ b/app/templates/login.html
@@ -17,7 +17,9 @@
 
     <!-- Logo / title -->
     <div class="text-center mb-8">
-      <img src="/static/logo.svg" alt="Keepup" class="w-16 h-16 mx-auto mb-4 rounded-2xl" />
+      <div class="w-16 h-16 mx-auto mb-4 rounded-2xl flex items-center justify-center" style="background:#0d1117;border:1px solid #21262d;">
+        <svg width="44" height="44" viewBox="0 0 28 28" fill="none"><rect width="28" height="28" rx="7" fill="#0f1923"/><rect x="7" y="13" width="14" height="3.5" rx="1" fill="#2d3a4a"/><rect x="7" y="17.5" width="14" height="3.5" rx="1" fill="#2d3a4a"/><rect x="7" y="22" width="14" height="3.5" rx="1" fill="#2d3a4a"/><path d="M14 12.5 L14 5" stroke="#3fb950" stroke-width="2.2" stroke-linecap="round"/><path d="M10.5 8.2 L14 4.5 L17.5 8.2" fill="none" stroke="#3fb950" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"/><circle cx="9" cy="14.75" r="1.1" fill="#3fb950"/><circle cx="9" cy="19.25" r="1.1" fill="#3fb950"/><circle cx="9" cy="23.75" r="1.1" fill="#253a2d"/></svg>
+      </div>
       <h1 class="text-2xl font-bold text-white">Keepup</h1>
       <p class="text-sm text-slate-500 mt-1">Sign in to continue</p>
     </div>

--- a/app/templates/partials/admin_nav.html
+++ b/app/templates/partials/admin_nav.html
@@ -7,7 +7,7 @@
     </a>
     <div class="w-px h-[18px] bg-[#21262d] flex-shrink-0"></div>
     <div class="flex items-center gap-2">
-      <img src="/static/logo.svg" alt="Keepup" class="w-7 h-7 rounded-lg flex-shrink-0" />
+      <svg width="26" height="26" viewBox="0 0 28 28" fill="none" class="flex-shrink-0"><rect width="28" height="28" rx="7" fill="#0f1923"/><rect x="7" y="13" width="14" height="3.5" rx="1" fill="#2d3a4a"/><rect x="7" y="17.5" width="14" height="3.5" rx="1" fill="#2d3a4a"/><rect x="7" y="22" width="14" height="3.5" rx="1" fill="#2d3a4a"/><path d="M14 12.5 L14 5" stroke="#3fb950" stroke-width="2.2" stroke-linecap="round"/><path d="M10.5 8.2 L14 4.5 L17.5 8.2" fill="none" stroke="#3fb950" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"/><circle cx="9" cy="14.75" r="1.1" fill="#3fb950"/><circle cx="9" cy="19.25" r="1.1" fill="#3fb950"/><circle cx="9" cy="23.75" r="1.1" fill="#253a2d"/></svg>
       <span class="text-[14px] font-medium tracking-tight text-slate-100">keep<span class="text-[#3fb950]">up</span></span>
     </div>
   </div>
@@ -23,6 +23,10 @@
       </button>
       <div id="notif-panel" class="hidden absolute right-0 top-full mt-2 w-80 sm:w-96 max-w-[calc(100vw-1rem)] bg-[#161b22] border border-[#30363d] rounded-xl shadow-2xl z-50 overflow-hidden"></div>
     </div>
+    <a href="/logout" class="flex items-center gap-1.5 text-[12px] font-medium px-3 py-1.5 rounded-md border border-[#30363d] bg-transparent text-[#8b949e] hover:text-[#f85149] hover:border-[#4a1515] hover:bg-[#1a0808] transition-colors">
+      <svg width="13" height="13" viewBox="0 0 16 16" fill="none"><path d="M6 14H3a1 1 0 01-1-1V3a1 1 0 011-1h3M10 11l3-3-3-3M13 8H6" stroke="currentColor" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"/></svg>
+      Sign out
+    </a>
   </div>
 </div>
 

--- a/app/templates/setup_connect.html
+++ b/app/templates/setup_connect.html
@@ -7,10 +7,61 @@
   <link rel="manifest" href="/static/manifest.json" />
   <meta name="theme-color" content="#0d1117" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Connect your infrastructure — Keepup</title>
+  <title>Connect your infrastructure — Keepup Setup</title>
   <script src="https://cdn.tailwindcss.com"></script>
   <script src="https://unpkg.com/htmx.org@1.9.10"></script>
-  <style>body { background-color: #0d1117; }</style>
+  <style>
+    body { background-color: #0d1117; }
+    .icon-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 10px; margin-bottom: 20px; }
+    .int-icon { background: #161b22; border: 0.5px solid #21262d; border-radius: 10px; padding: 14px 10px 10px; display: flex; flex-direction: column; align-items: center; gap: 7px; cursor: pointer; transition: border-color 0.15s; }
+    .int-icon:hover { border-color: #30363d; }
+    .int-icon.active { border-color: #388bfd; background: #0c1a2e; }
+    .int-icon.connected { border-color: #1a4a25; background: #0a1f10; }
+    .int-icon.connected.active { border-color: #3fb950; }
+    .int-logo { width: 34px; height: 34px; border-radius: 8px; display: flex; align-items: center; justify-content: center; flex-shrink: 0; }
+    .int-name { font-size: 11px; font-weight: 500; color: #8b949e; text-align: center; }
+    .int-icon.connected .int-name { color: #3fb950; }
+    .int-icon.active:not(.connected) .int-name { color: #388bfd; }
+    .int-bottom { display: flex; align-items: center; justify-content: space-between; width: 100%; margin-top: 2px; }
+    .int-count { font-size: 10px; font-weight: 500; padding: 2px 7px; border-radius: 10px; }
+    .count-green { background: #0f2b17; color: #3fb950; border: 0.5px solid #1a4a25; }
+    .count-gray { color: #484f58; font-size: 10px; }
+    .add-btn { font-size: 10px; font-weight: 500; padding: 3px 8px; border-radius: 5px; cursor: pointer; border: none; }
+    .add-btn-green { background: #1a4a25; color: #3fb950; }
+    .add-btn-gray { background: #21262d; color: #8b949e; }
+
+    .config-section { display: none; }
+    .config-card { background: #161b22; border: 0.5px solid #21262d; border-radius: 10px; overflow: hidden; margin-bottom: 12px; position: relative; }
+    .config-card-header { display: flex; align-items: center; justify-content: space-between; padding: 12px 16px; border-bottom: 0.5px solid #21262d; }
+    .config-card-title { font-size: 13px; font-weight: 500; color: #e6edf3; display: flex; align-items: center; gap: 8px; }
+    .config-card-body { padding: 14px 16px; }
+
+    .field { display: flex; flex-direction: column; gap: 4px; margin-bottom: 10px; }
+    .field-label { font-size: 11px; color: #6e7681; letter-spacing: 0.04em; }
+    .field-input { background: #0d1117; border: 0.5px solid #30363d; border-radius: 6px; padding: 7px 10px; font-size: 12px; color: #e6edf3; font-family: monospace; width: 100%; outline: none; }
+    .field-input:focus { border-color: #388bfd; }
+    .field-hint { font-size: 11px; color: #484f58; margin-top: 3px; }
+    .field-row { display: grid; grid-template-columns: 1fr 1fr; gap: 10px; }
+
+    .ha-notice { font-size: 12px; color: #484f58; background: #0c1a2e; border: 0.5px solid #1a3a6e; border-radius: 6px; padding: 10px 12px; margin-bottom: 10px; }
+
+    .btn-row { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; margin-top: 12px; }
+    .btn-test { font-size: 12px; font-weight: 500; padding: 6px 14px; border-radius: 6px; border: 0.5px solid #30363d; background: transparent; color: #8b949e; cursor: pointer; }
+    .btn-test:hover { background: #21262d; color: #e6edf3; }
+    .btn-save { font-size: 12px; font-weight: 500; padding: 6px 14px; border-radius: 6px; border: 0.5px solid #1a3a6e; background: #0c2045; color: #388bfd; cursor: pointer; }
+    .btn-save:hover { background: #0f2b5c; }
+
+    .delete-overlay { display: none; position: absolute; top: 0; right: 0; bottom: 0; width: 80px; background: linear-gradient(to right, transparent, rgba(248,81,73,0.12)); align-items: center; justify-content: flex-end; padding-right: 14px; pointer-events: none; }
+    .config-card:hover .delete-overlay { display: flex; }
+    .delete-btn { font-size: 11px; font-weight: 500; color: #f85149; background: #1a0808; border: 0.5px solid #4a1515; border-radius: 5px; padding: 4px 10px; cursor: pointer; pointer-events: all; }
+
+    .discover-btn { font-size: 12px; font-weight: 500; padding: 6px 14px; border-radius: 6px; border: 0.5px solid #2d4a3e; background: #0a1f10; color: #3fb950; cursor: pointer; margin-top: 8px; }
+    .discover-btn:hover { background: #0f2b17; }
+
+    .ssl-row { display: flex; align-items: center; gap: 8px; margin-bottom: 6px; }
+    .ssl-row input { accent-color: #388bfd; }
+    .ssl-row label { font-size: 12px; color: #8b949e; cursor: pointer; }
+  </style>
 </head>
 <body class="min-h-full text-slate-200 font-sans px-4 py-12">
 
@@ -18,7 +69,17 @@
 
     <!-- Header -->
     <div class="text-center mb-6">
-      <img src="/static/logo.svg" alt="Keepup" class="w-16 h-16 mx-auto mb-4 rounded-2xl" />
+      <svg width="56" height="56" viewBox="0 0 28 28" fill="none" class="mx-auto mb-4">
+        <rect width="28" height="28" rx="7" fill="#0f1923"/>
+        <rect x="7" y="13" width="14" height="3.5" rx="1" fill="#2d3a4a"/>
+        <rect x="7" y="17.5" width="14" height="3.5" rx="1" fill="#2d3a4a"/>
+        <rect x="7" y="22" width="14" height="3.5" rx="1" fill="#2d3a4a"/>
+        <path d="M14 12.5 L14 5" stroke="#3fb950" stroke-width="2.2" stroke-linecap="round"/>
+        <path d="M10.5 8.2 L14 4.5 L17.5 8.2" fill="none" stroke="#3fb950" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"/>
+        <circle cx="9" cy="14.75" r="1.1" fill="#3fb950"/>
+        <circle cx="9" cy="19.25" r="1.1" fill="#3fb950"/>
+        <circle cx="9" cy="23.75" r="1.1" fill="#253a2d"/>
+      </svg>
       <h1 class="text-2xl font-bold text-white">Connect your infrastructure</h1>
       <p class="text-sm text-slate-400 mt-1">Add integrations to monitor. All are optional — configure them later in Admin.</p>
     </div>
@@ -34,270 +95,456 @@
       </div>
     </div>
 
-    <div class="space-y-4">
+    <!-- Icon grid -->
+    <div class="icon-grid">
 
       <!-- Proxmox VE -->
-      <div id="proxmox-section">
-        {% include 'partials/setup_proxmox_section.html' %}
-      </div>
-
-      <!-- Proxmox Backup Server -->
-      <div class="bg-slate-800/60 border border-slate-700 rounded-2xl overflow-hidden">
-        <div class="flex items-center justify-between px-5 py-4 border-b border-slate-700">
-          <div>
-            <h2 class="text-sm font-semibold text-slate-200">Proxmox Backup Server <span class="text-xs font-normal text-slate-500 ml-1">optional</span></h2>
-            <p class="text-xs text-slate-500 mt-0.5">Monitor backup jobs and PBS version updates.</p>
-          </div>
-          {% if pbs_connected %}
-          <span class="flex items-center gap-1.5 text-xs text-green-400 font-medium flex-shrink-0 ml-4">
-            <span class="w-2 h-2 rounded-full bg-green-400"></span> Connected
-          </span>
+      <div class="int-icon {% if proxmox_connected %}connected{% endif %}" id="tile-proxmox" onclick="toggleConfig('proxmox')">
+        <div class="int-logo" style="background:#3d1f00">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none">
+            <path d="M12 3L4 7.5V16.5L12 21L20 16.5V7.5L12 3Z" stroke="#ff6600" stroke-width="1.5" stroke-linejoin="round"/>
+            <path d="M12 3V21M4 7.5L20 16.5M20 7.5L4 16.5" stroke="#ff6600" stroke-width="1" opacity="0.5"/>
+          </svg>
+        </div>
+        <div class="int-name">Proxmox VE</div>
+        <div class="int-bottom">
+          {% if proxmox_connected %}
+          <span class="int-count count-green">connected</span>
+          <button class="add-btn add-btn-green" onclick="event.stopPropagation();toggleConfig('proxmox')">Edit</button>
+          {% else %}
+          <span class="int-count count-gray">optional</span>
+          <button class="add-btn add-btn-gray" onclick="event.stopPropagation();toggleConfig('proxmox')">Add</button>
           {% endif %}
         </div>
-        <div class="px-5 py-4 space-y-3">
-          <div id="pbs-result"></div>
-          <div>
-            <label class="block text-xs font-medium text-slate-400 mb-1">PBS URL</label>
-            <input type="url" id="pbs-url" name="pbs_url" value="{{ pbs_url or '' }}"
-              placeholder="https://192.168.1.11:8007"
-              class="w-full bg-slate-700 border border-slate-600 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:border-blue-500 placeholder:text-slate-500">
-          </div>
-          <div>
-            <label class="block text-xs font-medium text-slate-400 mb-1">API token</label>
-            <input type="password" id="pbs-token" name="pbs_api_token" placeholder="user@pbs!tokenname=uuid"
-              class="w-full bg-slate-700 border border-slate-600 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:border-blue-500 placeholder:text-slate-500">
-            <p class="text-xs text-slate-500 mt-1">In PBS: Configuration → Access Control → API Tokens.</p>
-          </div>
-          <label class="flex items-center gap-2 cursor-pointer select-none">
-            <input type="checkbox" id="pbs-ssl" name="pbs_verify_ssl" value="on" class="w-4 h-4 rounded accent-blue-500">
-            <span class="text-sm text-slate-300">Verify SSL certificate</span>
-          </label>
-          <div id="pbs-test-result"></div>
-          <div class="flex gap-2 items-center flex-wrap">
-            <button
-              hx-post="/setup/connect/pbs/test"
-              hx-include="#pbs-url,#pbs-token,#pbs-ssl"
-              hx-target="#pbs-test-result"
-              class="px-4 py-2 rounded-lg bg-slate-600 hover:bg-slate-500 text-sm font-medium text-slate-200 transition-colors">
-              Test connection
-            </button>
-            <button
-              hx-post="/setup/connect/pbs/save"
-              hx-include="#pbs-url,#pbs-token,#pbs-ssl"
-              hx-target="#pbs-result"
-              class="px-4 py-2 rounded-lg bg-blue-600 hover:bg-blue-500 text-sm font-medium text-white transition-colors">
-              Save
-            </button>
-          </div>
+      </div>
+
+      <!-- PBS -->
+      <div class="int-icon {% if pbs_connected %}connected{% endif %}" id="tile-pbs" onclick="toggleConfig('pbs')">
+        <div class="int-logo" style="background:#3d1f00">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none">
+            <rect x="3" y="6" width="18" height="12" rx="2" stroke="#ff6600" stroke-width="1.5"/>
+            <path d="M3 10h18M7 10v8" stroke="#ff6600" stroke-width="1"/>
+          </svg>
+        </div>
+        <div class="int-name">Backup Server</div>
+        <div class="int-bottom">
+          {% if pbs_connected %}
+          <span class="int-count count-green">connected</span>
+          <button class="add-btn add-btn-green" onclick="event.stopPropagation();toggleConfig('pbs')">Edit</button>
+          {% else %}
+          <span class="int-count count-gray">optional</span>
+          <button class="add-btn add-btn-gray" onclick="event.stopPropagation();toggleConfig('pbs')">Add</button>
+          {% endif %}
         </div>
       </div>
 
       <!-- OPNsense -->
-      <div class="bg-slate-800/60 border border-slate-700 rounded-2xl overflow-hidden">
-        <div class="flex items-center justify-between px-5 py-4 border-b border-slate-700">
-          <div>
-            <h2 class="text-sm font-semibold text-slate-200">OPNsense <span class="text-xs font-normal text-slate-500 ml-1">optional</span></h2>
-            <p class="text-xs text-slate-500 mt-0.5">Monitor firmware and package updates on your OPNsense firewall.</p>
-          </div>
-          {% if opnsense_connected %}
-          <span class="flex items-center gap-1.5 text-xs text-green-400 font-medium flex-shrink-0 ml-4">
-            <span class="w-2 h-2 rounded-full bg-green-400"></span> Connected
-          </span>
-          {% endif %}
+      <div class="int-icon {% if opnsense_connected %}connected{% endif %}" id="tile-opnsense" onclick="toggleConfig('opnsense')">
+        <div class="int-logo" style="background:#3d1500">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none">
+            <path d="M12 3C7 3 3 7 3 12C3 17 7 21 12 21C17 21 21 17 21 12C21 7 17 3 12 3Z" stroke="#d94f00" stroke-width="1.5"/>
+            <path d="M12 7v5l3 3" stroke="#d94f00" stroke-width="1.5" stroke-linecap="round"/>
+          </svg>
         </div>
-        <div class="px-5 py-4 space-y-3">
-          <div id="opnsense-result"></div>
-          <div>
-            <label class="block text-xs font-medium text-slate-400 mb-1">OPNsense URL</label>
-            <input type="url" id="opn-url" name="opnsense_url" value="{{ opnsense_url or '' }}"
-              placeholder="https://192.168.1.1"
-              class="w-full bg-slate-700 border border-slate-600 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:border-blue-500 placeholder:text-slate-500">
-          </div>
-          <div class="grid grid-cols-2 gap-3">
-            <div>
-              <label class="block text-xs font-medium text-slate-400 mb-1">API key</label>
-              <input type="text" id="opn-key" name="opnsense_api_key" placeholder="key"
-                class="w-full bg-slate-700 border border-slate-600 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:border-blue-500 placeholder:text-slate-500">
-            </div>
-            <div>
-              <label class="block text-xs font-medium text-slate-400 mb-1">API secret</label>
-              <input type="password" id="opn-secret" name="opnsense_api_secret" placeholder="secret"
-                class="w-full bg-slate-700 border border-slate-600 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:border-blue-500 placeholder:text-slate-500">
-            </div>
-          </div>
-          <p class="text-xs text-slate-500">In OPNsense: System → Access → Users → your user → API keys.</p>
-          <label class="flex items-center gap-2 cursor-pointer select-none">
-            <input type="checkbox" id="opn-ssl" name="opnsense_verify_ssl" value="on" class="w-4 h-4 rounded accent-blue-500">
-            <span class="text-sm text-slate-300">Verify SSL certificate</span>
-          </label>
-          <div id="opnsense-test-result"></div>
-          <div class="flex gap-2 items-center flex-wrap">
-            <button
-              hx-post="/setup/connect/opnsense/test"
-              hx-include="#opn-url,#opn-key,#opn-secret,#opn-ssl"
-              hx-target="#opnsense-test-result"
-              class="px-4 py-2 rounded-lg bg-slate-600 hover:bg-slate-500 text-sm font-medium text-slate-200 transition-colors">
-              Test connection
-            </button>
-            <button
-              hx-post="/setup/connect/opnsense/save"
-              hx-include="#opn-url,#opn-key,#opn-secret,#opn-ssl"
-              hx-target="#opnsense-result"
-              class="px-4 py-2 rounded-lg bg-blue-600 hover:bg-blue-500 text-sm font-medium text-white transition-colors">
-              Save
-            </button>
-          </div>
+        <div class="int-name">OPNsense</div>
+        <div class="int-bottom">
+          {% if opnsense_connected %}
+          <span class="int-count count-green">connected</span>
+          <button class="add-btn add-btn-green" onclick="event.stopPropagation();toggleConfig('opnsense')">Edit</button>
+          {% else %}
+          <span class="int-count count-gray">optional</span>
+          <button class="add-btn add-btn-gray" onclick="event.stopPropagation();toggleConfig('opnsense')">Add</button>
+          {% endif %}
         </div>
       </div>
 
       <!-- pfSense -->
-      <div class="bg-slate-800/60 border border-slate-700 rounded-2xl overflow-hidden">
-        <div class="flex items-center justify-between px-5 py-4 border-b border-slate-700">
-          <div>
-            <h2 class="text-sm font-semibold text-slate-200">pfSense <span class="text-xs font-normal text-slate-500 ml-1">optional</span></h2>
-            <p class="text-xs text-slate-500 mt-0.5">Monitor firmware updates on your pfSense firewall. Requires pfSense 2.7+ or the pfSense API package.</p>
-          </div>
+      <div class="int-icon {% if pfsense_connected %}connected{% endif %}" id="tile-pfsense" onclick="toggleConfig('pfsense')">
+        <div class="int-logo" style="background:#0c1e3d">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none">
+            <path d="M4 6h16M4 12h10M4 18h13" stroke="#2775ca" stroke-width="1.5" stroke-linecap="round"/>
+          </svg>
+        </div>
+        <div class="int-name">pfSense</div>
+        <div class="int-bottom">
           {% if pfsense_connected %}
-          <span class="flex items-center gap-1.5 text-xs text-green-400 font-medium flex-shrink-0 ml-4">
-            <span class="w-2 h-2 rounded-full bg-green-400"></span> Connected
-          </span>
+          <span class="int-count count-green">connected</span>
+          <button class="add-btn add-btn-green" onclick="event.stopPropagation();toggleConfig('pfsense')">Edit</button>
+          {% else %}
+          <span class="int-count count-gray">optional</span>
+          <button class="add-btn add-btn-gray" onclick="event.stopPropagation();toggleConfig('pfsense')">Add</button>
           {% endif %}
         </div>
-        <div class="px-5 py-4 space-y-3">
-          <div id="pfsense-result"></div>
-          <div>
-            <label class="block text-xs font-medium text-slate-400 mb-1">pfSense URL</label>
-            <input type="url" id="pf-url" name="pfsense_url" value="{{ pfsense_url or '' }}"
-              placeholder="https://192.168.1.1"
-              class="w-full bg-slate-700 border border-slate-600 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:border-blue-500 placeholder:text-slate-500">
-          </div>
-          <div>
-            <label class="block text-xs font-medium text-slate-400 mb-1">API key</label>
-            <input type="password" id="pf-key" name="pfsense_api_key" placeholder="API key"
-              class="w-full bg-slate-700 border border-slate-600 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:border-blue-500 placeholder:text-slate-500">
-          </div>
-          <label class="flex items-center gap-2 cursor-pointer select-none">
-            <input type="checkbox" id="pf-ssl" name="pfsense_verify_ssl" value="on" class="w-4 h-4 rounded accent-blue-500">
-            <span class="text-sm text-slate-300">Verify SSL certificate</span>
-          </label>
-          <div id="pfsense-test-result"></div>
-          <div class="flex gap-2 items-center flex-wrap">
-            <button
-              hx-post="/setup/connect/pfsense/test"
-              hx-include="#pf-url,#pf-key,#pf-ssl"
-              hx-target="#pfsense-test-result"
-              class="px-4 py-2 rounded-lg bg-slate-600 hover:bg-slate-500 text-sm font-medium text-slate-200 transition-colors">
-              Test connection
-            </button>
-            <button
-              hx-post="/setup/connect/pfsense/save"
-              hx-include="#pf-url,#pf-key,#pf-ssl"
-              hx-target="#pfsense-result"
-              class="px-4 py-2 rounded-lg bg-blue-600 hover:bg-blue-500 text-sm font-medium text-white transition-colors">
-              Save
-            </button>
-          </div>
+      </div>
+
+      <!-- Home Assistant -->
+      <div class="int-icon {% if homeassistant_connected %}connected{% endif %}" id="tile-homeassistant" onclick="toggleConfig('homeassistant')">
+        <div class="int-logo" style="background:#0c2a3d">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none">
+            <path d="M3 12L12 3L21 12V20a1 1 0 01-1 1H5a1 1 0 01-1-1V12z" stroke="#18bcf2" stroke-width="1.5" stroke-linejoin="round"/>
+            <rect x="9" y="14" width="6" height="7" rx="1" stroke="#18bcf2" stroke-width="1.2"/>
+          </svg>
+        </div>
+        <div class="int-name">Home Assistant</div>
+        <div class="int-bottom">
+          {% if homeassistant_connected %}
+          <span class="int-count count-green">connected</span>
+          <button class="add-btn add-btn-green" onclick="event.stopPropagation();toggleConfig('homeassistant')">Edit</button>
+          {% else %}
+          <span class="int-count count-gray">optional</span>
+          <button class="add-btn add-btn-gray" onclick="event.stopPropagation();toggleConfig('homeassistant')">Add</button>
+          {% endif %}
         </div>
       </div>
 
       <!-- Portainer -->
+      <div class="int-icon {% if portainer_connected %}connected{% endif %}" id="tile-portainer" onclick="toggleConfig('portainer')">
+        <div class="int-logo" style="background:#0c2637">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none">
+            <rect x="4" y="4" width="7" height="7" rx="1" stroke="#13bef9" stroke-width="1.5"/>
+            <rect x="4" y="13" width="7" height="7" rx="1" stroke="#13bef9" stroke-width="1.5"/>
+            <rect x="13" y="4" width="7" height="7" rx="1" stroke="#13bef9" stroke-width="1.5"/>
+            <rect x="13" y="13" width="7" height="7" rx="1" stroke="#13bef9" stroke-width="1.2" stroke-dasharray="2 1"/>
+          </svg>
+        </div>
+        <div class="int-name">Portainer</div>
+        <div class="int-bottom">
+          {% if portainer_connected %}
+          <span class="int-count count-green">connected</span>
+          <button class="add-btn add-btn-green" onclick="event.stopPropagation();toggleConfig('portainer')">Edit</button>
+          {% else %}
+          <span class="int-count count-gray">optional</span>
+          <button class="add-btn add-btn-gray" onclick="event.stopPropagation();toggleConfig('portainer')">Add</button>
+          {% endif %}
+        </div>
+      </div>
+
+      <!-- Docker Hub -->
+      <div class="int-icon {% if dockerhub_connected %}connected{% endif %}" id="tile-dockerhub" onclick="toggleConfig('dockerhub')">
+        <div class="int-logo" style="background:#0c1e3d">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none">
+            <path d="M3 12h3v3H3zM7 12h3v3H7zM11 12h3v3H11zM11 8h3v3H11zM15 8h3v3H15z" stroke="#1d63ed" stroke-width="1.2" stroke-linejoin="round"/>
+            <path d="M20 13c.5-1 .5-3-1-4" stroke="#1d63ed" stroke-width="1.2" stroke-linecap="round"/>
+            <path d="M2 15c1 2 4 3 7 3h5c3 0 4-1 4-1" stroke="#1d63ed" stroke-width="1.2" stroke-linecap="round"/>
+          </svg>
+        </div>
+        <div class="int-name">Docker Hub</div>
+        <div class="int-bottom">
+          {% if dockerhub_connected %}
+          <span class="int-count count-green">connected</span>
+          <button class="add-btn add-btn-green" onclick="event.stopPropagation();toggleConfig('dockerhub')">Edit</button>
+          {% else %}
+          <span class="int-count count-gray">optional</span>
+          <button class="add-btn add-btn-gray" onclick="event.stopPropagation();toggleConfig('dockerhub')">Add</button>
+          {% endif %}
+        </div>
+      </div>
+
+    </div><!-- /icon-grid -->
+
+    <!-- Config sections -->
+
+    <!-- Proxmox VE config -->
+    <div class="config-section" id="config-proxmox">
+      <div id="proxmox-section">
+        {% include 'partials/setup_proxmox_section.html' %}
+      </div>
+    </div>
+
+    <!-- PBS config -->
+    <div class="config-section" id="config-pbs">
+      <div class="config-card">
+        <div class="config-card-header">
+          <div class="config-card-title">
+            <div class="int-logo" style="background:#3d1f00;width:22px;height:22px;border-radius:5px;flex-shrink:0">
+              <svg width="12" height="12" viewBox="0 0 24 24" fill="none"><rect x="3" y="6" width="18" height="12" rx="2" stroke="#ff6600" stroke-width="2"/><path d="M3 10h18" stroke="#ff6600" stroke-width="1.5"/></svg>
+            </div>
+            Proxmox Backup Server
+          </div>
+          {% if pbs_connected %}<span style="font-size:11px;color:#3fb950">● Connected</span>{% endif %}
+        </div>
+        <div class="config-card-body">
+          <div id="pbs-result"></div>
+          <div class="field">
+            <div class="field-label">PBS URL</div>
+            <input type="url" id="pbs-url" name="pbs_url" value="{{ pbs_url or '' }}"
+              placeholder="https://192.168.1.11:8007" class="field-input">
+          </div>
+          <div class="field">
+            <div class="field-label">API token</div>
+            <input type="password" id="pbs-token" name="pbs_api_token" placeholder="user@pbs!tokenname=uuid" class="field-input">
+            <div class="field-hint">PBS: Configuration → Access Control → API Tokens</div>
+          </div>
+          <div class="ssl-row">
+            <input type="checkbox" id="pbs-ssl" name="pbs_verify_ssl" value="on">
+            <label for="pbs-ssl">Verify SSL certificate</label>
+          </div>
+          <div id="pbs-test-result" style="font-size:12px;margin-bottom:6px"></div>
+          <div class="btn-row">
+            <button class="btn-test"
+              hx-post="/setup/connect/pbs/test"
+              hx-include="#pbs-url,#pbs-token,#pbs-ssl"
+              hx-target="#pbs-test-result">Test connection</button>
+            <button class="btn-save"
+              hx-post="/setup/connect/pbs/save"
+              hx-include="#pbs-url,#pbs-token,#pbs-ssl"
+              hx-target="#pbs-result">Save</button>
+          </div>
+        </div>
+        <div class="delete-overlay">
+          <button class="delete-btn"
+            hx-post="/setup/connect/pbs/clear"
+            hx-confirm="Remove PBS connection?"
+            hx-target="#config-pbs"
+            hx-swap="innerHTML">Delete</button>
+        </div>
+      </div>
+    </div>
+
+    <!-- OPNsense config -->
+    <div class="config-section" id="config-opnsense">
+      <div class="config-card">
+        <div class="config-card-header">
+          <div class="config-card-title">
+            <div class="int-logo" style="background:#3d1500;width:22px;height:22px;border-radius:5px;flex-shrink:0">
+              <svg width="12" height="12" viewBox="0 0 24 24" fill="none"><path d="M12 3C7 3 3 7 3 12s4 9 9 9 9-4 9-9-4-9-9-9z" stroke="#d94f00" stroke-width="2"/><path d="M12 7v5l3 3" stroke="#d94f00" stroke-width="1.5" stroke-linecap="round"/></svg>
+            </div>
+            OPNsense
+          </div>
+          {% if opnsense_connected %}<span style="font-size:11px;color:#3fb950">● Connected</span>{% endif %}
+        </div>
+        <div class="config-card-body">
+          <div id="opnsense-result"></div>
+          <div class="field">
+            <div class="field-label">OPNsense URL</div>
+            <input type="url" id="opn-url" name="opnsense_url" value="{{ opnsense_url or '' }}"
+              placeholder="https://192.168.1.1" class="field-input">
+          </div>
+          <div class="field-row">
+            <div class="field">
+              <div class="field-label">API key</div>
+              <input type="text" id="opn-key" name="opnsense_api_key" placeholder="key" class="field-input">
+            </div>
+            <div class="field">
+              <div class="field-label">API secret</div>
+              <input type="password" id="opn-secret" name="opnsense_api_secret" placeholder="secret" class="field-input">
+            </div>
+          </div>
+          <div class="field-hint" style="margin-bottom:8px">OPNsense: System → Access → Users → your user → API keys</div>
+          <div class="ssl-row">
+            <input type="checkbox" id="opn-ssl" name="opnsense_verify_ssl" value="on">
+            <label for="opn-ssl">Verify SSL certificate</label>
+          </div>
+          <div id="opnsense-test-result" style="font-size:12px;margin-bottom:6px"></div>
+          <div class="btn-row">
+            <button class="btn-test"
+              hx-post="/setup/connect/opnsense/test"
+              hx-include="#opn-url,#opn-key,#opn-secret,#opn-ssl"
+              hx-target="#opnsense-test-result">Test connection</button>
+            <button class="btn-save"
+              hx-post="/setup/connect/opnsense/save"
+              hx-include="#opn-url,#opn-key,#opn-secret,#opn-ssl"
+              hx-target="#opnsense-result">Save</button>
+          </div>
+        </div>
+        <div class="delete-overlay">
+          <button class="delete-btn"
+            hx-post="/setup/connect/opnsense/clear"
+            hx-confirm="Remove OPNsense connection?"
+            hx-target="#config-opnsense"
+            hx-swap="innerHTML">Delete</button>
+        </div>
+      </div>
+    </div>
+
+    <!-- pfSense config -->
+    <div class="config-section" id="config-pfsense">
+      <div class="config-card">
+        <div class="config-card-header">
+          <div class="config-card-title">
+            <div class="int-logo" style="background:#0c1e3d;width:22px;height:22px;border-radius:5px;flex-shrink:0">
+              <svg width="12" height="12" viewBox="0 0 24 24" fill="none"><path d="M4 6h16M4 12h10M4 18h13" stroke="#2775ca" stroke-width="2" stroke-linecap="round"/></svg>
+            </div>
+            pfSense
+          </div>
+          {% if pfsense_connected %}<span style="font-size:11px;color:#3fb950">● Connected</span>{% endif %}
+        </div>
+        <div class="config-card-body">
+          <div id="pfsense-result"></div>
+          <div class="field">
+            <div class="field-label">pfSense URL</div>
+            <input type="url" id="pf-url" name="pfsense_url" value="{{ pfsense_url or '' }}"
+              placeholder="https://192.168.1.1" class="field-input">
+          </div>
+          <div class="field">
+            <div class="field-label">API key</div>
+            <input type="password" id="pf-key" name="pfsense_api_key" placeholder="API key" class="field-input">
+          </div>
+          <div class="ssl-row">
+            <input type="checkbox" id="pf-ssl" name="pfsense_verify_ssl" value="on">
+            <label for="pf-ssl">Verify SSL certificate</label>
+          </div>
+          <div id="pfsense-test-result" style="font-size:12px;margin-bottom:6px"></div>
+          <div class="btn-row">
+            <button class="btn-test"
+              hx-post="/setup/connect/pfsense/test"
+              hx-include="#pf-url,#pf-key,#pf-ssl"
+              hx-target="#pfsense-test-result">Test connection</button>
+            <button class="btn-save"
+              hx-post="/setup/connect/pfsense/save"
+              hx-include="#pf-url,#pf-key,#pf-ssl"
+              hx-target="#pfsense-result">Save</button>
+          </div>
+        </div>
+        <div class="delete-overlay">
+          <button class="delete-btn"
+            hx-post="/setup/connect/pfsense/clear"
+            hx-confirm="Remove pfSense connection?"
+            hx-target="#config-pfsense"
+            hx-swap="innerHTML">Delete</button>
+        </div>
+      </div>
+    </div>
+
+    <!-- Home Assistant config -->
+    <div class="config-section" id="config-homeassistant">
+      <div class="config-card">
+        <div class="config-card-header">
+          <div class="config-card-title">
+            <div class="int-logo" style="background:#0c2a3d;width:22px;height:22px;border-radius:5px;flex-shrink:0">
+              <svg width="12" height="12" viewBox="0 0 24 24" fill="none"><path d="M3 12L12 3L21 12V20a1 1 0 01-1 1H5a1 1 0 01-1-1V12z" stroke="#18bcf2" stroke-width="2" stroke-linejoin="round"/></svg>
+            </div>
+            Home Assistant
+          </div>
+          {% if homeassistant_connected %}<span style="font-size:11px;color:#3fb950">● Connected</span>{% endif %}
+        </div>
+        <div class="config-card-body">
+          <div class="ha-notice">
+            Home Assistant can be monitored for updates but cannot be auto-updated from keepup.
+            Updates must be applied from within Home Assistant.
+          </div>
+          <div id="ha-result"></div>
+          <div class="field">
+            <div class="field-label">Home Assistant URL</div>
+            <input type="url" id="ha-url" name="ha_url" value="{{ homeassistant_url or '' }}"
+              placeholder="http://homeassistant.local:8123" class="field-input">
+          </div>
+          <div class="field">
+            <div class="field-label">Long-lived access token</div>
+            <input type="password" id="ha-token" name="ha_token" placeholder="eyJ…" class="field-input">
+            <div class="field-hint">Home Assistant: Profile → Long-lived access tokens → Create token</div>
+          </div>
+          <div id="ha-test-result" style="font-size:12px;margin-bottom:6px"></div>
+          <div class="btn-row">
+            <button class="btn-test"
+              hx-post="/setup/connect/homeassistant/test"
+              hx-include="#ha-url,#ha-token"
+              hx-target="#ha-test-result">Test connection</button>
+            <button class="btn-save"
+              hx-post="/setup/connect/homeassistant/save"
+              hx-include="#ha-url,#ha-token"
+              hx-target="#ha-result">Save</button>
+          </div>
+        </div>
+        <div class="delete-overlay">
+          <button class="delete-btn"
+            hx-post="/setup/connect/homeassistant/clear"
+            hx-confirm="Remove Home Assistant connection?"
+            hx-target="#config-homeassistant"
+            hx-swap="innerHTML">Delete</button>
+        </div>
+      </div>
+    </div>
+
+    <!-- Portainer config -->
+    <div class="config-section" id="config-portainer">
       <div id="portainer-section">
         {% include 'partials/setup_portainer_section.html' %}
       </div>
+    </div>
 
-      <!-- Home Assistant -->
-      <div class="bg-slate-800/60 border border-slate-700 rounded-2xl overflow-hidden">
-        <div class="flex items-center justify-between px-5 py-4 border-b border-slate-700">
-          <div>
-            <h2 class="text-sm font-semibold text-slate-200">Home Assistant <span class="text-xs font-normal text-slate-500 ml-1">optional</span></h2>
-            <p class="text-xs text-slate-500 mt-0.5">Get notified when a Home Assistant update is available. Keepup cannot install HA updates automatically.</p>
+    <!-- Docker Hub config -->
+    <div class="config-section" id="config-dockerhub">
+      <div class="config-card">
+        <div class="config-card-header">
+          <div class="config-card-title">
+            <div class="int-logo" style="background:#0c1e3d;width:22px;height:22px;border-radius:5px;flex-shrink:0">
+              <svg width="12" height="12" viewBox="0 0 24 24" fill="none"><path d="M3 12h3v3H3zM7 12h3v3H7zM11 12h3v3H11zM11 8h3v3H11zM15 8h3v3H15z" stroke="#1d63ed" stroke-width="1.5" stroke-linejoin="round"/></svg>
+            </div>
+            Docker Hub
           </div>
-          {% if homeassistant_connected %}
-          <span class="flex items-center gap-1.5 text-xs text-green-400 font-medium flex-shrink-0 ml-4">
-            <span class="w-2 h-2 rounded-full bg-green-400"></span> Connected
-          </span>
-          {% endif %}
+          {% if dockerhub_connected %}<span style="font-size:11px;color:#3fb950">● Connected</span>{% endif %}
         </div>
-        <div class="px-5 py-4 space-y-3">
-          <div id="ha-result"></div>
-          <div>
-            <label class="block text-xs font-medium text-slate-400 mb-1">Home Assistant URL</label>
-            <input type="url" id="ha-url" name="ha_url" value="{{ homeassistant_url or '' }}"
-              placeholder="http://homeassistant.local:8123"
-              class="w-full bg-slate-700 border border-slate-600 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:border-blue-500 placeholder:text-slate-500">
-          </div>
-          <div>
-            <label class="block text-xs font-medium text-slate-400 mb-1">Long-lived access token</label>
-            <input type="password" id="ha-token" name="ha_token" placeholder="eyJ…"
-              class="w-full bg-slate-700 border border-slate-600 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:border-blue-500 placeholder:text-slate-500">
-            <p class="text-xs text-slate-500 mt-1">In Home Assistant: Profile → Long-lived access tokens → Create token.</p>
-          </div>
-          <div id="ha-test-result"></div>
-          <div class="flex gap-2 items-center flex-wrap">
-            <button
-              hx-post="/setup/connect/homeassistant/test"
-              hx-include="#ha-url,#ha-token"
-              hx-target="#ha-test-result"
-              class="px-4 py-2 rounded-lg bg-slate-600 hover:bg-slate-500 text-sm font-medium text-slate-200 transition-colors">
-              Test connection
-            </button>
-            <button
-              hx-post="/setup/connect/homeassistant/save"
-              hx-include="#ha-url,#ha-token"
-              hx-target="#ha-result"
-              class="px-4 py-2 rounded-lg bg-blue-600 hover:bg-blue-500 text-sm font-medium text-white transition-colors">
-              Save
-            </button>
-          </div>
-        </div>
-      </div>
-
-      <!-- DockerHub -->
-      <div class="bg-slate-800/60 border border-slate-700 rounded-2xl overflow-hidden">
-        <div class="flex items-center justify-between px-5 py-4 border-b border-slate-700">
-          <div>
-            <h2 class="text-sm font-semibold text-slate-200">Docker Hub <span class="text-xs font-normal text-slate-500 ml-1">optional</span></h2>
-            <p class="text-xs text-slate-500 mt-0.5">Authenticate to avoid rate limits and check private image updates.</p>
-          </div>
-          {% if dockerhub_connected %}
-          <span class="flex items-center gap-1.5 text-xs text-green-400 font-medium flex-shrink-0 ml-4">
-            <span class="w-2 h-2 rounded-full bg-green-400"></span> Saved
-          </span>
-          {% endif %}
-        </div>
-        <div class="px-5 py-4 space-y-3">
+        <div class="config-card-body">
           <div id="dockerhub-result"></div>
-          <form hx-post="/setup/dockerhub/save" hx-target="#dockerhub-result" class="space-y-3">
-            <div>
-              <label class="block text-xs font-medium text-slate-400 mb-1">Docker Hub username</label>
-              <input type="text" name="dockerhub_username" placeholder="myusername"
-                class="w-full bg-slate-700 border border-slate-600 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:border-blue-500 placeholder:text-slate-500">
+          <form hx-post="/setup/dockerhub/save" hx-target="#dockerhub-result">
+            <div class="field">
+              <div class="field-label">Docker Hub username</div>
+              <input type="text" name="dockerhub_username" placeholder="myusername" class="field-input">
             </div>
-            <div>
-              <label class="block text-xs font-medium text-slate-400 mb-1">Access token</label>
-              <input type="password" name="dockerhub_token" placeholder="dckr_pat_…"
-                class="w-full bg-slate-700 border border-slate-600 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:border-blue-500 placeholder:text-slate-500">
-              <p class="text-xs text-slate-500 mt-1">In Docker Hub: Account Settings → Security → New access token.</p>
+            <div class="field">
+              <div class="field-label">Access token</div>
+              <input type="password" name="dockerhub_token" placeholder="dckr_pat_…" class="field-input">
+              <div class="field-hint">Docker Hub: Account Settings → Security → New access token</div>
             </div>
-            <button type="submit"
-              class="px-4 py-2 rounded-lg bg-blue-600 hover:bg-blue-500 text-sm font-medium text-white transition-colors">
-              Save
-            </button>
+            <div class="btn-row">
+              <button type="submit" class="btn-save">Save</button>
+            </div>
           </form>
         </div>
+        <div class="delete-overlay">
+          <button class="delete-btn"
+            hx-post="/setup/dockerhub/clear"
+            hx-confirm="Remove Docker Hub credentials?"
+            hx-target="#config-dockerhub"
+            hx-swap="innerHTML">Delete</button>
+        </div>
       </div>
-
-      <!-- Navigation -->
-      <div class="flex justify-between items-center pt-2">
-        <a href="/setup/hosts" class="text-sm text-slate-500 hover:text-slate-300">Skip — configure later</a>
-        <a href="/setup/hosts"
-          class="px-6 py-2.5 rounded-xl bg-blue-600 hover:bg-blue-500 text-sm font-semibold text-white transition-colors">
-          Continue to SSH setup →
-        </a>
-      </div>
-
     </div>
+
+    <!-- Navigation -->
+    <div class="flex justify-between items-center pt-4">
+      <a href="/setup/hosts" class="text-sm text-slate-500 hover:text-slate-300">Skip — configure later</a>
+      <a href="/setup/hosts"
+        class="px-6 py-2.5 rounded-xl bg-blue-600 hover:bg-blue-500 text-sm font-semibold text-white transition-colors">
+        Continue to SSH setup →
+      </a>
+    </div>
+
   </div>
+
+  <script>
+  function toggleConfig(id) {
+    const section = document.getElementById('config-' + id);
+    const tile = document.getElementById('tile-' + id);
+    const allSections = document.querySelectorAll('.config-section');
+    const allTiles = document.querySelectorAll('.int-icon');
+
+    const isOpen = section.style.display === 'block';
+
+    // Close all
+    allSections.forEach(s => s.style.display = 'none');
+    allTiles.forEach(t => t.classList.remove('active'));
+
+    // Open this one if it was closed
+    if (!isOpen) {
+      section.style.display = 'block';
+      tile.classList.add('active');
+      section.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+    }
+  }
+
+  // Auto-open config sections for already-connected integrations
+  document.addEventListener('DOMContentLoaded', function() {
+    {% if proxmox_connected %}toggleConfig('proxmox');{% endif %}
+    {% if pbs_connected %}toggleConfig('pbs');{% endif %}
+    {% if opnsense_connected %}toggleConfig('opnsense');{% endif %}
+    {% if pfsense_connected %}toggleConfig('pfsense');{% endif %}
+    {% if homeassistant_connected %}toggleConfig('homeassistant');{% endif %}
+    {% if portainer_connected %}toggleConfig('portainer');{% endif %}
+    {% if dockerhub_connected %}toggleConfig('dockerhub');{% endif %}
+  });
+  </script>
 
 </body>
 </html>

--- a/app/templates/setup_containers.html
+++ b/app/templates/setup_containers.html
@@ -1,0 +1,206 @@
+<!DOCTYPE html>
+<html lang="en" class="h-full">
+<head>
+  <meta charset="UTF-8" />
+  <link rel="icon" type="image/svg+xml" href="/static/favicon.svg" />
+  <link rel="apple-touch-icon" href="/static/icon-192.svg" />
+  <link rel="manifest" href="/static/manifest.json" />
+  <meta name="theme-color" content="#0d1117" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Container Monitoring — Keepup Setup</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script src="https://unpkg.com/htmx.org@1.9.10"></script>
+  <style>
+    body { background-color: #0d1117; }
+    .host-block { background: #161b22; border: 0.5px solid #21262d; border-radius: 10px; overflow: hidden; margin-bottom: 14px; }
+    .host-block-header { display: flex; align-items: center; justify-content: space-between; padding: 12px 16px; border-bottom: 0.5px solid #21262d; background: #0d1117; }
+    .host-info .host-name { font-size: 13px; font-weight: 500; color: #e6edf3; }
+    .host-info .host-ip { font-size: 11px; color: #484f58; font-family: monospace; margin-top: 1px; }
+    .host-actions { display: flex; gap: 6px; }
+    .sel-btn { font-size: 11px; font-weight: 500; padding: 4px 10px; border-radius: 5px; border: 0.5px solid #30363d; background: transparent; color: #8b949e; cursor: pointer; }
+    .sel-btn:hover { background: #161b22; color: #e6edf3; border-color: #484f58; }
+    .container-list { padding: 4px 0; }
+    .container-row { display: flex; align-items: center; justify-content: space-between; padding: 9px 16px; border-bottom: 0.5px solid #1a1f26; cursor: pointer; transition: background 0.1s; }
+    .container-row:last-child { border-bottom: none; }
+    .container-row:hover { background: #1a1f26; }
+    .ct-left { display: flex; align-items: center; gap: 10px; }
+    .ct-name { font-size: 13px; color: #e6edf3; }
+    .ct-image { font-size: 11px; color: #484f58; font-family: monospace; margin-top: 1px; }
+    .checkbox { width: 16px; height: 16px; border-radius: 4px; border: 0.5px solid #30363d; background: #0d1117; display: flex; align-items: center; justify-content: center; flex-shrink: 0; transition: background 0.1s, border-color 0.1s; }
+    .checkbox.checked { background: #0c2045; border-color: #388bfd; }
+    .host-block-footer { padding: 9px 16px; border-top: 0.5px solid #21262d; font-size: 11px; color: #484f58; }
+    .ct-count-active { color: #388bfd; }
+    .skip-link { text-align: center; font-size: 12px; color: #484f58; margin-top: 16px; }
+    .skip-link a { color: #484f58; text-decoration: none; }
+    .skip-link a:hover { color: #8b949e; }
+  </style>
+</head>
+<body class="min-h-full text-slate-200 font-sans px-4 py-12">
+
+  <div class="w-full max-w-2xl mx-auto">
+
+    <!-- Header -->
+    <div class="text-center mb-6">
+      <div class="w-16 h-16 mx-auto mb-4 rounded-2xl flex items-center justify-center" style="background:#0d1117;border:1px solid #21262d;">
+        <svg width="44" height="44" viewBox="0 0 28 28" fill="none"><rect width="28" height="28" rx="7" fill="#0f1923"/><rect x="7" y="13" width="14" height="3.5" rx="1" fill="#2d3a4a"/><rect x="7" y="17.5" width="14" height="3.5" rx="1" fill="#2d3a4a"/><rect x="7" y="22" width="14" height="3.5" rx="1" fill="#2d3a4a"/><path d="M14 12.5 L14 5" stroke="#3fb950" stroke-width="2.2" stroke-linecap="round"/><path d="M10.5 8.2 L14 4.5 L17.5 8.2" fill="none" stroke="#3fb950" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"/><circle cx="9" cy="14.75" r="1.1" fill="#3fb950"/><circle cx="9" cy="19.25" r="1.1" fill="#3fb950"/><circle cx="9" cy="23.75" r="1.1" fill="#253a2d"/></svg>
+      </div>
+      <h1 class="text-2xl font-bold text-white">Container monitoring</h1>
+      <p class="text-sm text-slate-400 mt-1">Choose which containers to monitor for image updates on each host.</p>
+    </div>
+
+    <!-- Progress bar -->
+    <div class="mb-8">
+      <div class="flex justify-between text-xs text-slate-500 mb-1">
+        <span>Step 7 of 8</span>
+        <span>Containers</span>
+      </div>
+      <div class="w-full bg-slate-700 rounded-full h-1.5">
+        <div class="bg-blue-500 h-1.5 rounded-full" style="width: 87.5%"></div>
+      </div>
+    </div>
+
+    <form method="post" action="/setup/containers/save">
+
+      {% if hosts %}
+
+        {% set has_any_containers = hosts | selectattr('containers') | list | length > 0 %}
+
+        {% if has_any_containers %}
+          {% for host in hosts %}
+            {% if host.containers %}
+            <div class="host-block" id="block-{{ host.id }}">
+              <div class="host-block-header">
+                <div class="host-info">
+                  <div class="host-name">{{ host.name }}</div>
+                  <div class="host-ip">{{ host.ip }}</div>
+                </div>
+                <div class="host-actions">
+                  <button type="button" class="sel-btn" onclick="selectAll('{{ host.id }}')">Select all</button>
+                  <button type="button" class="sel-btn" onclick="deselectAll('{{ host.id }}')">Deselect all</button>
+                </div>
+              </div>
+              <div class="container-list" id="{{ host.id }}-list">
+                {% for ct in host.containers %}
+                <div class="container-row" onclick="toggle(this)">
+                  <div class="ct-left">
+                    <div class="checkbox checked">
+                      <svg width="10" height="10" viewBox="0 0 10 10" fill="none">
+                        <path d="M2 5l2 2 4-4" stroke="#388bfd" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+                      </svg>
+                    </div>
+                    <div>
+                      <div class="ct-name">{{ ct.name }}</div>
+                      <div class="ct-image">{{ ct.image }}</div>
+                    </div>
+                  </div>
+                  <input type="checkbox" name="containers" value="{{ host.id }}:{{ ct.id }}"
+                         checked class="hidden-input" style="display:none"/>
+                </div>
+                {% endfor %}
+              </div>
+              <div class="host-block-footer">
+                <span id="{{ host.id }}-count" class="ct-count-active">
+                  {{ host.containers | length }} of {{ host.containers | length }} selected
+                </span>
+              </div>
+            </div>
+            {% else %}
+            <div class="host-block" id="block-{{ host.id }}">
+              <div class="host-block-header">
+                <div class="host-info">
+                  <div class="host-name">{{ host.name }}</div>
+                  <div class="host-ip">{{ host.ip }}</div>
+                </div>
+              </div>
+              <div class="px-4 py-5 text-center">
+                <p class="text-sm text-slate-500">No running containers found on this host.</p>
+                <p class="text-xs text-slate-600 mt-1">Docker may not be installed or no containers are currently running.</p>
+              </div>
+            </div>
+            {% endif %}
+          {% endfor %}
+
+        {% else %}
+          <!-- No containers on any host -->
+          <div class="bg-[#161b22] border border-[#21262d] rounded-xl px-5 py-8 text-center mb-6">
+            <div class="w-10 h-10 rounded-full bg-[#21262d] flex items-center justify-center mx-auto mb-3">
+              <svg width="18" height="18" viewBox="0 0 16 16" fill="none"><rect x="1" y="3" width="14" height="10" rx="2" stroke="#484f58" stroke-width="1.2"/><path d="M5 8h6M8 5v6" stroke="#484f58" stroke-width="1.2" stroke-linecap="round"/></svg>
+            </div>
+            <p class="text-sm font-medium text-slate-400">No containers found</p>
+            <p class="text-xs text-slate-600 mt-1">Docker isn't running on any of your SSH hosts, or no containers are active.</p>
+          </div>
+        {% endif %}
+
+      {% else %}
+        <!-- No SSH hosts -->
+        <div class="bg-[#161b22] border border-[#21262d] rounded-xl px-5 py-8 text-center mb-6">
+          <p class="text-sm font-medium text-slate-400">No SSH hosts configured</p>
+          <p class="text-xs text-slate-600 mt-1">Go back and add SSH hosts first.</p>
+        </div>
+      {% endif %}
+
+      <!-- Bottom buttons -->
+      <div class="flex justify-between items-center mt-2">
+        <a href="/setup/hosts" class="text-sm text-slate-500 hover:text-slate-300">← Back</a>
+        <button type="submit"
+          class="px-6 py-2.5 rounded-xl bg-blue-600 hover:bg-blue-500 text-sm font-semibold text-white transition-colors">
+          Continue to Notifications →
+        </button>
+      </div>
+
+    </form>
+
+    <div class="skip-link mt-4">
+      <a href="/setup/notifications">Skip — I'll set this up later in Admin</a>
+    </div>
+
+  </div>
+
+  <script>
+    const CHECK_SVG = `<svg width="10" height="10" viewBox="0 0 10 10" fill="none">
+      <path d="M2 5l2 2 4-4" stroke="#388bfd" stroke-width="1.5"
+            stroke-linecap="round" stroke-linejoin="round"/>
+    </svg>`;
+
+    function toggle(row) {
+      const cb = row.querySelector('.checkbox');
+      const checked = cb.classList.toggle('checked');
+      cb.innerHTML = checked ? CHECK_SVG : '';
+      row.querySelector('.hidden-input').checked = checked;
+      updateCount(row.closest('.container-list'));
+    }
+
+    function selectAll(id) {
+      document.querySelectorAll('#' + id + '-list .container-row').forEach(row => {
+        const cb = row.querySelector('.checkbox');
+        cb.classList.add('checked');
+        cb.innerHTML = CHECK_SVG;
+        row.querySelector('.hidden-input').checked = true;
+      });
+      updateCount(document.getElementById(id + '-list'));
+    }
+
+    function deselectAll(id) {
+      document.querySelectorAll('#' + id + '-list .container-row').forEach(row => {
+        const cb = row.querySelector('.checkbox');
+        cb.classList.remove('checked');
+        cb.innerHTML = '';
+        row.querySelector('.hidden-input').checked = false;
+      });
+      updateCount(document.getElementById(id + '-list'));
+    }
+
+    function updateCount(list) {
+      const id = list.id.replace('-list', '');
+      const total = list.querySelectorAll('.container-row').length;
+      const selected = list.querySelectorAll('.checkbox.checked').length;
+      const el = document.getElementById(id + '-count');
+      if (el) {
+        el.textContent = selected + ' of ' + total + ' selected';
+        el.className = selected > 0 ? 'ct-count-active' : '';
+      }
+    }
+  </script>
+
+</body>
+</html>

--- a/app/templates/setup_hosts.html
+++ b/app/templates/setup_hosts.html
@@ -44,9 +44,9 @@
       <!-- Bottom buttons -->
       <div class="flex justify-between items-center mt-2">
         <a href="/setup/connect" class="text-sm text-slate-500 hover:text-slate-300">← Back</a>
-        <a href="/setup/notifications"
+        <a href="/setup/containers"
           class="px-6 py-2.5 rounded-xl bg-blue-600 hover:bg-blue-500 text-sm font-semibold text-white transition-colors">
-          Continue to Notifications →
+          Continue to Containers →
         </a>
       </div>
 

--- a/app/templates/setup_notifications.html
+++ b/app/templates/setup_notifications.html
@@ -61,11 +61,11 @@
     <!-- Progress bar -->
     <div class="mb-8">
       <div class="flex justify-between text-xs text-slate-500 mb-1">
-        <span>Step 7 of 8</span>
+        <span>Step 8 of 8</span>
         <span>Notifications</span>
       </div>
       <div class="w-full bg-slate-700 rounded-full h-1.5">
-        <div class="bg-blue-500 h-1.5 rounded-full" style="width: 87%"></div>
+        <div class="bg-blue-500 h-1.5 rounded-full" style="width: 100%"></div>
       </div>
     </div>
 
@@ -279,7 +279,7 @@
 
       <!-- Bottom buttons -->
       <div class="flex justify-between items-center mt-2">
-        <a href="/setup/hosts" class="text-sm text-slate-500 hover:text-slate-300">← Back</a>
+        <a href="/setup/containers" class="text-sm text-slate-500 hover:text-slate-300">← Back</a>
         <a href="/setup/summary"
           class="inline-flex items-center gap-2 px-6 py-2.5 rounded-xl bg-green-600 hover:bg-green-500 text-sm font-semibold text-white transition-colors">
           <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/app/templates/setup_notifications.html
+++ b/app/templates/setup_notifications.html
@@ -10,7 +10,42 @@
   <title>Notifications — Keepup Setup</title>
   <script src="https://cdn.tailwindcss.com"></script>
   <script src="https://unpkg.com/htmx.org@1.9.10"></script>
-  <style>body { background-color: #0d1117; }</style>
+  <style>
+    body { background-color: #0d1117; }
+    .icon-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 0.75rem; }
+    .notif-icon {
+      display: flex; flex-direction: column; align-items: center;
+      gap: 0.5rem; padding: 1rem 0.5rem; border-radius: 1rem;
+      background: rgba(30,41,59,0.6); border: 1px solid #334155;
+      cursor: pointer; transition: border-color 0.15s, background 0.15s;
+      position: relative;
+    }
+    .notif-icon:hover { border-color: #3b82f6; background: rgba(30,41,59,0.9); }
+    .notif-icon.connected { border-color: #22c55e; }
+    .notif-icon.connected .badge { background: #166534; color: #4ade80; }
+    .notif-icon.active { border-color: #3b82f6; background: rgba(30,58,138,0.3); }
+    .badge {
+      font-size: 0.6rem; font-weight: 600; padding: 0.1rem 0.4rem;
+      border-radius: 9999px; background: #1e293b; color: #94a3b8; text-transform: uppercase; letter-spacing: 0.05em;
+    }
+    .config-section { display: none; margin-top: 0.75rem; }
+    .config-card {
+      background: rgba(30,41,59,0.6); border: 1px solid #334155;
+      border-radius: 1rem; overflow: hidden; position: relative;
+    }
+    .delete-overlay {
+      position: absolute; inset: 0; background: rgba(15,23,42,0.85);
+      display: flex; align-items: center; justify-content: center;
+      opacity: 0; transition: opacity 0.15s; border-radius: 1rem; z-index: 10;
+    }
+    .config-card:hover .delete-overlay { opacity: 1; }
+    .delete-btn {
+      padding: 0.4rem 1rem; border-radius: 0.5rem;
+      background: #7f1d1d; color: #fca5a5; font-size: 0.75rem;
+      font-weight: 600; border: 1px solid #991b1b; cursor: pointer;
+    }
+    .delete-btn:hover { background: #991b1b; }
+  </style>
 </head>
 <body class="min-h-full text-slate-200 font-sans px-4 py-12">
 
@@ -36,63 +71,180 @@
 
     <div class="space-y-6">
 
-      <!-- Pushover -->
-      <div class="bg-slate-800/60 border border-slate-700 rounded-2xl overflow-hidden">
-        <div class="px-5 py-4 border-b border-slate-700">
-          <h2 class="text-sm font-semibold text-slate-200">Pushover <span class="text-xs font-normal text-slate-500 ml-1">optional</span></h2>
-          <p class="text-xs text-slate-500 mt-0.5">Push notifications to your phone when image updates are available.</p>
-        </div>
-        <div class="px-5 py-4 space-y-4">
+      <!-- Info notice -->
+      <div class="flex gap-3 px-4 py-3 rounded-xl bg-slate-800/60 border border-slate-700 text-sm text-slate-400">
+        <svg class="w-4 h-4 mt-0.5 shrink-0 text-slate-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+            d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/>
+        </svg>
+        Notifications fire when auto-update jobs complete or fail. You can configure which events trigger alerts after setup in Admin → Notifications.
+      </div>
 
-          {% if pushover_token_set and pushover_user_set %}
-          <div class="flex items-center gap-2 text-green-400 text-sm">
-            <span>&#10003;</span>
-            <span>Pushover credentials saved{% if pushover_enabled %} — notifications enabled{% else %} — notifications disabled{% endif %}</span>
+      <!-- Notification provider icon grid -->
+      <div>
+        <p class="text-xs font-medium text-slate-500 uppercase tracking-wider mb-3">Notification providers</p>
+        <div class="icon-grid">
+
+          <!-- Email tile -->
+          <div class="notif-icon {% if email_configured %}connected{% endif %}"
+               id="tile-email"
+               onclick="toggleConfig('email')">
+            <svg class="w-8 h-8" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
+              <rect x="2" y="4" width="20" height="16" rx="2" fill="#1e3a5f" stroke="#3b82f6"/>
+              <path d="M2 7l10 7 10-7" stroke="#3b82f6" stroke-width="1.5"/>
+            </svg>
+            <span class="text-xs font-medium text-slate-200">Email</span>
+            <span class="badge">{% if email_configured %}connected{% else %}optional{% endif %}</span>
           </div>
-          {% endif %}
 
-          <div id="pushover-result"></div>
+          <!-- Pushover tile -->
+          <div class="notif-icon {% if pushover_token_set and pushover_user_set %}connected{% endif %}"
+               id="tile-pushover"
+               onclick="toggleConfig('pushover')">
+            <svg class="w-8 h-8" viewBox="0 0 24 24" fill="none">
+              <rect width="24" height="24" rx="6" fill="#1a2b1a"/>
+              <path d="M7 17V7l5 3.5L17 7v10" stroke="#4ade80" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+            </svg>
+            <span class="text-xs font-medium text-slate-200">Pushover</span>
+            <span class="badge">{% if pushover_token_set and pushover_user_set %}connected{% else %}optional{% endif %}</span>
+          </div>
 
-          <form hx-post="/setup/notifications/pushover/save"
-                hx-target="#pushover-result"
-                class="space-y-3">
-            <div class="grid grid-cols-2 gap-3">
-              <div>
-                <label class="block text-xs font-medium text-slate-400 mb-1">App token</label>
-                <input type="password" name="pushover_token"
-                  placeholder="{% if pushover_token_set %}already set{% else %}a1b2c3...{% endif %}"
-                  class="w-full bg-slate-700 border border-slate-600 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:border-blue-500 placeholder:text-slate-500">
+        </div>
+      </div>
+
+      <!-- Email config section -->
+      <div class="config-section" id="config-email">
+        <div class="config-card">
+          <div class="delete-overlay">
+            <button class="delete-btn"
+              hx-post="/setup/notifications/email/delete"
+              hx-target="#config-email"
+              hx-swap="outerHTML"
+              onclick="event.stopPropagation(); document.getElementById('tile-email').classList.remove('connected','active');">
+              Remove email config
+            </button>
+          </div>
+          <div class="px-5 py-4 border-b border-slate-700">
+            <h2 class="text-sm font-semibold text-slate-200">Email (SMTP)</h2>
+            <p class="text-xs text-slate-500 mt-0.5">Send notifications via your own SMTP server.</p>
+          </div>
+          <div class="px-5 py-4 space-y-4">
+            <div id="email-result"></div>
+            <form hx-post="/setup/notifications/email/save"
+                  hx-target="#email-result"
+                  class="space-y-3">
+              <div class="grid grid-cols-2 gap-3">
+                <div>
+                  <label class="block text-xs font-medium text-slate-400 mb-1">Sender name</label>
+                  <input type="text" name="sender_name" value="{{ email_sender_name }}"
+                    placeholder="Keepup"
+                    class="w-full bg-slate-700 border border-slate-600 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:border-blue-500 placeholder:text-slate-500">
+                </div>
+                <div>
+                  <label class="block text-xs font-medium text-slate-400 mb-1">Sender address</label>
+                  <input type="email" name="sender_address" value="{{ email_sender }}"
+                    placeholder="keepup@example.com"
+                    class="w-full bg-slate-700 border border-slate-600 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:border-blue-500 placeholder:text-slate-500">
+                </div>
               </div>
               <div>
-                <label class="block text-xs font-medium text-slate-400 mb-1">User key</label>
-                <input type="password" name="pushover_user_key"
-                  placeholder="{% if pushover_user_set %}already set{% else %}u1v2w3...{% endif %}"
+                <label class="block text-xs font-medium text-slate-400 mb-1">Recipient address</label>
+                <input type="email" name="recipient_address" value="{{ email_recipient }}"
+                  placeholder="you@example.com"
                   class="w-full bg-slate-700 border border-slate-600 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:border-blue-500 placeholder:text-slate-500">
               </div>
-            </div>
-            <p class="text-xs text-slate-500">Find these at <span class="text-slate-400">pushover.net</span> — App token under your application, User key on your profile.</p>
+              <div class="grid grid-cols-2 gap-3">
+                <div>
+                  <label class="block text-xs font-medium text-slate-400 mb-1">SMTP host</label>
+                  <input type="text" name="smtp_host" value="{{ email_smtp_host }}"
+                    placeholder="smtp.example.com"
+                    class="w-full bg-slate-700 border border-slate-600 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:border-blue-500 placeholder:text-slate-500">
+                </div>
+                <div>
+                  <label class="block text-xs font-medium text-slate-400 mb-1">SMTP port</label>
+                  <input type="number" name="smtp_port" value="{{ email_smtp_port }}"
+                    placeholder="587"
+                    class="w-full bg-slate-700 border border-slate-600 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:border-blue-500 placeholder:text-slate-500">
+                </div>
+              </div>
+              <div>
+                <label class="block text-xs font-medium text-slate-400 mb-1">SMTP password</label>
+                <input type="password" name="smtp_password"
+                  placeholder="{% if email_password_set %}already set{% else %}leave blank if not required{% endif %}"
+                  class="w-full bg-slate-700 border border-slate-600 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:border-blue-500 placeholder:text-slate-500">
+              </div>
+              <label class="flex items-center gap-2 cursor-pointer">
+                <input type="checkbox" name="tls" value="on"
+                  {% if email_tls %}checked{% endif %}
+                  class="w-4 h-4 rounded accent-blue-500">
+                <span class="text-sm text-slate-300">Use TLS/SSL</span>
+              </label>
+              <div class="flex gap-2">
+                <button type="button"
+                  hx-post="/setup/notifications/email/test"
+                  hx-target="#email-result"
+                  hx-include="closest form"
+                  class="px-4 py-2 rounded-lg bg-slate-700 hover:bg-slate-600 text-sm font-medium text-slate-300 transition-colors">
+                  Send test email
+                </button>
+                <button type="submit"
+                  class="px-4 py-2 rounded-lg bg-blue-600 hover:bg-blue-500 text-sm font-medium text-white transition-colors">
+                  Save
+                </button>
+              </div>
+            </form>
+          </div>
+        </div>
+      </div>
 
-            <label class="flex items-center gap-2 cursor-pointer">
-              <input type="checkbox" name="pushover_enabled" value="on"
-                {% if pushover_enabled %}checked{% endif %}
-                class="w-4 h-4 rounded accent-blue-500">
-              <span class="text-sm text-slate-300">Enable Pushover notifications</span>
-            </label>
-
-            <div class="flex gap-2">
-              <button type="button"
-                hx-post="/setup/notifications/pushover/test"
-                hx-target="#pushover-result"
-                hx-include="closest form"
-                class="px-4 py-2 rounded-lg bg-slate-700 hover:bg-slate-600 text-sm font-medium text-slate-300 transition-colors">
-                Send test notification
-              </button>
-              <button type="submit"
-                class="px-4 py-2 rounded-lg bg-blue-600 hover:bg-blue-500 text-sm font-medium text-white transition-colors">
-                Save
-              </button>
-            </div>
-          </form>
+      <!-- Pushover config section -->
+      <div class="config-section" id="config-pushover">
+        <div class="config-card">
+          <div class="px-5 py-4 border-b border-slate-700">
+            <h2 class="text-sm font-semibold text-slate-200">Pushover</h2>
+            <p class="text-xs text-slate-500 mt-0.5">Push notifications to your phone when image updates are available.</p>
+          </div>
+          <div class="px-5 py-4 space-y-4">
+            <div id="pushover-result"></div>
+            <form hx-post="/setup/notifications/pushover/save"
+                  hx-target="#pushover-result"
+                  class="space-y-3">
+              <div class="grid grid-cols-2 gap-3">
+                <div>
+                  <label class="block text-xs font-medium text-slate-400 mb-1">App token</label>
+                  <input type="password" name="pushover_token"
+                    placeholder="{% if pushover_token_set %}already set{% else %}a1b2c3...{% endif %}"
+                    class="w-full bg-slate-700 border border-slate-600 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:border-blue-500 placeholder:text-slate-500">
+                </div>
+                <div>
+                  <label class="block text-xs font-medium text-slate-400 mb-1">User key</label>
+                  <input type="password" name="pushover_user_key"
+                    placeholder="{% if pushover_user_set %}already set{% else %}u1v2w3...{% endif %}"
+                    class="w-full bg-slate-700 border border-slate-600 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:border-blue-500 placeholder:text-slate-500">
+                </div>
+              </div>
+              <p class="text-xs text-slate-500">Find these at <span class="text-slate-400">pushover.net</span> — App token under your application, User key on your profile.</p>
+              <label class="flex items-center gap-2 cursor-pointer">
+                <input type="checkbox" name="pushover_enabled" value="on"
+                  {% if pushover_enabled %}checked{% endif %}
+                  class="w-4 h-4 rounded accent-blue-500">
+                <span class="text-sm text-slate-300">Enable Pushover notifications</span>
+              </label>
+              <div class="flex gap-2">
+                <button type="button"
+                  hx-post="/setup/notifications/pushover/test"
+                  hx-target="#pushover-result"
+                  hx-include="closest form"
+                  class="px-4 py-2 rounded-lg bg-slate-700 hover:bg-slate-600 text-sm font-medium text-slate-300 transition-colors">
+                  Send test notification
+                </button>
+                <button type="submit"
+                  class="px-4 py-2 rounded-lg bg-blue-600 hover:bg-blue-500 text-sm font-medium text-white transition-colors">
+                  Save
+                </button>
+              </div>
+            </form>
+          </div>
         </div>
       </div>
 
@@ -103,9 +255,7 @@
           <p class="text-xs text-slate-500 mt-0.5">How often Keepup checks for available package and image updates in the background.</p>
         </div>
         <div class="px-5 py-4 space-y-4">
-
           <div id="schedule-result"></div>
-
           <form hx-post="/setup/notifications/schedule/save"
                 hx-target="#schedule-result"
                 class="space-y-3">
@@ -131,13 +281,38 @@
       <div class="flex justify-between items-center mt-2">
         <a href="/setup/hosts" class="text-sm text-slate-500 hover:text-slate-300">← Back</a>
         <a href="/setup/summary"
-          class="px-6 py-2.5 rounded-xl bg-blue-600 hover:bg-blue-500 text-sm font-semibold text-white transition-colors">
-          Continue to Summary →
+          class="inline-flex items-center gap-2 px-6 py-2.5 rounded-xl bg-green-600 hover:bg-green-500 text-sm font-semibold text-white transition-colors">
+          <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+          </svg>
+          Finish setup
         </a>
       </div>
 
     </div>
   </div>
+
+  <script>
+    function toggleConfig(id) {
+      const section = document.getElementById('config-' + id);
+      const tile = document.getElementById('tile-' + id);
+      const allSections = document.querySelectorAll('.config-section');
+      const allTiles = document.querySelectorAll('.notif-icon');
+      const isOpen = section.style.display === 'block';
+      allSections.forEach(s => s.style.display = 'none');
+      allTiles.forEach(t => t.classList.remove('active'));
+      if (!isOpen) {
+        section.style.display = 'block';
+        tile.classList.add('active');
+        section.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+      }
+    }
+
+    document.addEventListener('DOMContentLoaded', function() {
+      {% if email_configured %}toggleConfig('email');{% endif %}
+      {% if pushover_token_set and pushover_user_set and not email_configured %}toggleConfig('pushover');{% endif %}
+    });
+  </script>
 
 </body>
 </html>

--- a/tests/test_main_coverage.py
+++ b/tests/test_main_coverage.py
@@ -155,3 +155,69 @@ def test_docker_check_gather_exception_returns_error_partial(client, monkeypatch
     response = client.get("/api/docker/check")
     assert response.status_code == 200
     assert "gather exploded" in response.text or "error" in response.text.lower()
+
+
+# ---------------------------------------------------------------------------
+# _newer_version and _fetch_latest_version helpers
+# ---------------------------------------------------------------------------
+
+def test_newer_version_returns_true_when_latest_is_higher():
+    import app.main as m
+    assert m._newer_version("99.0.0") is True
+
+
+def test_newer_version_returns_false_when_same():
+    import app.main as m
+    assert m._newer_version(m.APP_VERSION) is False
+
+
+def test_newer_version_returns_false_on_none():
+    import app.main as m
+    assert m._newer_version(None) is False
+
+
+def test_newer_version_returns_false_on_bad_input():
+    import app.main as m
+    assert m._newer_version("not-a-version") is False
+
+
+@pytest.mark.asyncio
+async def test_fetch_latest_version_success(monkeypatch):
+    import app.main as m
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.json.return_value = {"tag_name": "v1.2.3", "html_url": "https://github.com/example"}
+    mock_client = AsyncMock()
+    mock_client.get = AsyncMock(return_value=resp)
+    ctx = MagicMock()
+    ctx.__aenter__ = AsyncMock(return_value=mock_client)
+    ctx.__aexit__ = AsyncMock(return_value=None)
+    with patch("httpx.AsyncClient", return_value=ctx):
+        tag, url = await m._fetch_latest_version()
+    assert tag == "1.2.3"
+    assert "github.com" in url
+
+
+@pytest.mark.asyncio
+async def test_fetch_latest_version_http_error(monkeypatch):
+    import app.main as m
+    resp = MagicMock()
+    resp.status_code = 403
+    mock_client = AsyncMock()
+    mock_client.get = AsyncMock(return_value=resp)
+    ctx = MagicMock()
+    ctx.__aenter__ = AsyncMock(return_value=mock_client)
+    ctx.__aexit__ = AsyncMock(return_value=None)
+    with patch("httpx.AsyncClient", return_value=ctx):
+        tag, url = await m._fetch_latest_version()
+    assert tag is None
+    assert url is None
+
+
+@pytest.mark.asyncio
+async def test_fetch_latest_version_exception(monkeypatch):
+    import app.main as m
+    with patch("httpx.AsyncClient", side_effect=Exception("network down")):
+        tag, url = await m._fetch_latest_version()
+    assert tag is None
+    assert url is None

--- a/tests/test_main_routes.py
+++ b/tests/test_main_routes.py
@@ -1,5 +1,5 @@
 """Smoke tests for main dashboard routes."""
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, patch, MagicMock
 
 
 # ---------------------------------------------------------------------------
@@ -106,3 +106,40 @@ def test_job_status_unknown_id(client):
     response = client.get("/api/jobs/doesnotexist")
     assert response.status_code == 200
     assert "not found" in response.text.lower()
+
+
+# ---------------------------------------------------------------------------
+# Sign out button
+# ---------------------------------------------------------------------------
+
+def test_dashboard_has_sign_out_link(client):
+    response = client.get("/dashboard")
+    assert response.status_code == 200
+    assert "/logout" in response.text
+    assert "Sign out" in response.text
+
+
+# ---------------------------------------------------------------------------
+# Version update notice
+# ---------------------------------------------------------------------------
+
+def test_dashboard_shows_update_notice_when_newer_version(client):
+    with patch("app.main._get_latest_version", new=AsyncMock(return_value=("99.0.0", "https://github.com/example/releases/tag/v99.0.0"))):
+        response = client.get("/dashboard")
+    assert response.status_code == 200
+    assert "99.0.0" in response.text
+    assert "available" in response.text
+
+
+def test_dashboard_no_update_notice_when_up_to_date(client):
+    with patch("app.main._get_latest_version", new=AsyncMock(return_value=("0.0.1", "https://example.com"))):
+        response = client.get("/dashboard")
+    assert response.status_code == 200
+    assert "available ↑" not in response.text
+
+
+def test_dashboard_no_update_notice_when_version_check_fails(client):
+    with patch("app.main._get_latest_version", new=AsyncMock(return_value=(None, None))):
+        response = client.get("/dashboard")
+    assert response.status_code == 200
+    assert "available ↑" not in response.text

--- a/tests/test_setup_containers.py
+++ b/tests/test_setup_containers.py
@@ -1,0 +1,200 @@
+"""Tests for setup wizard step 7 — container monitoring."""
+from unittest.mock import AsyncMock, patch
+from fastapi.testclient import TestClient
+
+
+def _create_admin():
+    from app.auth import create_admin
+    return create_admin(username="admin", password="password123", totp_secret=None)
+
+
+def _setup_client(config_file, data_dir, monkeypatch):
+    monkeypatch.setenv("PORTAINER_URL", "")
+    monkeypatch.setenv("PORTAINER_API_KEY", "")
+    from app.main import app
+    return TestClient(app, raise_server_exceptions=True)
+
+
+# ---------------------------------------------------------------------------
+# GET /setup/containers
+# ---------------------------------------------------------------------------
+
+def test_setup_containers_no_admin_redirects(config_file, data_dir, monkeypatch):
+    client = _setup_client(config_file, data_dir, monkeypatch)
+    response = client.get("/setup/containers", follow_redirects=False)
+    assert response.status_code == 302
+    assert "/setup" in response.headers["location"]
+
+
+def test_setup_containers_no_hosts_shows_empty_state(config_file, data_dir, monkeypatch):
+    client = _setup_client(config_file, data_dir, monkeypatch)
+    _create_admin()
+    with patch("app.auth_router.discover_containers", new=AsyncMock(return_value=[])):
+        response = client.get("/setup/containers")
+    assert response.status_code == 200
+    assert "Step 7 of 8" in response.text
+    assert "Container monitoring" in response.text
+
+
+def test_setup_containers_with_containers_renders_rows(config_file, data_dir, monkeypatch):
+    client = _setup_client(config_file, data_dir, monkeypatch)
+    _create_admin()
+
+    # conftest default config already has "Test Host" and "Custom User Host"
+    mock_containers = [
+        {"id": "plex", "name": "plex", "image": "linuxserver/plex:latest"},
+        {"id": "sonarr", "name": "sonarr", "image": "linuxserver/sonarr:latest"},
+    ]
+    with patch("app.auth_router.discover_containers", new=AsyncMock(return_value=mock_containers)):
+        response = client.get("/setup/containers")
+
+    assert response.status_code == 200
+    assert "plex" in response.text
+    assert "sonarr" in response.text
+    assert "linuxserver/plex:latest" in response.text
+    assert "Select all" in response.text
+    assert "Deselect all" in response.text
+
+
+def test_setup_containers_host_with_no_containers_shows_empty_state(config_file, data_dir, monkeypatch):
+    client = _setup_client(config_file, data_dir, monkeypatch)
+    _create_admin()
+
+    # All hosts return no containers — should show empty state
+    with patch("app.auth_router.discover_containers", new=AsyncMock(return_value=[])):
+        response = client.get("/setup/containers")
+
+    assert response.status_code == 200
+    assert "No" in response.text and "container" in response.text.lower()
+
+
+def test_setup_containers_all_checked_by_default(config_file, data_dir, monkeypatch):
+    client = _setup_client(config_file, data_dir, monkeypatch)
+    _create_admin()
+
+    with patch("app.auth_router.discover_containers", new=AsyncMock(return_value=[
+        {"id": "nginx", "name": "nginx", "image": "nginx:latest"}
+    ])):
+        response = client.get("/setup/containers")
+
+    # The hidden checkbox should be present and checked
+    assert 'name="containers"' in response.text
+    assert 'checked' in response.text
+
+
+# ---------------------------------------------------------------------------
+# POST /setup/containers/save
+# ---------------------------------------------------------------------------
+
+def test_setup_containers_save_redirects_to_notifications(config_file, data_dir, monkeypatch):
+    client = _setup_client(config_file, data_dir, monkeypatch)
+    _create_admin()
+
+    # "Test Host" → slug "test-host" (from conftest default config)
+    response = client.post("/setup/containers/save",
+                           data={"containers": ["test-host:nginx", "test-host:plex"]},
+                           follow_redirects=False)
+    assert response.status_code == 303
+    assert "/setup/notifications" in response.headers["location"]
+
+
+def test_setup_containers_save_stores_selection(config_file, data_dir, monkeypatch):
+    client = _setup_client(config_file, data_dir, monkeypatch)
+    _create_admin()
+
+    # "Test Host" → slug "test-host" (from conftest default config)
+    client.post("/setup/containers/save",
+                data={"containers": ["test-host:nginx", "test-host:plex"]},
+                follow_redirects=False)
+
+    import yaml
+    raw = yaml.safe_load(config_file.read_text())
+    test_host = next(h for h in raw["hosts"] if h["name"] == "Test Host")
+    assert test_host.get("docker_mode") == "selected"
+    assert "nginx" in test_host.get("docker_stacks", [])
+    assert "plex" in test_host.get("docker_stacks", [])
+
+
+def test_setup_containers_save_empty_selection(config_file, data_dir, monkeypatch):
+    """Empty selection (no containers checked) saves without error."""
+    client = _setup_client(config_file, data_dir, monkeypatch)
+    _create_admin()
+
+    response = client.post("/setup/containers/save", data={}, follow_redirects=False)
+    assert response.status_code == 303
+    assert "/setup/notifications" in response.headers["location"]
+
+
+# ---------------------------------------------------------------------------
+# config_manager — save_wizard_container_selection
+# ---------------------------------------------------------------------------
+
+def test_save_wizard_container_selection_sets_docker_mode(config_file, data_dir):
+    import yaml
+    from app.config_manager import save_wizard_container_selection
+
+    # conftest default: "Test Host" → slug "test-host"
+    save_wizard_container_selection(["test-host:plex", "test-host:sonarr"])
+
+    raw = yaml.safe_load(config_file.read_text())
+    host = next(h for h in raw["hosts"] if h["name"] == "Test Host")
+    assert host["docker_mode"] == "selected"
+    assert set(host["docker_stacks"]) == {"plex", "sonarr"}
+
+
+def test_save_wizard_container_selection_ignores_malformed(config_file, data_dir):
+    from app.config_manager import save_wizard_container_selection
+    # Should not raise even if some entries lack ':'
+    save_wizard_container_selection(["no-colon-here", "valid:container"])
+
+
+# ---------------------------------------------------------------------------
+# ssh_client — discover_containers
+# ---------------------------------------------------------------------------
+
+import pytest
+
+def _make_conn(stdout=""):
+    from unittest.mock import MagicMock
+    result = MagicMock()
+    result.stdout = stdout
+    conn = MagicMock()
+    conn.__aenter__ = AsyncMock(return_value=conn)
+    conn.__aexit__ = AsyncMock(return_value=False)
+    conn.run = AsyncMock(return_value=result)
+    return conn
+
+
+@pytest.mark.asyncio
+async def test_discover_containers_parses_docker_output():
+    from app.ssh_client import discover_containers
+
+    stdout = '{"name":"plex","image":"linuxserver/plex:latest"}\n{"name":"nginx","image":"nginx:alpine"}\n'
+    conn = _make_conn(stdout=stdout)
+    with patch("app.ssh_client.asyncssh.connect", new=AsyncMock(return_value=conn)):
+        result = await discover_containers({"name": "test", "host": "1.2.3.4"}, {})
+
+    assert len(result) == 2
+    assert result[0]["name"] == "plex"
+    assert result[1]["image"] == "nginx:alpine"
+
+
+@pytest.mark.asyncio
+async def test_discover_containers_returns_empty_on_error():
+    from app.ssh_client import discover_containers
+
+    with patch("app.ssh_client.asyncssh.connect", side_effect=Exception("connect failed")):
+        result = await discover_containers({"name": "test", "host": "1.2.3.4"}, {})
+
+    assert result == []
+
+
+@pytest.mark.asyncio
+async def test_discover_containers_handles_empty_output():
+    from app.ssh_client import discover_containers
+
+    conn = _make_conn(stdout="")
+    with patch("app.ssh_client.asyncssh.connect", new=AsyncMock(return_value=conn)):
+        result = await discover_containers({"name": "test", "host": "1.2.3.4"}, {})
+
+    assert result == []

--- a/tests/test_setup_notifications.py
+++ b/tests/test_setup_notifications.py
@@ -166,3 +166,120 @@ def test_schedule_save_manual_removes_key(setup_client, data_dir, config_file):
     assert response.status_code == 200
     raw = yaml.safe_load(config_file.read_text())
     assert "update_check_schedule" not in raw
+
+
+# ---------------------------------------------------------------------------
+# POST /setup/notifications/email/save
+# ---------------------------------------------------------------------------
+
+def test_email_save_stores_config(setup_client, data_dir, config_file):
+    import yaml
+    _create_admin()
+    response = setup_client.post("/setup/notifications/email/save", data={
+        "sender_name": "Keepup",
+        "sender_address": "keepup@example.com",
+        "recipient_address": "me@example.com",
+        "smtp_host": "smtp.example.com",
+        "smtp_port": "587",
+        "smtp_password": "secret",
+        "tls": "on",
+    })
+    assert response.status_code == 200
+    assert "saved" in response.text.lower() or "&#10003;" in response.text
+    raw = yaml.safe_load(config_file.read_text())
+    email = raw.get("email", {})
+    assert email.get("smtp_host") == "smtp.example.com"
+    assert email.get("sender_address") == "keepup@example.com"
+    assert email.get("tls") is True
+
+
+def test_email_save_no_host_returns_warning(setup_client, data_dir):
+    _create_admin()
+    response = setup_client.post("/setup/notifications/email/save", data={
+        "sender_name": "",
+        "sender_address": "a@b.com",
+        "recipient_address": "c@d.com",
+        "smtp_host": "",
+        "smtp_port": "587",
+    })
+    assert response.status_code == 200
+    assert "amber" in response.text or "required" in response.text.lower()
+
+
+# ---------------------------------------------------------------------------
+# POST /setup/notifications/email/test
+# ---------------------------------------------------------------------------
+
+def test_email_test_missing_fields(setup_client, data_dir):
+    _create_admin()
+    response = setup_client.post("/setup/notifications/email/test", data={
+        "sender_address": "",
+        "recipient_address": "",
+        "smtp_host": "",
+        "smtp_port": "587",
+    })
+    assert response.status_code == 200
+    assert "amber" in response.text or "Fill in" in response.text
+
+
+def test_email_test_smtp_failure(setup_client, data_dir):
+    _create_admin()
+    with patch("smtplib.SMTP", side_effect=Exception("Connection refused")):
+        with patch("smtplib.SMTP_SSL", side_effect=Exception("Connection refused")):
+            response = setup_client.post("/setup/notifications/email/test", data={
+                "sender_address": "a@b.com",
+                "recipient_address": "c@d.com",
+                "smtp_host": "smtp.example.com",
+                "smtp_port": "587",
+                "tls": "",
+            })
+    assert response.status_code == 200
+    assert "&#10007;" in response.text
+
+
+# ---------------------------------------------------------------------------
+# POST /setup/notifications/email/delete
+# ---------------------------------------------------------------------------
+
+def test_email_delete_removes_config(setup_client, data_dir, config_file):
+    import yaml
+    _create_admin()
+    # First save some config
+    setup_client.post("/setup/notifications/email/save", data={
+        "sender_address": "a@b.com",
+        "recipient_address": "c@d.com",
+        "smtp_host": "smtp.example.com",
+        "smtp_port": "587",
+    })
+    # Now delete it
+    response = setup_client.post("/setup/notifications/email/delete")
+    assert response.status_code == 200
+    raw = yaml.safe_load(config_file.read_text()) or {}
+    assert "email" not in raw
+
+
+# ---------------------------------------------------------------------------
+# GET /setup/notifications — email context variables
+# ---------------------------------------------------------------------------
+
+def test_setup_notifications_shows_email_tile(setup_client, data_dir):
+    _create_admin()
+    response = setup_client.get("/setup/notifications")
+    assert response.status_code == 200
+    assert "Email" in response.text
+    assert "Pushover" in response.text
+
+
+def test_setup_notifications_shows_connected_when_email_configured(setup_client, data_dir, config_file):
+    import yaml
+    _create_admin()
+    # Pre-configure email
+    setup_client.post("/setup/notifications/email/save", data={
+        "sender_address": "a@b.com",
+        "recipient_address": "c@d.com",
+        "smtp_host": "smtp.example.com",
+        "smtp_port": "587",
+    })
+    response = setup_client.get("/setup/notifications")
+    assert response.status_code == 200
+    assert "connected" in response.text.lower()


### PR DESCRIPTION
## Summary
- New wizard step between SSH Hosts and Notifications
- Discovers running Docker containers on each SSH host via `docker ps`
- User selects which containers to monitor; all pre-selected by default
- Updates all wizard step counters (Notifications moves from step 7 → step 8)

## Changes
- **`app/ssh_client.py`** — `discover_containers()`: SSHes to host, runs `docker ps --format JSON`, parses output line by line; returns `[]` on any error
- **`app/config_manager.py`** — `save_wizard_container_selection()`: takes `["slug:container", ...]` list, sets `docker_mode: selected` + `docker_stacks` per host
- **`app/auth_router.py`** — `GET /setup/containers` (async per-host discovery), `POST /setup/containers/save` (saves + redirect); imports updated
- **`app/templates/setup_containers.html`** — step 7 of 8 (87.5%); host blocks with name/IP header, Select all / Deselect all buttons, individual checkbox rows with live count footers; empty states for no-containers hosts and no-docker-anywhere; Skip link
- **`app/templates/setup_hosts.html`** — Continue button now links to `/setup/containers` 
- **`app/templates/setup_notifications.html`** — step 7 → step 8, 87% → 100%, Back → `/setup/containers`

## Test plan
- [x] 13 new tests — all pass
- [x] Page renders with step 7 of 8 indicator
- [x] Container rows rendered with pre-checked checkboxes
- [x] Per-host empty state when docker not running
- [x] Global empty state when no host has containers
- [x] POST saves correct docker_mode/docker_stacks to config
- [x] Empty POST (all deselected) redirects without error
- [x] `discover_containers` parses JSON docker output, handles errors, handles empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)