### PR TITLE
Monitor Docker containers on Proxmox nodes inline (OP#82)

### DIFF
--- a/app/backends/ssh_docker_backend.py
+++ b/app/backends/ssh_docker_backend.py
@@ -98,7 +98,8 @@ class SSHDockerBackend:
 
     async def update_stack(self, ref: str) -> None:
         slug, rest = self._parse_ref(ref)
-        host = next((h for h in self._docker_hosts() if h["slug"] == slug), None)
+        all_docker = [h for h in get_hosts() if h.get("docker_mode")]
+        host = next((h for h in all_docker if h["slug"] == slug), None)
         if host is None:
             raise ValueError(f"No Docker-enabled host with slug {slug!r}")
 

--- a/app/backends/ssh_docker_backend.py
+++ b/app/backends/ssh_docker_backend.py
@@ -32,7 +32,10 @@ class SSHDockerBackend:
     BACKEND_KEY = "ssh"
 
     def _docker_hosts(self) -> list[dict]:
-        return [h for h in get_hosts() if h.get("docker_mode")]
+        return [
+            h for h in get_hosts()
+            if h.get("docker_mode") and not (h.get("proxmox_node") and not h.get("proxmox_vmid"))
+        ]
 
     def _make_compose_ref(self, slug: str, project: str, container: str) -> str:
         return f"{slug}/{quote(project, safe='')}:{quote(container, safe='')}"

--- a/app/main.py
+++ b/app/main.py
@@ -338,8 +338,10 @@ async def home(request: Request) -> HTMLResponse:
 async def main_home(request: Request) -> HTMLResponse:
     hosts = get_hosts()
     backends = get_backends()
+    # Node hosts with docker_mode show inline — exclude from global Containers section
     docker_configured = any(b.BACKEND_KEY == "portainer" for b in backends) or any(
-        h.get("docker_mode") for h in hosts
+        h.get("docker_mode") and not (h.get("proxmox_node") and not h.get("proxmox_vmid"))
+        for h in hosts
     )
     pbs_creds = get_integration_credentials("proxmox_backup")
     pbs_cfg = get_pbs_config()
@@ -349,6 +351,11 @@ async def main_home(request: Request) -> HTMLResponse:
     latest_tag, latest_url = await _get_latest_version()
     show_update = _newer_version(latest_tag)
     host_groups, standalone_hosts = _group_hosts(hosts)
+    node_docker_slugs = [
+        g["node_host"]["slug"]
+        for g in host_groups
+        if g.get("node_host") and g["node_host"].get("docker_mode")
+    ]
     return templates.TemplateResponse(
         "index.html",
         {
@@ -356,6 +363,7 @@ async def main_home(request: Request) -> HTMLResponse:
             "hosts": hosts,
             "host_groups": host_groups,
             "standalone_hosts": standalone_hosts,
+            "node_docker_slugs": node_docker_slugs,
             "docker_configured": docker_configured,
             "pbs_configured": pbs_configured,
             "app_version": APP_VERSION,
@@ -368,6 +376,29 @@ async def main_home(request: Request) -> HTMLResponse:
 @app.get("/dashboard", response_class=HTMLResponse)
 async def dashboard_redirect(request: Request) -> HTMLResponse:
     return RedirectResponse("/home", status_code=301)
+
+
+@app.get("/api/host/{slug}/docker", response_class=HTMLResponse)
+async def host_docker(request: Request, slug: str) -> HTMLResponse:
+    """Return inline Docker container rows for a Proxmox node host."""
+    try:
+        host = _get_host(slug)
+        if not host.get("docker_mode"):
+            return HTMLResponse("")
+        from .backends.ssh_docker_backend import SSHDockerBackend
+
+        backend = SSHDockerBackend()
+        stacks = await backend._containers_for_host(host, get_ssh_config(), get_dockerhub_creds())
+        return templates.TemplateResponse(
+            "partials/node_docker_status.html",
+            {"request": request, "stacks": stacks, "slug": slug},
+        )
+    except Exception as exc:
+        log.exception("host_docker failed for %s: %s", slug, exc)
+        return templates.TemplateResponse(
+            "partials/error.html",
+            {"request": request, "message": str(exc)},
+        )
 
 
 @app.get("/api/integration/pbs/status", response_class=HTMLResponse)

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -165,6 +165,16 @@
           <div id="host-{{ host.slug }}-action" class="sm:text-right"></div>
           <span id="host-{{ host.slug }}-spinner" class="spinner text-[11px] text-slate-600">Refreshing…</span>
         </div>
+        {% if host.docker_mode %}
+        <div id="node-{{ host.slug }}-docker"
+          data-check
+          hx-get="/api/host/{{ host.slug }}/docker"
+          hx-trigger="load, check"
+          hx-swap="innerHTML"
+          hx-indicator="#node-{{ host.slug }}-docker-spinner">
+        </div>
+        <span id="node-{{ host.slug }}-docker-spinner" class="spinner text-[11px] text-slate-600">Checking containers…</span>
+        {% endif %}
         {% endif %}
 
         {% for host in group.lxcs %}
@@ -303,9 +313,10 @@
 
   <script>
   const _hostSlugs = {{ hosts | map(attribute='slug') | list | tojson }};
+  const _nodeDockerSlugs = {{ node_docker_slugs | tojson }};
   const _dockerConfigured = {{ 'true' if docker_configured else 'false' }};
   const _checkedIds = new Set();
-  const _totalChecks = _hostSlugs.length + (_dockerConfigured ? 1 : 0);
+  const _totalChecks = _hostSlugs.length + (_dockerConfigured ? 1 : 0) + _nodeDockerSlugs.length;
 
   function resetBanner() {
     _checkedIds.clear();
@@ -323,7 +334,8 @@
     const id = e.detail.target.id;
     const isHost = _hostSlugs.some(s => `host-${s}-status` === id);
     const isDocker = id === 'docker-status';
-    if (isHost || isDocker) {
+    const isNodeDocker = _nodeDockerSlugs.some(s => `node-${s}-docker` === id);
+    if (isHost || isDocker || isNodeDocker) {
       _checkedIds.add(id);
       if (_checkedIds.size >= _totalChecks) updateBanner();
     }
@@ -343,6 +355,10 @@
       const el = document.getElementById('docker-status');
       if (el && el.querySelector('.text-amber-400')) containerUpdates = true;
     }
+    _nodeDockerSlugs.forEach(slug => {
+      const el = document.getElementById(`node-${slug}-docker`);
+      if (el && el.querySelector('.text-amber-400')) containerUpdates = true;
+    });
 
     const banner = document.getElementById('status-banner');
     const icon = document.getElementById('banner-icon');

--- a/app/templates/partials/node_docker_status.html
+++ b/app/templates/partials/node_docker_status.html
@@ -1,0 +1,41 @@
+{% for stack in stacks %}
+{% set action_id = stack.update_path | replace('/', '-') | replace(':', '-') %}
+<div class="border-b border-[#21262d] px-4 py-3 grid grid-cols-1 sm:grid-cols-[1fr_1fr_160px] gap-2 sm:gap-3 items-start sm:items-center hover:bg-white/[0.02] transition-colors">
+  <div>
+    <div class="text-[13px] font-medium text-slate-100">{{ stack.name }}</div>
+    {% if stack.images %}
+    <div class="text-[11px] text-slate-500 font-mono mt-0.5">{{ stack.images[0].name }}</div>
+    {% endif %}
+    <span class="inline-flex items-center mt-1 px-1.5 py-0.5 rounded text-[10px] font-medium bg-blue-950/50 text-blue-400 border border-blue-900/40">Docker</span>
+  </div>
+  <div>
+    {% if stack.update_status == "update_available" or stack.update_status == "mixed" %}
+    <span class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-[12px] font-medium bg-amber-900/40 text-amber-400 border border-amber-800/50">
+      <span class="w-1.5 h-1.5 rounded-full bg-current flex-shrink-0"></span>
+      {% if stack.update_status == "mixed" %}Partial update{% else %}Update available{% endif %}
+    </span>
+    {% elif stack.update_status == "up_to_date" %}
+    <span class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-[12px] font-medium bg-green-900/40 text-green-400 border border-green-800/50">
+      <span class="w-1.5 h-1.5 rounded-full bg-current flex-shrink-0"></span>
+      Up to date
+    </span>
+    {% else %}
+    <span class="text-[12px] text-slate-500">Unknown</span>
+    {% endif %}
+  </div>
+  <div class="sm:text-right">
+    {% if stack.update_status in ("update_available", "mixed") %}
+    <div id="stack-{{ action_id }}-action">
+      <button
+        hx-post="/api/docker/stack/{{ stack.update_path }}/update"
+        hx-target="#stack-{{ action_id }}-action"
+        hx-swap="innerHTML"
+        hx-confirm="Pull and redeploy '{{ stack.name }}'?"
+        class="text-[12px] font-medium px-3 py-1 rounded-md border border-[#2ea043] text-green-400 hover:bg-green-900/20 transition-colors">
+        Redeploy
+      </button>
+    </div>
+    {% endif %}
+  </div>
+</div>
+{% endfor %}

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -237,9 +237,34 @@ async def test_discover_stacks_ssh_error_returns_empty(config_file, data_dir):
 @pytest.mark.asyncio
 async def test_update_stack_unknown_host_raises(config_file, data_dir):
     backend = SSHDockerBackend()
-    # No docker_mode hosts in config → _docker_hosts() returns []
+    # No docker_mode hosts in config → raises ValueError
     with pytest.raises(ValueError, match="my-server"):
         await backend.update_stack("my-server/sonarr")
+
+
+@pytest.mark.asyncio
+async def test_update_stack_proxmox_node_host_can_redeploy(config_file, data_dir):
+    """Proxmox node hosts are excluded from the global scan but can still be updated."""
+    import yaml
+
+    raw = yaml.safe_load(config_file.read_text())
+    raw["hosts"][0]["proxmox_node"] = "pve"
+    raw["hosts"][0]["docker_mode"] = "all"
+    config_file.write_text(yaml.dump(raw))
+
+    ls_output = json.dumps([{"Name": "sonarr", "ConfigFiles": "/opt/sonarr/docker-compose.yml"}])
+    conn = _make_multi_conn(
+        [
+            MagicMock(stdout=ls_output, returncode=0),
+            MagicMock(stdout="Pulled", returncode=0),
+            MagicMock(stdout="Started", returncode=0),
+        ]
+    )
+
+    with patch("app.backends.ssh_docker_backend._connect", new=AsyncMock(return_value=conn)):
+        backend = SSHDockerBackend()
+        # Should NOT raise even though node is excluded from _docker_hosts()
+        await backend.update_stack("test-host/sonarr:sonarr")
 
 
 @pytest.mark.asyncio

--- a/tests/test_main_routes.py
+++ b/tests/test_main_routes.py
@@ -343,3 +343,167 @@ def test_home_shows_standalone_divider_when_mixed(client, config_file):
 def test_home_no_standalone_divider_when_only_standalone(client):
     response = client.get("/home")
     assert "Standalone hosts" not in response.text
+
+
+# ---------------------------------------------------------------------------
+# Node Docker monitoring (OP#82)
+# ---------------------------------------------------------------------------
+
+
+def test_home_shows_docker_section_for_node_with_docker_mode(client, config_file):
+    """Node host with docker_mode gets an inline Docker HTMX section."""
+    import yaml
+
+    cfg = yaml.safe_load(config_file.read_text())
+    cfg["hosts"].append({
+        "name": "Proxmox VE (pve)",
+        "host": "10.0.0.1",
+        "proxmox_node": "pve",
+        "docker_mode": "all",
+    })
+    config_file.write_text(yaml.dump(cfg))
+
+    response = client.get("/home")
+    assert response.status_code == 200
+    assert "/api/host/proxmox-ve-(pve)/docker" in response.text
+
+
+def test_home_no_docker_section_for_node_without_docker_mode(client, config_file):
+    """Node host without docker_mode does not render an inline Docker section."""
+    import yaml
+
+    cfg = yaml.safe_load(config_file.read_text())
+    cfg["hosts"].append({
+        "name": "Proxmox VE (pve)",
+        "host": "10.0.0.1",
+        "proxmox_node": "pve",
+    })
+    config_file.write_text(yaml.dump(cfg))
+
+    response = client.get("/home")
+    assert response.status_code == 200
+    assert "/api/host/proxmox-ve-(pve)/docker" not in response.text
+
+
+def test_host_docker_no_docker_mode_returns_empty(client, config_file):
+    """Host without docker_mode returns empty response from /api/host/{slug}/docker."""
+    response = client.get("/api/host/test-host/docker")
+    assert response.status_code == 200
+    assert response.text == ""
+
+
+def test_host_docker_returns_container_rows(client, config_file):
+    """Node host with docker_mode and containers returns Docker badge rows."""
+    import yaml
+    from unittest.mock import AsyncMock, patch
+
+    cfg = yaml.safe_load(config_file.read_text())
+    cfg["hosts"].append({
+        "name": "PVE Node",
+        "host": "10.0.0.1",
+        "proxmox_node": "pve",
+        "docker_mode": "all",
+    })
+    config_file.write_text(yaml.dump(cfg))
+
+    mock_stacks = [
+        {
+            "id": "pve-node/myapp:myapp",
+            "name": "myapp",
+            "endpoint_id": "pve-node",
+            "endpoint_name": "PVE Node",
+            "update_status": "up_to_date",
+            "images": [{"name": "nginx:latest", "status": "up_to_date"}],
+            "update_path": "ssh/pve-node/myapp:myapp",
+            "_compose_project": "myapp",
+        }
+    ]
+
+    with patch(
+        "app.backends.ssh_docker_backend.SSHDockerBackend._containers_for_host",
+        new=AsyncMock(return_value=mock_stacks),
+    ):
+        response = client.get("/api/host/pve-node/docker")
+
+    assert response.status_code == 200
+    assert "myapp" in response.text
+    assert "Docker" in response.text
+    assert "Up to date" in response.text
+
+
+def test_host_docker_update_available_shows_redeploy(client, config_file):
+    """Container with update_available shows Redeploy button."""
+    import yaml
+    from unittest.mock import AsyncMock, patch
+
+    cfg = yaml.safe_load(config_file.read_text())
+    cfg["hosts"].append({
+        "name": "PVE Node",
+        "host": "10.0.0.1",
+        "proxmox_node": "pve",
+        "docker_mode": "all",
+    })
+    config_file.write_text(yaml.dump(cfg))
+
+    mock_stacks = [
+        {
+            "id": "pve-node/myapp:myapp",
+            "name": "myapp",
+            "endpoint_id": "pve-node",
+            "endpoint_name": "PVE Node",
+            "update_status": "update_available",
+            "images": [{"name": "nginx:latest", "status": "update_available"}],
+            "update_path": "ssh/pve-node/myapp:myapp",
+            "_compose_project": "myapp",
+        }
+    ]
+
+    with patch(
+        "app.backends.ssh_docker_backend.SSHDockerBackend._containers_for_host",
+        new=AsyncMock(return_value=mock_stacks),
+    ):
+        response = client.get("/api/host/pve-node/docker")
+
+    assert "Update available" in response.text
+    assert "Redeploy" in response.text
+
+
+def test_ssh_docker_backend_excludes_proxmox_nodes(monkeypatch, config_file):
+    """SSHDockerBackend._docker_hosts() does not include Proxmox node hosts."""
+    import yaml
+    import app.config_manager as cm
+
+    cfg = yaml.safe_load(config_file.read_text())
+    cfg["hosts"] = [
+        {"name": "Plain Host", "host": "1.2.3.4", "docker_mode": "all"},
+        {"name": "PVE Node", "host": "10.0.0.1", "proxmox_node": "pve", "docker_mode": "all"},
+        {"name": "LXC 101", "host": "10.0.0.2", "proxmox_node": "pve", "proxmox_vmid": 101, "docker_mode": "all"},
+    ]
+    config_file.write_text(yaml.dump(cfg))
+
+    from app.backends.ssh_docker_backend import SSHDockerBackend
+
+    backend = SSHDockerBackend()
+    docker_hosts = backend._docker_hosts()
+    names = [h["name"] for h in docker_hosts]
+
+    assert "Plain Host" in names
+    assert "LXC 101" in names
+    assert "PVE Node" not in names
+
+
+def test_home_node_with_docker_not_in_global_containers(client, config_file):
+    """Node host with docker_mode doesn't make docker_configured True for global section."""
+    import yaml
+
+    cfg = yaml.safe_load(config_file.read_text())
+    # Remove portainer env, ensure only node Docker exists
+    cfg["hosts"] = [
+        {"name": "PVE Node", "host": "10.0.0.1", "proxmox_node": "pve", "docker_mode": "all"},
+    ]
+    config_file.write_text(yaml.dump(cfg))
+
+    response = client.get("/home")
+    assert response.status_code == 200
+    # Global Containers section should NOT appear (no portainer, no non-node docker hosts)
+    assert 'id="docker-status"' not in response.text


### PR DESCRIPTION
OP#82

## Summary
- Proxmox node hosts with `docker_mode` set now show their Docker containers as inline sub-rows under the node group header in the OS packages section, with a blue "Docker" badge
- Node hosts are excluded from the global Containers section (`SSHDockerBackend._docker_hosts()`) so containers don't appear twice
- New endpoint `GET /api/host/{slug}/docker` returns HTMX-rendered container rows for a specific node host
- New partial `partials/node_docker_status.html` renders per-container status with Redeploy button when updates available
- Banner JS updated to track node Docker checks and flag container updates

## Test plan
- [ ] Add a Proxmox node host with `docker_mode=all` — containers appear under the node group
- [ ] Node host without `docker_mode` — no Docker rows rendered
- [ ] Container with update available shows "Update available" badge and Redeploy button
- [ ] Node Docker containers do NOT appear in global Containers section
- [ ] Status banner turns amber when a node Docker container has an update

🤖 Generated with [Claude Code](https://claude.com/claude-code)