### PR TITLE
Redesign Proxmox setup wizard into guided multi-step flow (OP#85)

### DIFF
--- a/app/auth_router.py
+++ b/app/auth_router.py
@@ -352,6 +352,56 @@ async def setup_connect(request: Request) -> HTMLResponse:
 # --- Proxmox ---
 
 
+def _setup_proxmox_client_parts() -> tuple[str, str, bool]:
+    """Return (url, token, verify_ssl) from saved Proxmox config."""
+    cfg = get_proxmox_config()
+    creds = get_integration_credentials("proxmox")
+    url = cfg.get("url", "")
+    token_id = creds.get("token_id", "")
+    secret = creds.get("secret", "")
+    if not token_id:
+        api_user = creds.get("api_user", "")
+        api_token = creds.get("api_token", "")
+        token = f"{api_user}!{api_token}" if api_user else api_token
+    else:
+        token = f"{token_id}={secret}"
+    return url, token, cfg.get("verify_ssl", False)
+
+
+def _proxmox_lxc_step(request: Request, resources: list[dict]) -> HTMLResponse:
+    lxcs = [r for r in resources if r["type"] == "lxc"]
+    if lxcs:
+        return templates.TemplateResponse(
+            "partials/setup_proxmox_section.html",
+            {
+                "request": request,
+                "proxmox_connected": True,
+                "proxmox_step": "lxcs",
+                "proxmox_resources": resources,
+                "available_keys": get_available_ssh_keys(),
+            },
+        )
+    return _proxmox_vm_step(request, resources)
+
+
+def _proxmox_vm_step(request: Request, resources: list[dict]) -> HTMLResponse:
+    vms = [r for r in resources if r["type"] == "qemu"]
+    if vms:
+        return templates.TemplateResponse(
+            "partials/setup_proxmox_section.html",
+            {
+                "request": request,
+                "proxmox_connected": True,
+                "proxmox_step": "vms",
+                "proxmox_resources": resources,
+            },
+        )
+    return templates.TemplateResponse(
+        "partials/setup_proxmox_section.html",
+        {"request": request, "proxmox_connected": True, "proxmox_step": "done"},
+    )
+
+
 @router.post("/setup/connect/proxmox/test", response_class=HTMLResponse)
 async def setup_test_proxmox(
     request: Request,
@@ -362,7 +412,6 @@ async def setup_test_proxmox(
     proxmox_verify_ssl: str = Form(""),
 ) -> HTMLResponse:
     url = proxmox_url.strip().rstrip("/")
-    api_user = proxmox_api_user.strip()
     token_id = proxmox_token_id.strip()
     secret = proxmox_secret.strip()
     verify_ssl = proxmox_verify_ssl == "on"
@@ -388,9 +437,7 @@ async def setup_test_proxmox(
             hint = "SSL error — try disabling SSL verification."
         else:
             hint = msg[:120]
-        return HTMLResponse(
-            f'<span class="text-red-400 text-sm">&#10007; {hint}</span>'
-        )
+        return HTMLResponse(f'<span class="text-red-400 text-sm">&#10007; {hint}</span>')
 
 
 @router.post("/setup/connect/proxmox/save", response_class=HTMLResponse)
@@ -401,19 +448,12 @@ async def setup_save_proxmox(
     proxmox_token_id: str = Form(""),
     proxmox_secret: str = Form(""),
     proxmox_verify_ssl: str = Form(""),
-    proxmox_ssh_user: str = Form(""),
-    proxmox_ssh_auth: str = Form("key"),
-    proxmox_ssh_key: str = Form(""),
-    proxmox_ssh_password: str = Form(""),
 ) -> HTMLResponse:
     url = proxmox_url.strip().rstrip("/")
     api_user = proxmox_api_user.strip()
     token_id = proxmox_token_id.strip()
     secret = proxmox_secret.strip()
     verify_ssl = proxmox_verify_ssl == "on"
-    ssh_user = proxmox_ssh_user.strip()
-    ssh_key = proxmox_ssh_key.strip() if proxmox_ssh_auth == "key" else ""
-    ssh_password = proxmox_ssh_password.strip() if proxmox_ssh_auth == "password" else ""
     save_proxmox_config(url=url, verify_ssl=verify_ssl)
     cred_kwargs: dict = {}
     if api_user:
@@ -422,87 +462,227 @@ async def setup_save_proxmox(
         cred_kwargs["token_id"] = token_id
     if secret:
         cred_kwargs["secret"] = secret
-    if ssh_user:
-        cred_kwargs["ssh_user"] = ssh_user
-    if ssh_key:
-        cred_kwargs["ssh_key"] = ssh_key
-        cred_kwargs["ssh_password"] = None  # clear password when switching to key
-    if ssh_password:
-        cred_kwargs["ssh_password"] = ssh_password
-        cred_kwargs["ssh_key"] = None  # clear key when switching to password
     if cred_kwargs:
         save_integration_credentials("proxmox", **cred_kwargs)
     _queue_integration_host(request, "proxmox", "Proxmox VE", url)
+
+    nodes: list[str] = []
+    resources: list[dict] = []
+    if url and token_id and secret:
+        try:
+            token = f"{token_id}={secret}"
+            client = ProxmoxClient(url=url, api_token=token, verify_ssl=verify_ssl)
+            nodes = await client.get_nodes()
+            resources = await client.discover_resources()
+            request.session["setup_proxmox_resources"] = resources
+        except Exception:
+            pass
+
     return templates.TemplateResponse(
         "partials/setup_proxmox_section.html",
         {
             "request": request,
-            "proxmox_url": url,
             "proxmox_connected": True,
-            "proxmox_saved": True,
+            "proxmox_step": "node",
+            "proxmox_nodes": nodes,
+            "proxmox_url": url,
         },
     )
 
 
 @router.post("/setup/connect/proxmox/discover", response_class=HTMLResponse)
 async def setup_proxmox_discover(request: Request) -> HTMLResponse:
-    cfg = get_proxmox_config()
-    creds = get_integration_credentials("proxmox")
-    url = cfg.get("url", "")
-    token_id = creds.get("token_id", "")
-    secret = creds.get("secret", "")
-    # Legacy fallback: old format stored full token in api_token
-    if not token_id:
-        api_user = creds.get("api_user", "")
-        api_token = creds.get("api_token", "")
-        token = f"{api_user}!{api_token}" if api_user else api_token
-    else:
-        token = f"{token_id}={secret}"
-    verify_ssl = cfg.get("verify_ssl", False)
+    """For already-connected Proxmox: discover resources and enter the guided flow."""
+    url, token, verify_ssl = _setup_proxmox_client_parts()
     if not url or not token:
-        return HTMLResponse(
-            '<p class="text-sm text-red-400">Proxmox not configured.</p>'
-        )
+        return HTMLResponse('<p class="text-sm text-red-400">Proxmox not configured.</p>')
     try:
         client = ProxmoxClient(url=url, api_token=token, verify_ssl=verify_ssl)
+        nodes = await client.get_nodes()
         resources = await client.discover_resources()
+        request.session["setup_proxmox_resources"] = resources
         return templates.TemplateResponse(
             "partials/setup_proxmox_section.html",
             {
                 "request": request,
-                "proxmox_url": url,
                 "proxmox_connected": True,
-                "proxmox_resources": resources,
+                "proxmox_step": "node",
+                "proxmox_nodes": nodes,
+                "proxmox_url": url,
             },
         )
     except Exception as exc:
+        return HTMLResponse(f'<p class="text-sm text-red-400">Discovery failed: {exc}</p>')
+
+
+@router.post("/setup/connect/proxmox/add-node", response_class=HTMLResponse)
+async def setup_proxmox_add_node(request: Request) -> HTMLResponse:
+    import urllib.parse
+    url, token, verify_ssl = _setup_proxmox_client_parts()
+    px_host = urllib.parse.urlparse(url).hostname or ""
+    try:
+        client = ProxmoxClient(url=url, api_token=token, verify_ssl=verify_ssl)
+        nodes = await client.get_nodes()
+    except Exception as exc:
         return HTMLResponse(
-            f'<p class="text-sm text-red-400">Discovery failed: {exc}</p>'
+            f'<p class="text-sm text-red-400">Could not reach Proxmox API: {exc}</p>'
         )
-
-
-@router.post("/setup/connect/proxmox/select-hosts", response_class=HTMLResponse)
-async def setup_proxmox_select_hosts(request: Request) -> HTMLResponse:
-    form = await request.form()
-    selected = form.getlist("selected_hosts")  # list of "node:vmid:type:name:ip" strings
-    pending = []
-    for entry in selected:
-        parts = entry.split(":", 4)
-        if len(parts) >= 4:
-            pending.append(
-                {
-                    "node": parts[0],
-                    "vmid": parts[1],
-                    "type": parts[2],
-                    "name": parts[3],
-                    "ip": parts[4] if len(parts) > 4 else "",
-                }
+    existing = {h["host"] for h in get_hosts()}
+    for node in nodes:
+        if px_host and px_host not in existing:
+            add_host(
+                name=f"Proxmox VE ({node})",
+                host=px_host,
+                user=None,
+                port=None,
+                proxmox_node=node,
             )
-    request.session["setup_proxmox_pending"] = pending
-    count = len(pending)
-    label = f"{count} host{'s' if count != 1 else ''}"
+            existing.add(px_host)
+    resources = request.session.get("setup_proxmox_resources", [])
+    return _proxmox_lxc_step(request, resources)
+
+
+@router.post("/setup/connect/proxmox/skip-node", response_class=HTMLResponse)
+async def setup_proxmox_skip_node(request: Request) -> HTMLResponse:
+    resources = request.session.get("setup_proxmox_resources", [])
+    return _proxmox_lxc_step(request, resources)
+
+
+@router.post("/setup/connect/proxmox/test-ssh", response_class=HTMLResponse)
+async def setup_proxmox_test_ssh(
+    request: Request,
+    proxmox_ssh_user: str = Form("root"),
+    proxmox_ssh_auth: str = Form("key"),
+    proxmox_ssh_key: str = Form(""),
+    proxmox_ssh_password: str = Form(""),
+) -> HTMLResponse:
+    import urllib.parse
+    cfg = get_proxmox_config()
+    px_host = urllib.parse.urlparse(cfg.get("url", "")).hostname or ""
+    if not px_host:
+        return HTMLResponse('<span class="text-red-400 text-xs">Proxmox not configured.</span>')
+    user = proxmox_ssh_user.strip() or "root"
+    key_path = (
+        f"/app/keys/{proxmox_ssh_key.strip()}"
+        if proxmox_ssh_auth == "key" and proxmox_ssh_key.strip()
+        else None
+    )
+    password = proxmox_ssh_password.strip() if proxmox_ssh_auth == "password" else ""
+    if proxmox_ssh_auth == "key" and not key_path:
+        return HTMLResponse('<span class="text-amber-400 text-xs">Select a key file first.</span>')
+    if proxmox_ssh_auth == "password" and not password:
+        return HTMLResponse('<span class="text-amber-400 text-xs">Enter a password first.</span>')
+    host_entry: dict = {"name": "Proxmox VE", "host": px_host, "user": user}
+    if key_path:
+        host_entry["key"] = key_path
+    creds: dict = {}
+    if password:
+        creds["ssh_password"] = password
+    result = await verify_connection(host_entry, get_ssh_config(), creds)
+    if result["ok"]:
+        return HTMLResponse(
+            f'<span class="text-green-400 text-xs">&#10003; Connected to {px_host}</span>'
+            f"<script>proxmoxSshTestPassed();</script>"
+        )
     return HTMLResponse(
-        f'<p class="text-sm text-green-400">&#10003; {label} queued for SSH setup in the next step.</p>'
+        f'<span class="text-red-400 text-xs">&#10007; {result["message"]}</span>'
+    )
+
+
+@router.post("/setup/connect/proxmox/save-lxcs", response_class=HTMLResponse)
+async def setup_proxmox_save_lxcs(
+    request: Request,
+    proxmox_ssh_user: str = Form("root"),
+    proxmox_ssh_auth: str = Form("key"),
+    proxmox_ssh_key: str = Form(""),
+    proxmox_ssh_password: str = Form(""),
+) -> HTMLResponse:
+    form = await request.form()
+    selected = form.getlist("selected_lxcs")
+
+    ssh_user = proxmox_ssh_user.strip() or "root"
+    ssh_key = proxmox_ssh_key.strip() if proxmox_ssh_auth == "key" else ""
+    ssh_password = proxmox_ssh_password.strip() if proxmox_ssh_auth == "password" else ""
+    cred_kwargs: dict = {"ssh_user": ssh_user}
+    if ssh_key:
+        cred_kwargs["ssh_key"] = ssh_key
+        cred_kwargs["ssh_password"] = None
+    if ssh_password:
+        cred_kwargs["ssh_password"] = ssh_password
+        cred_kwargs["ssh_key"] = None
+    save_integration_credentials("proxmox", **cred_kwargs)
+
+    existing = {h["host"] for h in get_hosts()}
+    for entry in selected:
+        parts = entry.split(":", 3)
+        if len(parts) < 3:
+            continue
+        node, vmid_str, name = parts[0], parts[1], parts[2]
+        ip = parts[3] if len(parts) > 3 else ""
+        if not ip or ip in existing:
+            continue
+        vmid = int(vmid_str) if vmid_str.isdigit() else None
+        if vmid is not None:
+            add_host(name=name, host=ip, user=None, port=None, proxmox_node=node, proxmox_vmid=vmid)
+            existing.add(ip)
+
+    resources = request.session.get("setup_proxmox_resources", [])
+    return _proxmox_vm_step(request, resources)
+
+
+@router.post("/setup/connect/proxmox/skip-lxcs", response_class=HTMLResponse)
+async def setup_proxmox_skip_lxcs(request: Request) -> HTMLResponse:
+    resources = request.session.get("setup_proxmox_resources", [])
+    return _proxmox_vm_step(request, resources)
+
+
+@router.post("/setup/connect/proxmox/save-vms", response_class=HTMLResponse)
+async def setup_proxmox_save_vms(request: Request) -> HTMLResponse:
+    form = await request.form()
+    selected = form.getlist("selected_vms")
+    vm_action = str(form.get("vm_action", "later"))
+
+    existing = {h["host"] for h in get_hosts()}
+    added: list[dict] = []
+    for entry in selected:
+        parts = entry.split(":", 2)
+        if len(parts) < 3:
+            continue
+        node, vmid_str, name = parts[0], parts[1], parts[2]
+        ip = str(form.get(f"vm_ip_{vmid_str}", "")).strip()
+        if not ip or ip in existing:
+            continue
+        add_host(name=name, host=ip, user=None, port=None)
+        existing.add(ip)
+        added.append({"node": node, "vmid": vmid_str, "name": name, "ip": ip, "type": "qemu"})
+
+    if vm_action == "now" and added:
+        pending = request.session.get("setup_proxmox_pending", [])
+        pending.extend(added)
+        request.session["setup_proxmox_pending"] = pending
+
+    summary = None
+    if added:
+        label = f"{len(added)} VM{'s' if len(added) != 1 else ''} added"
+        note = "continue to set up logins" if vm_action == "now" else "finish login setup from Admin › Hosts"
+        summary = f"{label} — {note}"
+
+    return templates.TemplateResponse(
+        "partials/setup_proxmox_section.html",
+        {
+            "request": request,
+            "proxmox_connected": True,
+            "proxmox_step": "done",
+            "proxmox_added_summary": summary,
+        },
+    )
+
+
+@router.post("/setup/connect/proxmox/skip-vms", response_class=HTMLResponse)
+async def setup_proxmox_skip_vms(request: Request) -> HTMLResponse:
+    return templates.TemplateResponse(
+        "partials/setup_proxmox_section.html",
+        {"request": request, "proxmox_connected": True, "proxmox_step": "done"},
     )
 
 

--- a/app/templates/partials/setup_proxmox_section.html
+++ b/app/templates/partials/setup_proxmox_section.html
@@ -13,156 +13,292 @@
 
   <div class="px-5 py-4 space-y-3">
 
-    {% if proxmox_saved %}
-    <p class="text-sm text-green-400">&#10003; Proxmox saved.</p>
-    {% endif %}
+  {% if proxmox_step == 'node' %}
+  <!-- ── Step 2: Proxmox node ── -->
+  <p class="text-xs text-slate-400">Would you like to monitor OS updates on the Proxmox host itself?</p>
+  {% if proxmox_nodes %}
+  <div class="space-y-1">
+    {% for node in proxmox_nodes %}
+    <div class="flex items-center gap-2 px-3 py-2 rounded-lg bg-slate-700/40 text-sm text-slate-200">
+      <span class="text-slate-500">◈</span> {{ node }}
+      <span class="text-xs text-slate-500 ml-1">Proxmox node</span>
+    </div>
+    {% endfor %}
+  </div>
+  {% endif %}
+  <div class="flex gap-2">
+    <button
+      hx-post="/setup/connect/proxmox/add-node"
+      hx-target="#proxmox-section"
+      hx-swap="outerHTML"
+      class="px-4 py-2 rounded-lg bg-blue-600 hover:bg-blue-500 text-sm font-medium text-white transition-colors">
+      Add Proxmox node to monitoring
+    </button>
+    <button
+      hx-post="/setup/connect/proxmox/skip-node"
+      hx-target="#proxmox-section"
+      hx-swap="outerHTML"
+      class="px-4 py-2 rounded-lg bg-slate-700 hover:bg-slate-600 text-sm font-medium text-slate-300 transition-colors">
+      Skip
+    </button>
+  </div>
 
-    {% if proxmox_resources is defined %}
+  {% elif proxmox_step == 'lxcs' %}
+  <!-- ── Step 3: LXC containers ── -->
+  {% set lxcs = proxmox_resources | selectattr('type', 'equalto', 'lxc') | list %}
+  <p class="text-xs text-slate-400">Select the LXC containers you want Keepup to monitor.</p>
+  <div class="space-y-1.5">
+    {% for r in lxcs %}
+    <label class="flex items-center gap-3 px-3 py-2 rounded-lg bg-slate-700/50 cursor-pointer hover:bg-slate-700 transition-colors">
+      <input type="checkbox" name="selected_lxcs"
+             value="{{ r.node }}:{{ r.vmid }}:{{ r.name }}:{{ r.ip or '' }}"
+             class="proxmox-lxc-check w-4 h-4 rounded accent-blue-500 flex-shrink-0"
+             onchange="proxmoxUpdateLxcPanel()">
+      <div class="min-w-0">
+        <span class="text-sm text-slate-200 font-medium">{{ r.name }}</span>
+        <span class="text-xs text-slate-500 ml-2">LXC {{ r.vmid }} · {{ r.node }}{% if r.ip %} · {{ r.ip }}{% endif %}</span>
+      </div>
+      <span class="ml-auto text-xs px-2 py-0.5 rounded-full flex-shrink-0
+        {% if r.status == 'running' %}bg-green-900/40 text-green-400
+        {% else %}bg-slate-700 text-slate-400{% endif %}">
+        {{ r.status }}
+      </span>
+    </label>
+    {% endfor %}
+  </div>
 
-      <!-- Discovered VMs/LXCs -->
-      {% if proxmox_resources %}
-      {% set vms = proxmox_resources | selectattr('type', 'equalto', 'qemu') | list %}
-      {% set lxcs = proxmox_resources | selectattr('type', 'equalto', 'lxc') | list %}
-      <form hx-post="/setup/connect/proxmox/select-hosts"
-            hx-target="#proxmox-select-result"
-            class="space-y-3">
-
-        {% if vms %}
-        <div>
-          <p class="text-xs font-medium text-slate-400 mb-1.5">Virtual Machines (QEMU)</p>
-          <p class="text-xs text-slate-500 mb-2">VMs require SSH for OS package monitoring. Select any you want Keepup to monitor.</p>
-          <div class="space-y-1.5 max-h-48 overflow-y-auto pr-1">
-            {% for r in vms %}
-            <label class="flex items-center gap-3 px-3 py-2 rounded-lg bg-slate-700/50 cursor-pointer hover:bg-slate-700 transition-colors">
-              <input type="checkbox" name="selected_hosts"
-                value="{{ r.node }}:{{ r.vmid }}:{{ r.type }}:{{ r.name }}:{{ r.ip or '' }}"
-                class="w-4 h-4 rounded accent-blue-500 flex-shrink-0">
-              <div class="min-w-0">
-                <span class="text-sm text-slate-200 font-medium">{{ r.name }}</span>
-                <span class="text-xs text-slate-500 ml-2">VM {{ r.vmid }} · {{ r.node }}{% if r.ip %} · {{ r.ip }}{% endif %}</span>
-              </div>
-              <span class="ml-auto text-xs px-2 py-0.5 rounded-full flex-shrink-0
-                {% if r.status == 'running' %}bg-green-900/40 text-green-400
-                {% else %}bg-slate-700 text-slate-400{% endif %}">
-                {{ r.status }}
-              </span>
-            </label>
-            {% endfor %}
-          </div>
-        </div>
-        {% endif %}
-
-        {% if lxcs %}
-        <div>
-          <p class="text-xs font-medium text-slate-400 mb-1.5">LXC Containers</p>
-          <p class="text-xs text-slate-500 mb-2">LXCs run directly on Proxmox. Select any you want Keepup to monitor via SSH.</p>
-          <div class="space-y-1.5 max-h-48 overflow-y-auto pr-1">
-            {% for r in lxcs %}
-            <label class="flex items-center gap-3 px-3 py-2 rounded-lg bg-slate-700/50 cursor-pointer hover:bg-slate-700 transition-colors">
-              <input type="checkbox" name="selected_hosts"
-                value="{{ r.node }}:{{ r.vmid }}:{{ r.type }}:{{ r.name }}:{{ r.ip or '' }}"
-                class="w-4 h-4 rounded accent-blue-500 flex-shrink-0">
-              <div class="min-w-0">
-                <span class="text-sm text-slate-200 font-medium">{{ r.name }}</span>
-                <span class="text-xs text-slate-500 ml-2">LXC {{ r.vmid }} · {{ r.node }}{% if r.ip %} · {{ r.ip }}{% endif %}</span>
-              </div>
-              <span class="ml-auto text-xs px-2 py-0.5 rounded-full flex-shrink-0
-                {% if r.status == 'running' %}bg-green-900/40 text-green-400
-                {% else %}bg-slate-700 text-slate-400{% endif %}">
-                {{ r.status }}
-              </span>
-            </label>
-            {% endfor %}
-          </div>
-        </div>
-        {% endif %}
-
-        <div class="flex gap-2 items-center flex-wrap">
-          <button type="submit"
-            class="px-4 py-2 rounded-lg bg-blue-600 hover:bg-blue-500 text-sm font-medium text-white transition-colors">
-            Queue selected for SSH setup
-          </button>
-          <button type="button"
-            hx-post="/setup/connect/proxmox/select-hosts"
-            hx-target="#proxmox-select-result"
-            hx-vals='{"selected_hosts": ""}'
-            class="px-4 py-2 rounded-lg bg-slate-700 hover:bg-slate-600 text-sm font-medium text-slate-300 transition-colors">
-            Skip SSH setup
-          </button>
-        </div>
-      </form>
-      <div id="proxmox-select-result"></div>
-      {% else %}
-      <p class="text-xs text-slate-500 italic">No VMs or LXC containers found.</p>
-      {% endif %}
-
-    {% elif proxmox_connected %}
-
-      <!-- Connected state: offer discovery -->
-      <p class="text-xs text-slate-400">
-        Credentials saved. Discover VMs and LXC containers to optionally set up SSH monitoring for them.
-      </p>
-      <button
-        hx-post="/setup/connect/proxmox/discover"
-        hx-target="#proxmox-section"
-        hx-swap="outerHTML"
-        class="px-4 py-2 rounded-lg bg-slate-600 hover:bg-slate-500 text-sm font-medium text-slate-200 transition-colors">
-        Discover VMs &amp; LXCs
+  <!-- SSH panel — shown when ≥1 LXC is checked -->
+  <div id="proxmox-lxc-ssh-panel" class="hidden rounded-xl border border-slate-600 bg-slate-700/30 px-4 py-3 space-y-3">
+    <div>
+      <p class="text-xs font-medium text-slate-300">One more thing</p>
+      <p class="text-xs text-slate-500 mt-0.5">To check updates on LXC containers, Keepup needs to connect to your Proxmox server directly. This one-time setup covers all your LXCs.</p>
+    </div>
+    <div class="flex gap-3">
+      <div class="flex-1">
+        <label class="block text-xs font-medium text-slate-400 mb-1">Login user</label>
+        <input type="text" id="proxmox-lxc-ssh-user" name="proxmox_ssh_user" value="root"
+               class="w-full bg-slate-700 border border-slate-600 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:border-blue-500">
+        <p class="text-xs text-slate-500 mt-1">A dedicated user is recommended, but root may be used.</p>
+      </div>
+      <div class="flex-1">
+        <label class="block text-xs font-medium text-slate-400 mb-1">Auth method</label>
+        <select id="proxmox-lxc-ssh-auth" name="proxmox_ssh_auth"
+                onchange="proxmoxToggleSshAuth()"
+                class="w-full bg-slate-700 border border-slate-600 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:border-blue-500">
+          <option value="key">SSH key</option>
+          <option value="password">Password</option>
+        </select>
+      </div>
+    </div>
+    <div id="proxmox-lxc-key-row">
+      <label class="block text-xs font-medium text-slate-400 mb-1">Key file</label>
+      <select id="proxmox-lxc-ssh-key" name="proxmox_ssh_key"
+              class="w-full bg-slate-700 border border-slate-600 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:border-blue-500">
+        <option value="">— select key —</option>
+        {% for k in available_keys %}
+        <option value="{{ k }}">{{ k }}</option>
+        {% endfor %}
+      </select>
+    </div>
+    <div id="proxmox-lxc-pass-row" class="hidden">
+      <label class="block text-xs font-medium text-slate-400 mb-1">Password</label>
+      <input type="password" id="proxmox-lxc-ssh-pass" name="proxmox_ssh_password"
+             placeholder="Proxmox server login password"
+             class="w-full bg-slate-700 border border-slate-600 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:border-blue-500">
+    </div>
+    <div class="flex items-center gap-3">
+      <button type="button"
+        hx-post="/setup/connect/proxmox/test-ssh"
+        hx-include="#proxmox-lxc-ssh-user,#proxmox-lxc-ssh-auth,#proxmox-lxc-ssh-key,#proxmox-lxc-ssh-pass"
+        hx-target="#proxmox-lxc-test-result"
+        class="px-3 py-1.5 rounded-lg bg-slate-600 hover:bg-slate-500 text-xs font-medium text-slate-200 transition-colors">
+        Test connection
       </button>
+      <div id="proxmox-lxc-test-result"></div>
+    </div>
+  </div>
 
-    {% else %}
+  <div class="flex gap-2 items-center flex-wrap">
+    <button id="proxmox-add-lxcs-btn" type="button" disabled
+      hx-post="/setup/connect/proxmox/save-lxcs"
+      hx-include=".proxmox-lxc-check,#proxmox-lxc-ssh-user,#proxmox-lxc-ssh-auth,#proxmox-lxc-ssh-key,#proxmox-lxc-ssh-pass"
+      hx-target="#proxmox-section"
+      hx-swap="outerHTML"
+      class="px-4 py-2 rounded-lg bg-blue-600 text-sm font-medium text-white transition-colors opacity-50 cursor-not-allowed">
+      Add selected LXCs
+    </button>
+    <button type="button"
+      hx-post="/setup/connect/proxmox/skip-lxcs"
+      hx-target="#proxmox-section"
+      hx-swap="outerHTML"
+      class="px-4 py-2 rounded-lg bg-slate-700 hover:bg-slate-600 text-sm font-medium text-slate-300 transition-colors">
+      Skip
+    </button>
+  </div>
 
-      <!-- Initial form -->
-      <div id="proxmox-test-result"></div>
-      <div>
-        <label class="block text-xs font-medium text-slate-400 mb-1">Proxmox URL</label>
-        <input type="url" name="proxmox_url" value="{{ proxmox_url or '' }}"
-          placeholder="https://192.168.1.10:8006"
-          class="w-full bg-slate-700 border border-slate-600 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:border-blue-500 placeholder:text-slate-500">
-      </div>
-      <div>
-        <label class="block text-xs font-medium text-slate-400 mb-1">API user</label>
-        <input type="text" name="proxmox_api_user" placeholder="root@pam"
-          class="w-full bg-slate-700 border border-slate-600 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:border-blue-500 placeholder:text-slate-500">
-        <p class="text-xs text-slate-500 mt-1">Datacenter → Permissions → Users</p>
-      </div>
-      <div class="flex gap-3">
-        <div class="flex-1">
-          <label class="block text-xs font-medium text-slate-400 mb-1">Token ID</label>
-          <input type="text" name="proxmox_token_id" placeholder="root@pam!Keepup"
-            class="w-full bg-slate-700 border border-slate-600 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:border-blue-500 placeholder:text-slate-500">
-          <p class="text-xs text-slate-500 mt-1">Datacenter → Permissions → API Tokens → Token ID</p>
+  <script>
+  function proxmoxUpdateLxcPanel() {
+    const anyChecked = document.querySelectorAll('.proxmox-lxc-check:checked').length > 0;
+    document.getElementById('proxmox-lxc-ssh-panel').classList.toggle('hidden', !anyChecked);
+    proxmoxUpdateAddBtn();
+  }
+  function proxmoxToggleSshAuth() {
+    const val = document.getElementById('proxmox-lxc-ssh-auth').value;
+    document.getElementById('proxmox-lxc-key-row').classList.toggle('hidden', val !== 'key');
+    document.getElementById('proxmox-lxc-pass-row').classList.toggle('hidden', val !== 'password');
+    window._proxmoxSshTested = false;
+    proxmoxUpdateAddBtn();
+  }
+  function proxmoxSshTestPassed() {
+    window._proxmoxSshTested = true;
+    proxmoxUpdateAddBtn();
+  }
+  function proxmoxUpdateAddBtn() {
+    const anyChecked = document.querySelectorAll('.proxmox-lxc-check:checked').length > 0;
+    const btn = document.getElementById('proxmox-add-lxcs-btn');
+    if (!btn) return;
+    const ok = anyChecked && window._proxmoxSshTested;
+    btn.disabled = !ok;
+    btn.classList.toggle('opacity-50', !ok);
+    btn.classList.toggle('cursor-not-allowed', !ok);
+    btn.classList.toggle('hover:bg-blue-500', ok);
+  }
+  window._proxmoxSshTested = false;
+  </script>
+
+  {% elif proxmox_step == 'vms' %}
+  <!-- ── Step 4: Virtual machines ── -->
+  {% set vms = proxmox_resources | selectattr('type', 'equalto', 'qemu') | list %}
+  <p class="text-xs text-slate-400">VMs are independent machines. Keepup will add them to your host list — you'll set up a login for each one separately.</p>
+  <form id="proxmox-vm-form" class="space-y-1.5">
+    {% for r in vms %}
+    <div class="px-3 py-2 rounded-lg bg-slate-700/50">
+      <label class="flex items-center gap-3 cursor-pointer">
+        <input type="checkbox" name="selected_vms"
+               value="{{ r.node }}:{{ r.vmid }}:{{ r.name }}"
+               class="w-4 h-4 rounded accent-blue-500 flex-shrink-0">
+        <div class="min-w-0 flex-1">
+          <span class="text-sm text-slate-200 font-medium">{{ r.name }}</span>
+          <span class="text-xs text-slate-500 ml-2">VM {{ r.vmid }} · {{ r.node }}{% if r.ip %} · {{ r.ip }}{% endif %}</span>
         </div>
-        <div class="flex-1">
-          <label class="block text-xs font-medium text-slate-400 mb-1">Secret</label>
-          <input type="password" name="proxmox_secret" placeholder="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
-            class="w-full bg-slate-700 border border-slate-600 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:border-blue-500 placeholder:text-slate-500">
-          <p class="text-xs text-slate-500 mt-1">Datacenter → Permissions → API Tokens → Secret</p>
-        </div>
-      </div>
-      <label class="flex items-center gap-2 cursor-pointer select-none">
-        <input type="checkbox" name="proxmox_verify_ssl" value="on" class="w-4 h-4 rounded accent-blue-500">
-        <span class="text-sm text-slate-300">Verify SSL certificate</span>
+        <span class="ml-auto text-xs px-2 py-0.5 rounded-full flex-shrink-0
+          {% if r.status == 'running' %}bg-green-900/40 text-green-400
+          {% else %}bg-slate-700 text-slate-400{% endif %}">
+          {{ r.status }}
+        </span>
       </label>
-      <div class="flex gap-2 items-center flex-wrap">
-        <button
-          hx-post="/setup/connect/proxmox/test"
-          hx-include="[name='proxmox_url'],[name='proxmox_api_user'],[name='proxmox_token_id'],[name='proxmox_secret'],[name='proxmox_verify_ssl']"
-          hx-target="#proxmox-test-result"
-          class="px-4 py-2 rounded-lg bg-slate-600 hover:bg-slate-500 text-sm font-medium text-slate-200 transition-colors">
-          Test connection
-        </button>
-        <button
-          hx-post="/setup/connect/proxmox/save"
-          hx-include="[name='proxmox_url'],[name='proxmox_api_user'],[name='proxmox_token_id'],[name='proxmox_secret'],[name='proxmox_verify_ssl']"
-          hx-target="#proxmox-section"
-          hx-swap="outerHTML"
-          class="px-4 py-2 rounded-lg bg-blue-600 hover:bg-blue-500 text-sm font-medium text-white transition-colors">
-          Save
-        </button>
+      {% if r.ip %}
+      <input type="hidden" name="vm_ip_{{ r.vmid }}" value="{{ r.ip }}">
+      {% else %}
+      <div class="mt-2 ml-7">
+        <input type="text" name="vm_ip_{{ r.vmid }}" placeholder="Enter IP address"
+               class="w-48 bg-slate-700 border border-slate-600 rounded px-2 py-1 text-xs text-slate-200 focus:outline-none focus:border-blue-500 placeholder:text-slate-500">
+        <span class="text-xs text-slate-500 ml-2">IP not auto-detected</span>
       </div>
+      {% endif %}
+    </div>
+    {% endfor %}
+  </form>
+  <div class="flex flex-col gap-2 items-start pt-1">
+    <button type="button"
+      hx-post="/setup/connect/proxmox/save-vms"
+      hx-include="#proxmox-vm-form"
+      hx-vals='{"vm_action": "now"}'
+      hx-target="#proxmox-section"
+      hx-swap="outerHTML"
+      class="px-4 py-2 rounded-lg bg-blue-600 hover:bg-blue-500 text-sm font-medium text-white transition-colors">
+      Set up logins now
+    </button>
+    <button type="button"
+      hx-post="/setup/connect/proxmox/save-vms"
+      hx-include="#proxmox-vm-form"
+      hx-vals='{"vm_action": "later"}'
+      hx-target="#proxmox-section"
+      hx-swap="outerHTML"
+      class="px-4 py-2 rounded-lg bg-slate-700 hover:bg-slate-600 text-sm font-medium text-slate-300 transition-colors">
+      Save to set up later
+    </button>
+    <button type="button"
+      hx-post="/setup/connect/proxmox/skip-vms"
+      hx-target="#proxmox-section"
+      hx-swap="outerHTML"
+      class="text-xs text-slate-500 hover:text-slate-400 transition-colors px-1 py-1">
+      Skip
+    </button>
+  </div>
 
-    {% endif %}
+  {% elif proxmox_step == 'done' %}
+  <!-- ── Done ── -->
+  <p class="text-sm text-green-400">&#10003; Proxmox setup complete.</p>
+  {% if proxmox_added_summary %}
+  <p class="text-xs text-slate-400">{{ proxmox_added_summary }}</p>
+  {% endif %}
+
+  {% elif proxmox_connected %}
+  <!-- Already connected — offer to continue setup -->
+  <p class="text-xs text-slate-400">
+    Credentials saved. Continue to discover and add your VMs and LXC containers.
+  </p>
+  <button
+    hx-post="/setup/connect/proxmox/discover"
+    hx-target="#proxmox-section"
+    hx-swap="outerHTML"
+    class="px-4 py-2 rounded-lg bg-slate-600 hover:bg-slate-500 text-sm font-medium text-slate-200 transition-colors">
+    Discover VMs &amp; LXCs
+  </button>
+
+  {% else %}
+  <!-- ── Step 1: API credentials ── -->
+  <div id="proxmox-test-result"></div>
+  <div>
+    <label class="block text-xs font-medium text-slate-400 mb-1">Proxmox URL</label>
+    <input type="url" name="proxmox_url" value="{{ proxmox_url or '' }}"
+      placeholder="https://192.168.1.10:8006"
+      class="w-full bg-slate-700 border border-slate-600 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:border-blue-500 placeholder:text-slate-500">
+  </div>
+  <div>
+    <label class="block text-xs font-medium text-slate-400 mb-1">API user</label>
+    <input type="text" name="proxmox_api_user" placeholder="root@pam"
+      class="w-full bg-slate-700 border border-slate-600 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:border-blue-500 placeholder:text-slate-500">
+    <p class="text-xs text-slate-500 mt-1">Datacenter → Permissions → Users</p>
+  </div>
+  <div class="flex gap-3">
+    <div class="flex-1">
+      <label class="block text-xs font-medium text-slate-400 mb-1">Token ID</label>
+      <input type="text" name="proxmox_token_id" placeholder="root@pam!Keepup"
+        class="w-full bg-slate-700 border border-slate-600 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:border-blue-500 placeholder:text-slate-500">
+      <p class="text-xs text-slate-500 mt-1">Datacenter → Permissions → API Tokens → Token ID</p>
+    </div>
+    <div class="flex-1">
+      <label class="block text-xs font-medium text-slate-400 mb-1">Secret</label>
+      <input type="password" name="proxmox_secret" placeholder="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+        class="w-full bg-slate-700 border border-slate-600 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:border-blue-500 placeholder:text-slate-500">
+      <p class="text-xs text-slate-500 mt-1">Datacenter → Permissions → API Tokens → Secret</p>
+    </div>
+  </div>
+  <label class="flex items-center gap-2 cursor-pointer select-none">
+    <input type="checkbox" name="proxmox_verify_ssl" value="on" class="w-4 h-4 rounded accent-blue-500">
+    <span class="text-sm text-slate-300">Verify SSL certificate</span>
+  </label>
+  <div class="flex gap-2 items-center flex-wrap">
+    <button
+      hx-post="/setup/connect/proxmox/test"
+      hx-include="[name='proxmox_url'],[name='proxmox_api_user'],[name='proxmox_token_id'],[name='proxmox_secret'],[name='proxmox_verify_ssl']"
+      hx-target="#proxmox-test-result"
+      class="px-4 py-2 rounded-lg bg-slate-600 hover:bg-slate-500 text-sm font-medium text-slate-200 transition-colors">
+      Test connection
+    </button>
+    <button
+      hx-post="/setup/connect/proxmox/save"
+      hx-include="[name='proxmox_url'],[name='proxmox_api_user'],[name='proxmox_token_id'],[name='proxmox_secret'],[name='proxmox_verify_ssl']"
+      hx-target="#proxmox-section"
+      hx-swap="outerHTML"
+      class="px-4 py-2 rounded-lg bg-blue-600 hover:bg-blue-500 text-sm font-medium text-white transition-colors">
+      Save
+    </button>
+  </div>
+
+  {% endif %}
 
   </div>
 </div>

--- a/tests/test_setup_connect.py
+++ b/tests/test_setup_connect.py
@@ -206,23 +206,14 @@ def test_proxmox_discover_success(setup_client, data_dir):
 
     with patch("app.auth_router.ProxmoxClient") as MockClient:
         instance = AsyncMock()
-        instance.discover_resources = AsyncMock(
-            return_value=[
-                {
-                    "type": "qemu",
-                    "node": "pve",
-                    "vmid": 100,
-                    "name": "ubuntu",
-                    "status": "running",
-                    "ip": "",
-                },
-            ]
-        )
+        instance.get_nodes = AsyncMock(return_value=["pve"])
+        instance.discover_resources = AsyncMock(return_value=[])
         MockClient.return_value = instance
         response = setup_client.post("/setup/connect/proxmox/discover")
 
     assert response.status_code == 200
-    assert "ubuntu" in response.text
+    # Discover now returns the node step
+    assert "pve" in response.text or "Proxmox node" in response.text or "Add Proxmox node" in response.text
 
 
 def test_proxmox_discover_failure(setup_client, data_dir):
@@ -235,6 +226,7 @@ def test_proxmox_discover_failure(setup_client, data_dir):
 
     with patch("app.auth_router.ProxmoxClient") as MockClient:
         instance = AsyncMock()
+        instance.get_nodes = AsyncMock(side_effect=Exception("timeout"))
         instance.discover_resources = AsyncMock(side_effect=Exception("timeout"))
         MockClient.return_value = instance
         response = setup_client.post("/setup/connect/proxmox/discover")
@@ -244,27 +236,139 @@ def test_proxmox_discover_failure(setup_client, data_dir):
 
 
 # ---------------------------------------------------------------------------
-# POST /setup/connect/proxmox/select-hosts
+# New guided flow endpoints
 # ---------------------------------------------------------------------------
 
 
-def test_proxmox_select_hosts(setup_client, data_dir):
+def test_proxmox_add_node(setup_client, data_dir):
+    _create_admin()
+    from app.config_manager import save_proxmox_config
+    from app.credentials import save_integration_credentials
+
+    save_proxmox_config(url="https://192.168.1.10:8006", verify_ssl=False)
+    save_integration_credentials("proxmox", token_id="user@pam!token", secret="abc")
+
+    with patch("app.auth_router.ProxmoxClient") as MockClient:
+        instance = AsyncMock()
+        instance.get_nodes = AsyncMock(return_value=["pve"])
+        MockClient.return_value = instance
+        response = setup_client.post("/setup/connect/proxmox/add-node")
+
+    assert response.status_code == 200
+    # Proceeds to LXC step (or done if no resources in session)
+    assert "proxmox-section" in response.text
+
+
+def test_proxmox_skip_node(setup_client, data_dir):
+    _create_admin()
+    response = setup_client.post("/setup/connect/proxmox/skip-node")
+    assert response.status_code == 200
+    # No LXCs in session → skips to done or VMs
+    assert "proxmox-section" in response.text
+
+
+def test_proxmox_test_ssh_no_config(setup_client, data_dir):
     _create_admin()
     response = setup_client.post(
-        "/setup/connect/proxmox/select-hosts",
+        "/setup/connect/proxmox/test-ssh",
+        data={"proxmox_ssh_user": "root", "proxmox_ssh_auth": "key", "proxmox_ssh_key": ""},
+    )
+    assert response.status_code == 200
+    assert "not configured" in response.text.lower() or "select a key" in response.text.lower()
+
+
+def test_proxmox_test_ssh_success(setup_client, data_dir):
+    _create_admin()
+    from app.config_manager import save_proxmox_config
+
+    save_proxmox_config(url="https://192.168.1.10:8006", verify_ssl=False)
+
+    with patch("app.auth_router.verify_connection", new_callable=AsyncMock) as mock_vc:
+        mock_vc.return_value = {"ok": True, "message": ""}
+        response = setup_client.post(
+            "/setup/connect/proxmox/test-ssh",
+            data={"proxmox_ssh_user": "root", "proxmox_ssh_auth": "password", "proxmox_ssh_password": "secret"},
+        )
+    assert response.status_code == 200
+    assert "192.168.1.10" in response.text
+    assert "proxmoxSshTestPassed" in response.text
+
+
+def test_proxmox_test_ssh_failure(setup_client, data_dir):
+    _create_admin()
+    from app.config_manager import save_proxmox_config
+
+    save_proxmox_config(url="https://192.168.1.10:8006", verify_ssl=False)
+
+    with patch("app.auth_router.verify_connection", new_callable=AsyncMock) as mock_vc:
+        mock_vc.return_value = {"ok": False, "message": "Connection refused"}
+        response = setup_client.post(
+            "/setup/connect/proxmox/test-ssh",
+            data={"proxmox_ssh_user": "root", "proxmox_ssh_auth": "password", "proxmox_ssh_password": "secret"},
+        )
+    assert response.status_code == 200
+    assert "Connection refused" in response.text
+
+
+def test_proxmox_save_lxcs(setup_client, data_dir):
+    _create_admin()
+    response = setup_client.post(
+        "/setup/connect/proxmox/save-lxcs",
         data={
-            "selected_hosts": ["pve:100:vm:ubuntu-vm", "pve:101:lxc:debian-ct"],
+            "selected_lxcs": ["pve:100:debian:192.168.1.100"],
+            "proxmox_ssh_user": "root",
+            "proxmox_ssh_auth": "password",
+            "proxmox_ssh_password": "secret",
         },
     )
     assert response.status_code == 200
-    assert "2 hosts" in response.text or "queued" in response.text.lower()
+    from app.config_manager import get_hosts
+    assert any(h.get("proxmox_vmid") == 100 for h in get_hosts())
 
 
-def test_proxmox_select_hosts_empty(setup_client, data_dir):
+def test_proxmox_skip_lxcs(setup_client, data_dir):
     _create_admin()
-    response = setup_client.post("/setup/connect/proxmox/select-hosts", data={})
+    response = setup_client.post("/setup/connect/proxmox/skip-lxcs")
     assert response.status_code == 200
-    assert "0 hosts" in response.text or "queued" in response.text.lower()
+    assert "proxmox-section" in response.text
+
+
+def test_proxmox_save_vms_later(setup_client, data_dir):
+    _create_admin()
+    response = setup_client.post(
+        "/setup/connect/proxmox/save-vms",
+        data={
+            "selected_vms": ["pve:200:ubuntu-server"],
+            "vm_ip_200": "192.168.1.200",
+            "vm_action": "later",
+        },
+    )
+    assert response.status_code == 200
+    assert "done" in response.text or "complete" in response.text.lower() or "added" in response.text
+    from app.config_manager import get_hosts
+    assert any(h.get("host") == "192.168.1.200" for h in get_hosts())
+
+
+def test_proxmox_save_vms_now(setup_client, data_dir):
+    _create_admin()
+    with setup_client as c:
+        response = c.post(
+            "/setup/connect/proxmox/save-vms",
+            data={
+                "selected_vms": ["pve:201:media-server"],
+                "vm_ip_201": "192.168.1.201",
+                "vm_action": "now",
+            },
+        )
+    assert response.status_code == 200
+    assert "done" in response.text or "complete" in response.text.lower() or "added" in response.text
+
+
+def test_proxmox_skip_vms(setup_client, data_dir):
+    _create_admin()
+    response = setup_client.post("/setup/connect/proxmox/skip-vms")
+    assert response.status_code == 200
+    assert "complete" in response.text.lower() or "done" in response.text
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_setup_hosts.py
+++ b/tests/test_setup_hosts.py
@@ -537,29 +537,15 @@ def test_setup_hosts_shows_queued_cards_when_pending(
 ):
     """GET /setup/hosts shows queued host cards when proxmox_pending is in session."""
     _create_admin()
-    # Inject queued hosts into session by using the select-hosts route
-    from unittest.mock import MagicMock, AsyncMock, patch
-
-    with patch("app.auth_router.ProxmoxClient") as MockClient:
-        mock_instance = MagicMock()
-        mock_instance.discover_resources = AsyncMock(
-            return_value=[
-                {
-                    "type": "vm",
-                    "node": "pve1",
-                    "vmid": 100,
-                    "name": "MyVM",
-                    "status": "running",
-                },
-            ]
-        )
-        MockClient.return_value = mock_instance
-        setup_client.post(
-            "/setup/connect/proxmox/select-hosts",
-            data={
-                "selected_hosts": ["pve1:100:vm:MyVM"],
-            },
-        )
+    # Queue a VM via save-vms with vm_action=now so it ends up in setup_proxmox_pending
+    setup_client.post(
+        "/setup/connect/proxmox/save-vms",
+        data={
+            "selected_vms": ["pve1:100:MyVM"],
+            "vm_ip_100": "192.168.1.100",
+            "vm_action": "now",
+        },
+    )
     response = setup_client.get("/setup/hosts")
     assert response.status_code == 200
     assert "MyVM" in response.text


### PR DESCRIPTION
OP#85

## Summary
- Replaces the single-step Proxmox setup with a guided 4-step wizard: connect → node → LXCs → VMs
- Captures SSH credentials during the LXC step so LXC monitoring works out of the box without post-setup configuration
- SSH panel uses progressive disclosure — only appears when at least one LXC is selected

## Changes
- `app/templates/partials/setup_proxmox_section.html`: Complete rewrite into 5 template states (`proxmox_connected`, `node`, `lxcs`, `vms`, `done`)
- `app/auth_router.py`: New endpoints `add-node`, `skip-node`, `test-ssh`, `save-lxcs`, `skip-lxcs`, `save-vms`, `skip-vms`; removed `select-hosts`
- `tests/test_setup_connect.py`: Updated + added tests for all new wizard steps
- `tests/test_setup_hosts.py`: Updated pending-VMs test to use new `save-vms` endpoint

## Test plan
- [ ] Connect a Proxmox integration in setup wizard and verify node/LXC/VM steps appear in sequence
- [ ] Check LXC SSH panel only shows when at least one LXC is checked
- [ ] Verify "Test login" enables the Add button on success and shows error on failure
- [ ] Skip paths: skip node, skip LXCs, skip VMs — all reach done state cleanly
- [ ] VMs with no IP show inline IP input; VMs with existing IP do not

🤖 Generated with [Claude Code](https://claude.com/claude-code)