### PR TITLE
Add connection source badges for Docker and OS Package sections (OP#82, OP#83)

### DIFF
--- a/app/backends/ssh_docker_backend.py
+++ b/app/backends/ssh_docker_backend.py
@@ -34,6 +34,18 @@ class SSHDockerBackend:
     def _docker_hosts(self) -> list[dict]:
         return [h for h in get_hosts() if h.get("docker_mode")]
 
+    def _connection_badge(self, host: dict) -> str:
+        proxmox_node = host.get("proxmox_node")
+        proxmox_vmid = host.get("proxmox_vmid")
+        proxmox_type = host.get("proxmox_type") or "lxc"
+        if proxmox_node and proxmox_vmid is None:
+            return "Node · Proxmox API"
+        elif proxmox_node and proxmox_type == "lxc":
+            return f"LXC {proxmox_vmid} · pct exec"
+        elif proxmox_node and proxmox_type == "vm":
+            return f"VM {proxmox_vmid} · SSH"
+        return "SSH"
+
     def _make_compose_ref(self, slug: str, project: str, container: str) -> str:
         return f"{slug}/{quote(project, safe='')}:{quote(container, safe='')}"
 
@@ -178,6 +190,7 @@ class SSHDockerBackend:
                         "name": container_name,
                         "endpoint_id": slug,
                         "endpoint_name": host["name"],
+                        "connection_badge": self._connection_badge(host),
                         "update_status": status,
                         "images": [{"name": image, "status": status}],
                         "update_path": f"{self.BACKEND_KEY}/{ref}",

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -153,6 +153,7 @@
             <div class="text-[13px] font-medium text-slate-100">{{ host.name }}</div>
             <div class="text-[11px] text-slate-500 font-mono mt-0.5">{{ host.host }}</div>
             <span class="inline-flex items-center mt-1 px-1.5 py-0.5 rounded text-[10px] font-medium bg-orange-950/50 text-orange-400 border border-orange-900/40">Node</span>
+            <span class="inline-flex items-center mt-1 ml-1 px-1.5 py-0.5 rounded text-[10px] font-medium bg-slate-800 text-slate-400 border border-slate-700">Proxmox API</span>
           </div>
           <div id="host-{{ host.slug }}-status"
             data-check
@@ -173,6 +174,7 @@
             <div class="text-[13px] font-medium text-slate-100">{{ host.name }}</div>
             <div class="text-[11px] text-slate-500 font-mono mt-0.5">{{ host.host }}</div>
             <span class="inline-flex items-center mt-1 px-1.5 py-0.5 rounded text-[10px] font-medium bg-orange-950/50 text-orange-400 border border-orange-900/40">LXC {{ host.proxmox_vmid }}</span>
+            <span class="inline-flex items-center mt-1 ml-1 px-1.5 py-0.5 rounded text-[10px] font-medium bg-slate-800 text-slate-400 border border-slate-700">pct exec</span>
           </div>
           <div id="host-{{ host.slug }}-status"
             data-check
@@ -193,6 +195,7 @@
             <div class="text-[13px] font-medium text-slate-100">{{ host.name }}</div>
             <div class="text-[11px] text-slate-500 font-mono mt-0.5">{{ host.host }}</div>
             <span class="inline-flex items-center mt-1 px-1.5 py-0.5 rounded text-[10px] font-medium bg-orange-950/50 text-orange-400 border border-orange-900/40">VM {{ host.proxmox_vmid }}</span>
+            <span class="inline-flex items-center mt-1 ml-1 px-1.5 py-0.5 rounded text-[10px] font-medium bg-slate-800 text-slate-400 border border-slate-700">SSH</span>
           </div>
           <div id="host-{{ host.slug }}-status"
             data-check

--- a/app/templates/partials/docker_status.html
+++ b/app/templates/partials/docker_status.html
@@ -21,6 +21,7 @@
 
   {% for endpoint_name, group_stacks in needs_update | groupby("endpoint_name") %}
   {% set group_list = group_stacks | list %}
+  {% set badge = group_list[0].connection_badge if group_list else "" %}
   <div>
     <div class="host-group-header">
       <div class="host-group-name">
@@ -29,6 +30,9 @@
           <rect x="2" y="9" width="12" height="3" rx="1" stroke="#8b949e" stroke-width="1.3"/>
         </svg>
         {{ endpoint_name }}
+        {% if badge %}
+        <span class="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium bg-slate-800 text-slate-400 border border-slate-700">{{ badge }}</span>
+        {% endif %}
       </div>
       <span class="host-group-count">{{ group_list | length }} update{{ 's' if group_list | length != 1 }}</span>
     </div>

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -1085,3 +1085,105 @@ def test_parse_json_output_ignores_invalid_lines():
     assert len(result) == 2
     assert result[0]["Name"] == "good"
     assert result[1]["Name"] == "also-good"
+
+
+# ---------------------------------------------------------------------------
+# SSHDockerBackend — _connection_badge
+# ---------------------------------------------------------------------------
+
+
+def test_connection_badge_standalone():
+    b = SSHDockerBackend()
+    assert b._connection_badge({}) == "SSH"
+    assert b._connection_badge({"name": "plain"}) == "SSH"
+
+
+def test_connection_badge_proxmox_node():
+    b = SSHDockerBackend()
+    host = {"proxmox_node": "pve"}
+    assert b._connection_badge(host) == "Node · Proxmox API"
+
+
+def test_connection_badge_lxc_explicit():
+    b = SSHDockerBackend()
+    host = {"proxmox_node": "pve", "proxmox_vmid": 101, "proxmox_type": "lxc"}
+    assert b._connection_badge(host) == "LXC 101 · pct exec"
+
+
+def test_connection_badge_lxc_default():
+    """proxmox_type absent defaults to lxc."""
+    b = SSHDockerBackend()
+    host = {"proxmox_node": "pve", "proxmox_vmid": 102}
+    assert b._connection_badge(host) == "LXC 102 · pct exec"
+
+
+def test_connection_badge_vm():
+    b = SSHDockerBackend()
+    host = {"proxmox_node": "pve", "proxmox_vmid": 200, "proxmox_type": "vm"}
+    assert b._connection_badge(host) == "VM 200 · SSH"
+
+
+@pytest.mark.asyncio
+async def test_get_stacks_includes_connection_badge(config_file, data_dir):
+    """Each stack entry carries a connection_badge field."""
+    import yaml
+
+    raw = yaml.safe_load(config_file.read_text())
+    raw["hosts"][0]["docker_mode"] = "all"
+    config_file.write_text(yaml.dump(raw))
+
+    docker_ps_output = json.dumps(
+        {"Names": "/app", "Image": "app:latest", "Labels": ""}
+    )
+    inspect_output = '["app@sha256:abc"]'
+
+    conn = _make_multi_conn(
+        [
+            MagicMock(stdout=docker_ps_output, returncode=0),
+            MagicMock(stdout=inspect_output, returncode=0),
+        ]
+    )
+
+    with (
+        patch("app.backends.ssh_docker_backend._connect", new=AsyncMock(return_value=conn)),
+        patch("app.backends.ssh_docker_backend.check_image_update",
+              new=AsyncMock(return_value="up_to_date")),
+    ):
+        backend = SSHDockerBackend()
+        stacks = await backend.get_stacks_with_update_status()
+
+    assert len(stacks) == 1
+    assert stacks[0]["connection_badge"] == "SSH"
+
+
+@pytest.mark.asyncio
+async def test_get_stacks_proxmox_node_connection_badge(config_file, data_dir):
+    """A host flagged as a Proxmox node gets the Node · Proxmox API badge."""
+    import yaml
+
+    raw = yaml.safe_load(config_file.read_text())
+    raw["hosts"][0]["docker_mode"] = "all"
+    raw["hosts"][0]["proxmox_node"] = "pve"
+    config_file.write_text(yaml.dump(raw))
+
+    docker_ps_output = json.dumps(
+        {"Names": "/app", "Image": "app:latest", "Labels": ""}
+    )
+    inspect_output = '["app@sha256:abc"]'
+
+    conn = _make_multi_conn(
+        [
+            MagicMock(stdout=docker_ps_output, returncode=0),
+            MagicMock(stdout=inspect_output, returncode=0),
+        ]
+    )
+
+    with (
+        patch("app.backends.ssh_docker_backend._connect", new=AsyncMock(return_value=conn)),
+        patch("app.backends.ssh_docker_backend.check_image_update",
+              new=AsyncMock(return_value="up_to_date")),
+    ):
+        backend = SSHDockerBackend()
+        stacks = await backend.get_stacks_with_update_status()
+
+    assert stacks[0]["connection_badge"] == "Node · Proxmox API"

--- a/tests/test_main_routes.py
+++ b/tests/test_main_routes.py
@@ -343,3 +343,128 @@ def test_home_shows_standalone_divider_when_mixed(client, config_file):
 def test_home_no_standalone_divider_when_only_standalone(client):
     response = client.get("/home")
     assert "Standalone hosts" not in response.text
+
+
+# ---------------------------------------------------------------------------
+# Connection source badges on OS Packages rows
+# ---------------------------------------------------------------------------
+
+
+def test_home_shows_proxmox_api_badge_on_node_row(client, config_file):
+    import yaml
+
+    cfg = yaml.safe_load(config_file.read_text())
+    cfg["hosts"].append({
+        "name": "My Node",
+        "host": "10.0.0.1",
+        "proxmox_node": "pve",
+    })
+    config_file.write_text(yaml.dump(cfg))
+
+    response = client.get("/home")
+    assert "Proxmox API" in response.text
+
+
+def test_home_shows_pct_exec_badge_on_lxc_row(client, config_file):
+    import yaml
+
+    cfg = yaml.safe_load(config_file.read_text())
+    cfg["hosts"].append({
+        "name": "My LXC",
+        "host": "10.0.0.5",
+        "proxmox_node": "pve",
+        "proxmox_vmid": 105,
+        "proxmox_type": "lxc",
+    })
+    config_file.write_text(yaml.dump(cfg))
+
+    response = client.get("/home")
+    assert "pct exec" in response.text
+
+
+def test_home_shows_ssh_badge_on_vm_row(client, config_file):
+    import yaml
+
+    cfg = yaml.safe_load(config_file.read_text())
+    cfg["hosts"].append({
+        "name": "My VM",
+        "host": "10.0.0.6",
+        "proxmox_node": "pve",
+        "proxmox_vmid": 201,
+        "proxmox_type": "vm",
+    })
+    config_file.write_text(yaml.dump(cfg))
+
+    response = client.get("/home")
+    assert response.text.count("SSH") >= 1
+
+
+def test_home_standalone_has_no_connection_badge(client):
+    response = client.get("/home")
+    assert "Proxmox API" not in response.text
+    assert "pct exec" not in response.text
+
+
+# ---------------------------------------------------------------------------
+# connection_badge rendered in docker_status partial
+# ---------------------------------------------------------------------------
+
+
+def test_docker_check_shows_connection_badge_in_group_header(client, config_file, monkeypatch):
+    import yaml
+    import app.backend_loader as bl
+
+    cfg = yaml.safe_load(config_file.read_text())
+    cfg["hosts"][0]["docker_mode"] = "all"
+    config_file.write_text(yaml.dump(cfg))
+
+    ssh_b = MagicMock()
+    ssh_b.BACKEND_KEY = "ssh"
+    ssh_b.get_stacks_with_update_status = AsyncMock(return_value=[
+        {
+            "id": "my-node/mystack:app",
+            "name": "app",
+            "endpoint_id": "my-node",
+            "endpoint_name": "My Node",
+            "connection_badge": "Node · Proxmox API",
+            "update_status": "update_available",
+            "images": [{"name": "app:latest", "status": "update_available"}],
+            "update_path": "ssh/my-node/mystack:app",
+            "_compose_project": "mystack",
+        }
+    ])
+    monkeypatch.setattr(bl, "_backends", [ssh_b])
+
+    response = client.get("/api/docker/check")
+    assert response.status_code == 200
+    assert "Node · Proxmox API" in response.text
+
+
+def test_docker_check_shows_lxc_connection_badge(client, config_file, monkeypatch):
+    import yaml
+    import app.backend_loader as bl
+
+    cfg = yaml.safe_load(config_file.read_text())
+    cfg["hosts"][0]["docker_mode"] = "all"
+    config_file.write_text(yaml.dump(cfg))
+
+    ssh_b = MagicMock()
+    ssh_b.BACKEND_KEY = "ssh"
+    ssh_b.get_stacks_with_update_status = AsyncMock(return_value=[
+        {
+            "id": "my-lxc/~app",
+            "name": "app",
+            "endpoint_id": "my-lxc",
+            "endpoint_name": "My LXC",
+            "connection_badge": "LXC 104 · pct exec",
+            "update_status": "update_available",
+            "images": [{"name": "app:latest", "status": "update_available"}],
+            "update_path": "ssh/my-lxc/~app",
+            "_compose_project": "",
+        }
+    ])
+    monkeypatch.setattr(bl, "_backends", [ssh_b])
+
+    response = client.get("/api/docker/check")
+    assert response.status_code == 200
+    assert "LXC 104 · pct exec" in response.text


### PR DESCRIPTION
OP#82 OP#83

## Summary

- All Docker containers from all host types (standalone, Proxmox nodes, LXCs, VMs) appear in one unified **Containers** section, grouped by host
- Each group header now shows a connection source badge: `Node · Proxmox API`, `LXC {vmid} · pct exec`, `VM {vmid} · SSH`, or `SSH`
- OS Packages rows for Proxmox hosts also gain a second connection badge alongside the existing type badge (Node → `Proxmox API`, LXC → `pct exec`, VM → `SSH`)
- `_connection_badge()` helper added to `SSHDockerBackend`; `connection_badge` field populated on every stack entry

## Test plan

- [ ] `_connection_badge` unit tests cover all four host types (standalone, node, LXC, VM, LXC-default)
- [ ] Integration tests verify `connection_badge` is present on stack entries for standalone and Proxmox node hosts
- [ ] Dashboard renders connection badge in Containers group headers
- [ ] Dashboard renders connection badge on Node / LXC / VM OS Packages rows
- [ ] All 774 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)