### PR TITLE
Group Proxmox resources by node with type badges on dashboard (OP#84)

### DIFF
--- a/app/admin.py
+++ b/app/admin.py
@@ -317,10 +317,16 @@ async def admin_proxmox_select_hosts(request: Request) -> HTMLResponse:
                 name=name, host=ip, user=None, port=None,
                 proxmox_node=node,
                 proxmox_vmid=vmid,
+                proxmox_type="lxc",
             )
             lxc_added.append(name)
         else:
-            add_host(name=name, host=ip, user=None, port=None)
+            add_host(
+                name=name, host=ip, user=None, port=None,
+                proxmox_node=node,
+                proxmox_vmid=vmid,
+                proxmox_type="vm",
+            )
             vm_added.append(name)
         existing.add(ip)
 

--- a/app/config_manager.py
+++ b/app/config_manager.py
@@ -52,6 +52,7 @@ def _build_host_entry(
     docker_mode: str | None = None,
     proxmox_node: str | None = None,
     proxmox_vmid: int | None = None,
+    proxmox_type: str | None = None,
 ) -> dict:
     """Builds a host entry for config.yml — no credentials stored here."""
     entry: dict = {"name": name, "host": host}
@@ -67,6 +68,8 @@ def _build_host_entry(
         entry["proxmox_node"] = proxmox_node
     if proxmox_vmid is not None:
         entry["proxmox_vmid"] = proxmox_vmid
+    if proxmox_type:
+        entry["proxmox_type"] = proxmox_type
     return entry
 
 
@@ -79,6 +82,7 @@ def add_host(
     docker_mode: str | None = None,
     proxmox_node: str | None = None,
     proxmox_vmid: int | None = None,
+    proxmox_type: str | None = None,
 ) -> str:
     """Add a host to config and return its slug."""
     config = load_config()
@@ -90,6 +94,7 @@ def add_host(
             docker_mode=docker_mode,
             proxmox_node=proxmox_node,
             proxmox_vmid=proxmox_vmid,
+            proxmox_type=proxmox_type,
         )
     )
     save_config(config)

--- a/app/main.py
+++ b/app/main.py
@@ -177,6 +177,33 @@ def _get_host(slug: str) -> dict:
     raise KeyError(f"Host {slug!r} not in config")
 
 
+def _group_hosts(hosts: list[dict]) -> tuple[list[dict], list[dict]]:
+    """Return (proxmox_groups, standalone_hosts).
+
+    Each group: {name, node_host, lxcs, vms} where node_host may be None
+    if the node itself isn't monitored.
+    """
+    nodes: dict[str, dict] = {}
+    standalone: list[dict] = []
+    for h in hosts:
+        node = h.get("proxmox_node")
+        if not node:
+            standalone.append(h)
+            continue
+        if node not in nodes:
+            nodes[node] = {"name": node, "node_host": None, "lxcs": [], "vms": []}
+        vmid = h.get("proxmox_vmid")
+        if vmid is None:
+            nodes[node]["node_host"] = h
+        else:
+            ptype = h.get("proxmox_type") or "lxc"
+            if ptype == "vm":
+                nodes[node]["vms"].append(h)
+            else:
+                nodes[node]["lxcs"].append(h)
+    return list(nodes.values()), standalone
+
+
 _jobs: dict[str, dict] = {}
 
 
@@ -321,11 +348,14 @@ async def main_home(request: Request) -> HTMLResponse:
     )
     latest_tag, latest_url = await _get_latest_version()
     show_update = _newer_version(latest_tag)
