### PR TITLE
Derive API user from Token ID automatically (OP#92)

### DIFF
--- a/app/auth_router.py
+++ b/app/auth_router.py
@@ -22,6 +22,7 @@ from .auth import (
 from .config_manager import (
     add_host,
     delete_host,
+    derive_api_user,
     get_available_ssh_keys,
     get_dockerhub_config,
     get_email_config,
@@ -406,7 +407,6 @@ def _proxmox_vm_step(request: Request, resources: list[dict]) -> HTMLResponse:
 async def setup_test_proxmox(
     request: Request,
     proxmox_url: str = Form(""),
-    proxmox_api_user: str = Form(""),
     proxmox_token_id: str = Form(""),
     proxmox_secret: str = Form(""),
     proxmox_verify_ssl: str = Form(""),
@@ -444,22 +444,19 @@ async def setup_test_proxmox(
 async def setup_save_proxmox(
     request: Request,
     proxmox_url: str = Form(""),
-    proxmox_api_user: str = Form(""),
     proxmox_token_id: str = Form(""),
     proxmox_secret: str = Form(""),
     proxmox_verify_ssl: str = Form(""),
 ) -> HTMLResponse:
     url = proxmox_url.strip().rstrip("/")
-    api_user = proxmox_api_user.strip()
     token_id = proxmox_token_id.strip()
     secret = proxmox_secret.strip()
     verify_ssl = proxmox_verify_ssl == "on"
     save_proxmox_config(url=url, verify_ssl=verify_ssl)
     cred_kwargs: dict = {}
-    if api_user:
-        cred_kwargs["api_user"] = api_user
     if token_id:
         cred_kwargs["token_id"] = token_id
+        cred_kwargs["api_user"] = derive_api_user(token_id)
     if secret:
         cred_kwargs["secret"] = secret
     if cred_kwargs:

--- a/app/config_manager.py
+++ b/app/config_manager.py
@@ -8,6 +8,11 @@ _CONFIG_PATH = Path(os.getenv("CONFIG_PATH", "/app/config/config.yml"))
 _lock = threading.Lock()
 
 
+def derive_api_user(token_id: str) -> str:
+    """Derive the Proxmox API user from a Token ID (format: user@realm!token_name)."""
+    return token_id.split("!")[0] if "!" in token_id else token_id
+
+
 def slugify(name: str) -> str:
     import re
     slug = name.lower().replace(" ", "-").replace("_", "-")

--- a/app/templates/partials/setup_proxmox_section.html
+++ b/app/templates/partials/setup_proxmox_section.html
@@ -256,12 +256,6 @@
       placeholder="https://192.168.1.10:8006"
       class="w-full bg-slate-700 border border-slate-600 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:border-blue-500 placeholder:text-slate-500">
   </div>
-  <div>
-    <label class="block text-xs font-medium text-slate-400 mb-1">API user</label>
-    <input type="text" name="proxmox_api_user" placeholder="root@pam"
-      class="w-full bg-slate-700 border border-slate-600 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:border-blue-500 placeholder:text-slate-500">
-    <p class="text-xs text-slate-500 mt-1">Datacenter → Permissions → Users</p>
-  </div>
   <div class="flex gap-3">
     <div class="flex-1">
       <label class="block text-xs font-medium text-slate-400 mb-1">Token ID</label>
@@ -283,14 +277,14 @@
   <div class="flex gap-2 items-center flex-wrap">
     <button
       hx-post="/setup/connect/proxmox/test"
-      hx-include="[name='proxmox_url'],[name='proxmox_api_user'],[name='proxmox_token_id'],[name='proxmox_secret'],[name='proxmox_verify_ssl']"
+      hx-include="[name='proxmox_url'],[name='proxmox_token_id'],[name='proxmox_secret'],[name='proxmox_verify_ssl']"
       hx-target="#proxmox-test-result"
       class="px-4 py-2 rounded-lg bg-slate-600 hover:bg-slate-500 text-sm font-medium text-slate-200 transition-colors">
       Test connection
     </button>
     <button
       hx-post="/setup/connect/proxmox/save"
-      hx-include="[name='proxmox_url'],[name='proxmox_api_user'],[name='proxmox_token_id'],[name='proxmox_secret'],[name='proxmox_verify_ssl']"
+      hx-include="[name='proxmox_url'],[name='proxmox_token_id'],[name='proxmox_secret'],[name='proxmox_verify_ssl']"
       hx-target="#proxmox-section"
       hx-swap="outerHTML"
       class="px-4 py-2 rounded-lg bg-blue-600 hover:bg-blue-500 text-sm font-medium text-white transition-colors">

--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -3,12 +3,34 @@ import yaml
 from app.config_manager import (
     add_host,
     delete_host,
+    derive_api_user,
     get_hosts,
     get_ssh_config,
     slugify,
     update_host,
     update_ssh_config,
 )
+
+
+# ---------------------------------------------------------------------------
+# derive_api_user
+# ---------------------------------------------------------------------------
+
+
+def test_derive_api_user_standard():
+    assert derive_api_user("root@pam!mytoken") == "root@pam"
+
+
+def test_derive_api_user_custom_realm():
+    assert derive_api_user("keepup@pve!Keepup") == "keepup@pve"
+
+
+def test_derive_api_user_no_exclamation_returns_full():
+    assert derive_api_user("root@pam") == "root@pam"
+
+
+def test_derive_api_user_empty():
+    assert derive_api_user("") == ""
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_setup_connect.py
+++ b/tests/test_setup_connect.py
@@ -100,6 +100,41 @@ def test_setup_security_correct_totp_enrolls_mfa(setup_client):
 
 
 # ---------------------------------------------------------------------------
+# derive_api_user — backwards compat via saved credentials
+# ---------------------------------------------------------------------------
+
+
+def test_proxmox_save_derives_api_user_from_token_id(setup_client, data_dir):
+    """Saving Proxmox credentials derives api_user from token_id automatically."""
+    _create_admin()
+    with patch("app.auth_router.ProxmoxClient") as MockClient:
+        instance = AsyncMock()
+        instance.get_nodes = AsyncMock(return_value=[])
+        instance.discover_resources = AsyncMock(return_value=[])
+        MockClient.return_value = instance
+        setup_client.post(
+            "/setup/connect/proxmox/save",
+            data={
+                "proxmox_url": "https://192.168.1.10:8006",
+                "proxmox_token_id": "root@pam!Keepup",
+                "proxmox_secret": "abc123",
+            },
+        )
+    from app.credentials import get_integration_credentials
+    creds = get_integration_credentials("proxmox")
+    assert creds.get("api_user") == "root@pam"
+    assert creds.get("token_id") == "root@pam!Keepup"
+
+
+def test_proxmox_existing_api_user_in_config_still_readable(data_dir):
+    """Existing configs with api_user stored explicitly continue to work."""
+    from app.credentials import save_integration_credentials, get_integration_credentials
+    save_integration_credentials("proxmox", api_user="root@pam", token_id="root@pam!old", secret="s")
+    creds = get_integration_credentials("proxmox")
+    assert creds.get("api_user") == "root@pam"
+
+
+# ---------------------------------------------------------------------------
 # POST /setup/connect/proxmox/test
 # ---------------------------------------------------------------------------
 
@@ -114,7 +149,6 @@ def test_proxmox_test_success(setup_client, data_dir):
             "/setup/connect/proxmox/test",
             data={
                 "proxmox_url": "https://192.168.1.10:8006",
-                "proxmox_api_user": "user@pam",
                 "proxmox_token_id": "user@pam!token",
                 "proxmox_secret": "abc",
             },
@@ -133,7 +167,6 @@ def test_proxmox_test_auth_error(setup_client, data_dir):
             "/setup/connect/proxmox/test",
             data={
                 "proxmox_url": "https://192.168.1.10:8006",
-                "proxmox_api_user": "user@pam",
                 "proxmox_token_id": "user@pam!badtoken",
                 "proxmox_secret": "bad",
             },
@@ -154,7 +187,6 @@ def test_proxmox_test_connect_error(setup_client, data_dir):
             "/setup/connect/proxmox/test",
             data={
                 "proxmox_url": "https://192.0.2.1:8006",
-                "proxmox_api_user": "user@pam",
                 "proxmox_token_id": "user@pam!token",
                 "proxmox_secret": "abc",
             },
@@ -175,7 +207,6 @@ def test_proxmox_test_ssl_error(setup_client, data_dir):
             "/setup/connect/proxmox/test",
             data={
                 "proxmox_url": "https://192.168.1.10:8006",
-                "proxmox_api_user": "user@pam",
                 "proxmox_token_id": "user@pam!token",
                 "proxmox_secret": "abc",
             },


### PR DESCRIPTION
## Summary
- Removes the manual `proxmox_api_user` field from the Proxmox setup form
- Adds `derive_api_user()` helper that splits Token ID on `!` to extract the user (e.g. `root@pam!Keepup` → `root@pam`)
- Backwards compatible — existing configs with explicit `api_user` still readable

## Test plan
- [x] `derive_api_user` unit tests (4 new tests)
- [x] `test_proxmox_save_derives_api_user_from_token_id` — verifies auto-derivation
- [x] `test_proxmox_existing_api_user_in_config_still_readable` — backwards compat
- [x] All 789 tests pass

Closes OP#92

🤖 Generated with [Claude Code](https://claude.com/claude-code)