### PR TITLE
Improve Proxmox setup screen: description copy and remove optional label (OP#93)

### DIFF
--- a/app/templates/partials/setup_proxmox_section.html
+++ b/app/templates/partials/setup_proxmox_section.html
@@ -1,8 +1,8 @@
 <div id="proxmox-section" class="bg-slate-800/60 border border-slate-700 rounded-2xl overflow-hidden">
   <div class="flex items-center justify-between px-5 py-4 border-b border-slate-700">
     <div>
-      <h2 class="text-sm font-semibold text-slate-200">Proxmox VE <span class="text-xs font-normal text-slate-500 ml-1">optional</span></h2>
-      <p class="text-xs text-slate-500 mt-0.5">Monitor VMs and LXC containers via the Proxmox API.</p>
+      <h2 class="text-sm font-semibold text-slate-200">Proxmox VE</h2>
+      <p class="text-xs text-slate-500 mt-0.5">Monitor your Proxmox server. The API is used to discover nodes, VMs, and LXC containers and check for available updates. To run updates, SSH access is also required.</p>
     </div>
     {% if proxmox_connected %}
     <span class="flex items-center gap-1.5 text-xs text-green-400 font-medium flex-shrink-0 ml-4">


### PR DESCRIPTION
## Summary

- Remove misleading "optional" label from Proxmox VE heading
- Update description to clarify API scope and SSH requirement: "Monitor your Proxmox server. The API is used to discover nodes, VMs, and LXC containers and check for available updates. To run updates, SSH access is also required."
- SSL checkbox already unchecked by default — no change needed

## Test plan

- [x] 783 tests pass, no regressions
- [x] QA passed all acceptance criteria

🤖 Generated with [Claude Code](https://claude.com/claude-code)