+    host_groups, standalone_hosts = _group_hosts(hosts)
     return templates.TemplateResponse(
         "index.html",
         {
             "request": request,
             "hosts": hosts,
+            "host_groups": host_groups,
+            "standalone_hosts": standalone_hosts,
             "docker_configured": docker_configured,
             "pbs_configured": pbs_configured,
             "app_version": APP_VERSION,

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -135,7 +135,88 @@
           <span class="text-[11px] font-medium text-slate-600 uppercase tracking-widest text-right">Action</span>
         </div>
 
-        {% for host in hosts %}
+        {% if not hosts %}
+        <div class="px-4 py-8 text-sm text-slate-500 text-center">No hosts configured. <a href="/admin" class="text-blue-400 hover:underline">Add one in Admin →</a></div>
+        {% endif %}
+
+        {# Proxmox groups #}
+        {% for group in host_groups %}
+        <div class="flex items-center gap-2 px-4 py-2 bg-[#0d1117] border-b border-[#21262d]">
+          <span class="text-orange-500" style="font-size:11px">◈</span>
+          <span class="text-[11px] font-medium text-orange-400 tracking-wide">Proxmox VE {{ group.name }}</span>
+        </div>
+
+        {% if group.node_host %}
+        {% set host = group.node_host %}
+        <div class="border-b border-[#21262d] px-4 py-3 grid grid-cols-1 sm:grid-cols-[1fr_1fr_160px] gap-2 sm:gap-3 items-start sm:items-center hover:bg-white/[0.02] transition-colors">
+          <div>
+            <div class="text-[13px] font-medium text-slate-100">{{ host.name }}</div>
+            <div class="text-[11px] text-slate-500 font-mono mt-0.5">{{ host.host }}</div>
+            <span class="inline-flex items-center mt-1 px-1.5 py-0.5 rounded text-[10px] font-medium bg-orange-950/50 text-orange-400 border border-orange-900/40">Node</span>
+          </div>
+          <div id="host-{{ host.slug }}-status"
+            data-check
+            hx-get="/api/host/{{ host.slug }}/check"
+            hx-trigger="load, check"
+            hx-swap="innerHTML"
+            hx-indicator="#host-{{ host.slug }}-spinner">
+            <span class="text-[12px] text-slate-500 animate-pulse">Checking…</span>
+          </div>
+          <div id="host-{{ host.slug }}-action" class="sm:text-right"></div>
+          <span id="host-{{ host.slug }}-spinner" class="spinner text-[11px] text-slate-600">Refreshing…</span>
+        </div>
+        {% endif %}
+
+        {% for host in group.lxcs %}
+        <div class="border-b border-[#21262d] px-4 py-3 grid grid-cols-1 sm:grid-cols-[1fr_1fr_160px] gap-2 sm:gap-3 items-start sm:items-center hover:bg-white/[0.02] transition-colors">
+          <div>
+            <div class="text-[13px] font-medium text-slate-100">{{ host.name }}</div>
+            <div class="text-[11px] text-slate-500 font-mono mt-0.5">{{ host.host }}</div>
+            <span class="inline-flex items-center mt-1 px-1.5 py-0.5 rounded text-[10px] font-medium bg-orange-950/50 text-orange-400 border border-orange-900/40">LXC {{ host.proxmox_vmid }}</span>
+          </div>
+          <div id="host-{{ host.slug }}-status"
+            data-check
+            hx-get="/api/host/{{ host.slug }}/check"
+            hx-trigger="load, check"
+            hx-swap="innerHTML"
+            hx-indicator="#host-{{ host.slug }}-spinner">
+            <span class="text-[12px] text-slate-500 animate-pulse">Checking…</span>
+          </div>
+          <div id="host-{{ host.slug }}-action" class="sm:text-right"></div>
+          <span id="host-{{ host.slug }}-spinner" class="spinner text-[11px] text-slate-600">Refreshing…</span>
+        </div>
+        {% endfor %}
+
+        {% for host in group.vms %}
+        <div class="border-b border-[#21262d] px-4 py-3 grid grid-cols-1 sm:grid-cols-[1fr_1fr_160px] gap-2 sm:gap-3 items-start sm:items-center hover:bg-white/[0.02] transition-colors">
+          <div>
+            <div class="text-[13px] font-medium text-slate-100">{{ host.name }}</div>
+            <div class="text-[11px] text-slate-500 font-mono mt-0.5">{{ host.host }}</div>
+            <span class="inline-flex items-center mt-1 px-1.5 py-0.5 rounded text-[10px] font-medium bg-orange-950/50 text-orange-400 border border-orange-900/40">VM {{ host.proxmox_vmid }}</span>
+          </div>
+          <div id="host-{{ host.slug }}-status"
+            data-check
+            hx-get="/api/host/{{ host.slug }}/check"
+            hx-trigger="load, check"
+            hx-swap="innerHTML"
+            hx-indicator="#host-{{ host.slug }}-spinner">
+            <span class="text-[12px] text-slate-500 animate-pulse">Checking…</span>
+          </div>
+          <div id="host-{{ host.slug }}-action" class="sm:text-right"></div>
+          <span id="host-{{ host.slug }}-spinner" class="spinner text-[11px] text-slate-600">Refreshing…</span>
+        </div>
+        {% endfor %}
+
+        {% endfor %}
+
+        {# Standalone hosts — section divider only shown when Proxmox groups also exist #}
+        {% if standalone_hosts and host_groups %}
+        <div class="px-4 py-2 bg-[#0d1117] border-b border-[#21262d]">
+          <span class="text-[11px] font-medium text-slate-500 uppercase tracking-widest">Standalone hosts</span>
+        </div>
+        {% endif %}
+
+        {% for host in standalone_hosts %}
         <div class="border-b border-[#21262d] last:border-0 px-4 py-3 grid grid-cols-1 sm:grid-cols-[1fr_1fr_160px] gap-2 sm:gap-3 items-start sm:items-center hover:bg-white/[0.02] transition-colors">
           <div>
             <div class="text-[13px] font-medium text-slate-100">{{ host.name }}</div>
@@ -152,9 +233,8 @@
           <div id="host-{{ host.slug }}-action" class="sm:text-right"></div>
           <span id="host-{{ host.slug }}-spinner" class="spinner text-[11px] text-slate-600">Refreshing…</span>
         </div>
-        {% else %}
-        <div class="px-4 py-8 text-sm text-slate-500 text-center">No hosts configured. <a href="/admin" class="text-blue-400 hover:underline">Add one in Admin →</a></div>
         {% endfor %}
+
       </div>
     </section>
 

--- a/tests/test_main_routes.py
+++ b/tests/test_main_routes.py
@@ -169,3 +169,177 @@ def test_dashboard_no_update_notice_when_version_check_fails(client):
         response = client.get("/dashboard")
     assert response.status_code == 200
     assert "available ↑" not in response.text
+
+
+# ---------------------------------------------------------------------------
+# _group_hosts unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_group_hosts_all_standalone():
+    from app.main import _group_hosts
+
+    hosts = [
+        {"slug": "a", "name": "A", "host": "1.1.1.1"},
+        {"slug": "b", "name": "B", "host": "1.1.1.2"},
+    ]
+    groups, standalone = _group_hosts(hosts)
+    assert groups == []
+    assert len(standalone) == 2
+
+
+def test_group_hosts_proxmox_node_only():
+    from app.main import _group_hosts
+
+    hosts = [
+        {"slug": "pve", "name": "Proxmox VE (pve)", "host": "10.0.0.1", "proxmox_node": "pve"},
+    ]
+    groups, standalone = _group_hosts(hosts)
+    assert len(groups) == 1
+    assert groups[0]["name"] == "pve"
+    assert groups[0]["node_host"]["slug"] == "pve"
+    assert groups[0]["lxcs"] == []
+    assert groups[0]["vms"] == []
+    assert standalone == []
+
+
+def test_group_hosts_lxc_defaults_to_lxc_type():
+    from app.main import _group_hosts
+
+    hosts = [
+        {
+            "slug": "myct",
+            "name": "My CT",
+            "host": "10.0.0.2",
+            "proxmox_node": "pve",
+            "proxmox_vmid": 101,
+        },
+    ]
+    groups, standalone = _group_hosts(hosts)
+    assert len(groups[0]["lxcs"]) == 1
+    assert groups[0]["vms"] == []
+
+
+def test_group_hosts_explicit_vm_type():
+    from app.main import _group_hosts
+
+    hosts = [
+        {
+            "slug": "myvm",
+            "name": "My VM",
+            "host": "10.0.0.3",
+            "proxmox_node": "pve",
+            "proxmox_vmid": 200,
+            "proxmox_type": "vm",
+        },
+    ]
+    groups, standalone = _group_hosts(hosts)
+    assert groups[0]["vms"][0]["slug"] == "myvm"
+    assert groups[0]["lxcs"] == []
+
+
+def test_group_hosts_mixed_node_lxc_vm_and_standalone():
+    from app.main import _group_hosts
+
+    hosts = [
+        {"slug": "standalone", "name": "Standalone", "host": "1.2.3.4"},
+        {"slug": "node", "name": "PVE", "host": "10.0.0.1", "proxmox_node": "pve"},
+        {"slug": "lxc101", "name": "LXC 101", "host": "10.0.0.2", "proxmox_node": "pve", "proxmox_vmid": 101, "proxmox_type": "lxc"},
+        {"slug": "vm200", "name": "VM 200", "host": "10.0.0.3", "proxmox_node": "pve", "proxmox_vmid": 200, "proxmox_type": "vm"},
+    ]
+    groups, standalone = _group_hosts(hosts)
+    assert len(groups) == 1
+    assert groups[0]["node_host"]["slug"] == "node"
+    assert len(groups[0]["lxcs"]) == 1
+    assert len(groups[0]["vms"]) == 1
+    assert len(standalone) == 1
+
+
+def test_group_hosts_multiple_nodes():
+    from app.main import _group_hosts
+
+    hosts = [
+        {"slug": "n1", "name": "Node1", "host": "10.0.0.1", "proxmox_node": "pve1"},
+        {"slug": "n2", "name": "Node2", "host": "10.0.0.2", "proxmox_node": "pve2"},
+        {"slug": "ct1", "name": "CT1", "host": "10.0.0.3", "proxmox_node": "pve1", "proxmox_vmid": 101},
+    ]
+    groups, standalone = _group_hosts(hosts)
+    assert len(groups) == 2
+    pve1 = next(g for g in groups if g["name"] == "pve1")
+    assert pve1["node_host"]["slug"] == "n1"
+    assert len(pve1["lxcs"]) == 1
+
+
+# ---------------------------------------------------------------------------
+# Dashboard rendering with grouped hosts
+# ---------------------------------------------------------------------------
+
+
+def test_home_shows_proxmox_group_header(client, config_file):
+    import yaml
+
+    cfg = yaml.safe_load(config_file.read_text())
+    cfg["hosts"].append({
+        "name": "Proxmox VE (pve)",
+        "host": "10.0.0.1",
+        "proxmox_node": "pve",
+    })
+    config_file.write_text(yaml.dump(cfg))
+
+    response = client.get("/home")
+    assert response.status_code == 200
+    assert "Proxmox VE pve" in response.text
+
+
+def test_home_shows_lxc_badge(client, config_file):
+    import yaml
+
+    cfg = yaml.safe_load(config_file.read_text())
+    cfg["hosts"].append({
+        "name": "My LXC",
+        "host": "10.0.0.5",
+        "proxmox_node": "pve",
+        "proxmox_vmid": 105,
+        "proxmox_type": "lxc",
+    })
+    config_file.write_text(yaml.dump(cfg))
+
+    response = client.get("/home")
+    assert "LXC 105" in response.text
+
+
+def test_home_shows_vm_badge(client, config_file):
+    import yaml
+
+    cfg = yaml.safe_load(config_file.read_text())
+    cfg["hosts"].append({
+        "name": "My VM",
+        "host": "10.0.0.6",
+        "proxmox_node": "pve",
+        "proxmox_vmid": 201,
+        "proxmox_type": "vm",
+    })
+    config_file.write_text(yaml.dump(cfg))
+
+    response = client.get("/home")
+    assert "VM 201" in response.text
+
+
+def test_home_shows_standalone_divider_when_mixed(client, config_file):
+    import yaml
+
+    cfg = yaml.safe_load(config_file.read_text())
+    cfg["hosts"].append({
+        "name": "Proxmox VE (pve)",
+        "host": "10.0.0.1",
+        "proxmox_node": "pve",
+    })
+    config_file.write_text(yaml.dump(cfg))
+
+    response = client.get("/home")
+    assert "Standalone hosts" in response.text
+
+
+def test_home_no_standalone_divider_when_only_standalone(client):
+    response = client.get("/home")
+    assert "Standalone hosts" not in response.text


### PR DESCRIPTION
OP#84

## Summary
- Dashboard now groups Proxmox hosts under an orange "◈ Proxmox VE {node}" header row per cluster node
- Type badges appear below each host name: **Node**, **LXC {vmid}**, **VM {vmid}** in orange
- Standalone (non-Proxmox) hosts appear last with a "Standalone hosts" divider only when Proxmox groups are also present
- Added `proxmox_type` field to `config_manager` so LXC/VM distinction is persisted; falls back to `"lxc"` for existing hosts with only `proxmox_vmid` set

## Test plan
- [ ] Open dashboard with a Proxmox node host → see "◈ Proxmox VE {node}" group header and "Node" badge
- [ ] Add an LXC via Admin > Integrations > Proxmox → see "LXC {vmid}" badge under group
- [ ] Add a VM via Admin > Integrations > Proxmox → see "VM {vmid}" badge under group
- [ ] Dashboard with only standalone SSH hosts → no group headers, no divider
- [ ] Dashboard with both Proxmox and SSH hosts → "Standalone hosts" divider appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)