### PR TITLE
Add guided SSH key generation to Proxmox wizard (OP#95)

### DIFF
--- a/app/auth_router.py
+++ b/app/auth_router.py
@@ -1,6 +1,7 @@
 import re
 import time
 from collections import defaultdict
+from pathlib import Path
 from zoneinfo import available_timezones
 
 import httpx
@@ -583,6 +584,57 @@ async def setup_proxmox_test_ssh(
         )
     return HTMLResponse(
         f'<span class="text-red-400 text-xs">&#10007; {result["message"]}</span>'
+    )
+
+
+@router.post("/setup/connect/proxmox/generate-ssh-key", response_class=HTMLResponse)
+async def setup_proxmox_generate_ssh_key() -> HTMLResponse:
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+    from cryptography.hazmat.primitives import serialization
+
+    key_path = Path("/app/keys/keepup_proxmox_ed25519")
+    key_path.parent.mkdir(parents=True, exist_ok=True)
+
+    if key_path.exists():
+        private_key = serialization.load_ssh_private_key(key_path.read_bytes(), password=None)
+    else:
+        private_key = Ed25519PrivateKey.generate()
+        pem = private_key.private_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PrivateFormat.OpenSSH,
+            encryption_algorithm=serialization.NoEncryption(),
+        )
+        key_path.write_bytes(pem)
+        key_path.chmod(0o600)
+
+    pub = private_key.public_key().public_bytes(
+        encoding=serialization.Encoding.OpenSSH,
+        format=serialization.PublicFormat.OpenSSH,
+    ).decode()
+
+    echo_cmd = f'echo "{pub}" >> ~/.ssh/authorized_keys'
+    return HTMLResponse(
+        f'<div class="mt-2 space-y-2">'
+        f'<p class="text-xs text-green-400">&#10003; Key pair generated &mdash; <code>keepup_proxmox_ed25519</code></p>'
+        f'<p class="text-xs text-slate-400">Run this on your Proxmox node to authorise Keepup:</p>'
+        f'<div class="relative">'
+        f'<textarea readonly rows="2" id="proxmox-keygen-cmd"'
+        f' class="w-full bg-slate-900 border border-slate-600 rounded-lg px-3 py-2 text-xs text-slate-300 font-mono resize-none focus:outline-none"'
+        f'>{echo_cmd}</textarea>'
+        f'<button type="button"'
+        f' onclick="navigator.clipboard.writeText(document.getElementById(\'proxmox-keygen-cmd\').value)"'
+        f' class="absolute top-2 right-2 px-2 py-0.5 rounded bg-slate-600 hover:bg-slate-500 text-xs text-slate-300 transition-colors">'
+        f'Copy</button>'
+        f'</div>'
+        f'<script>'
+        f'(function(){{'
+        f'  var sel = document.getElementById("proxmox-lxc-ssh-key");'
+        f'  if (sel) {{ for (var i=0; i<sel.options.length; i++) {{'
+        f'    if (sel.options[i].value === "keepup_proxmox_ed25519") {{ sel.selectedIndex = i; break; }}'
+        f'  }} }}'
+        f'}})();'
+        f'</script>'
+        f'</div>'
     )
 
 

--- a/app/templates/partials/setup_proxmox_section.html
+++ b/app/templates/partials/setup_proxmox_section.html
@@ -92,13 +92,23 @@
     </div>
     <div id="proxmox-lxc-key-row">
       <label class="block text-xs font-medium text-slate-400 mb-1">Key file</label>
-      <select id="proxmox-lxc-ssh-key" name="proxmox_ssh_key"
-              class="w-full bg-slate-700 border border-slate-600 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:border-blue-500">
-        <option value="">— select key —</option>
-        {% for k in available_keys %}
-        <option value="{{ k }}">{{ k }}</option>
-        {% endfor %}
-      </select>
+      <div class="flex gap-2">
+        <select id="proxmox-lxc-ssh-key" name="proxmox_ssh_key"
+                class="flex-1 bg-slate-700 border border-slate-600 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:border-blue-500">
+          <option value="">— select key —</option>
+          {% for k in available_keys %}
+          <option value="{{ k }}"{% if k == 'keepup_proxmox_ed25519' %} selected{% endif %}>{{ k }}</option>
+          {% endfor %}
+        </select>
+        <button type="button"
+          hx-post="/setup/connect/proxmox/generate-ssh-key"
+          hx-target="#proxmox-keygen-result"
+          hx-swap="innerHTML"
+          class="px-3 py-2 rounded-lg bg-slate-600 hover:bg-slate-500 text-xs font-medium text-slate-200 transition-colors whitespace-nowrap">
+          Generate key pair
+        </button>
+      </div>
+      <div id="proxmox-keygen-result"></div>
     </div>
     <div id="proxmox-lxc-pass-row" class="hidden">
       <label class="block text-xs font-medium text-slate-400 mb-1">Password</label>

--- a/tests/test_setup_connect.py
+++ b/tests/test_setup_connect.py
@@ -574,3 +574,96 @@ def test_homeassistant_test_generic_failure(setup_client, data_dir):
         )
     assert response.status_code == 200
     assert "&#10007;" in response.text
+
+
+# ---------------------------------------------------------------------------
+# POST /setup/connect/proxmox/generate-ssh-key
+# ---------------------------------------------------------------------------
+
+
+def test_generate_ssh_key_creates_file(setup_client, data_dir, tmp_path, monkeypatch):
+    _create_admin()
+    keys_dir = tmp_path / "keys"
+    keys_dir.mkdir()
+    monkeypatch.setattr("app.auth_router.Path", lambda p: keys_dir / "keepup_proxmox_ed25519" if "keepup" in str(p) else __import__("pathlib").Path(p))
+
+    import app.auth_router as ar
+    real_path = __import__("pathlib").Path
+
+    def patched_path(p):
+        s = str(p)
+        if s == "/app/keys/keepup_proxmox_ed25519":
+            return keys_dir / "keepup_proxmox_ed25519"
+        return real_path(p)
+
+    monkeypatch.setattr(ar, "Path", patched_path)
+
+    response = setup_client.post("/setup/connect/proxmox/generate-ssh-key")
+    assert response.status_code == 200
+    assert (keys_dir / "keepup_proxmox_ed25519").exists()
+
+
+def test_generate_ssh_key_idempotent(setup_client, data_dir, tmp_path, monkeypatch):
+    _create_admin()
+    keys_dir = tmp_path / "keys"
+    keys_dir.mkdir()
+
+    import app.auth_router as ar
+    real_path = __import__("pathlib").Path
+
+    def patched_path(p):
+        if str(p) == "/app/keys/keepup_proxmox_ed25519":
+            return keys_dir / "keepup_proxmox_ed25519"
+        return real_path(p)
+
+    monkeypatch.setattr(ar, "Path", patched_path)
+
+    r1 = setup_client.post("/setup/connect/proxmox/generate-ssh-key")
+    r2 = setup_client.post("/setup/connect/proxmox/generate-ssh-key")
+    assert r1.status_code == 200
+    assert r2.status_code == 200
+    # Both responses should contain the same public key
+    assert "ssh-ed25519" in r1.text
+    assert r1.text == r2.text
+
+
+def test_generate_ssh_key_private_not_in_response(setup_client, data_dir, tmp_path, monkeypatch):
+    _create_admin()
+    keys_dir = tmp_path / "keys"
+    keys_dir.mkdir()
+
+    import app.auth_router as ar
+    real_path = __import__("pathlib").Path
+
+    def patched_path(p):
+        if str(p) == "/app/keys/keepup_proxmox_ed25519":
+            return keys_dir / "keepup_proxmox_ed25519"
+        return real_path(p)
+
+    monkeypatch.setattr(ar, "Path", patched_path)
+
+    response = setup_client.post("/setup/connect/proxmox/generate-ssh-key")
+    assert response.status_code == 200
+    assert "PRIVATE" not in response.text
+    assert "BEGIN OPENSSH" not in response.text
+
+
+def test_generate_ssh_key_public_key_valid_format(setup_client, data_dir, tmp_path, monkeypatch):
+    _create_admin()
+    keys_dir = tmp_path / "keys"
+    keys_dir.mkdir()
+
+    import app.auth_router as ar
+    real_path = __import__("pathlib").Path
+
+    def patched_path(p):
+        if str(p) == "/app/keys/keepup_proxmox_ed25519":
+            return keys_dir / "keepup_proxmox_ed25519"
+        return real_path(p)
+
+    monkeypatch.setattr(ar, "Path", patched_path)
+
+    response = setup_client.post("/setup/connect/proxmox/generate-ssh-key")
+    assert response.status_code == 200
+    assert "ssh-ed25519" in response.text
+    assert "authorized_keys" in response.text


### PR DESCRIPTION
## Summary
- Adds a "Generate key pair" button to the Proxmox LXC SSH panel
- Generates an ed25519 keypair at `/app/keys/keepup_proxmox_ed25519` via `POST /setup/connect/proxmox/generate-ssh-key`
- After generation, shows the public key with a copy-to-clipboard `echo` command and auto-selects the key in the dropdown
- Password auth remains available as an escape hatch via the existing select; existing key dropdown preserved

## Test plan
- [x] `test_generate_ssh_key_creates_file` — key file written to `/app/keys/keepup_proxmox_ed25519`
- [x] `test_generate_ssh_key_idempotent` — calling twice returns same public key
- [x] `test_generate_ssh_key_private_not_in_response` — private key absent from response
- [x] `test_generate_ssh_key_public_key_valid_format` — response contains `ssh-ed25519` and `authorized_keys`
- [x] 793 tests pass, no regressions

Closes OP#95

🤖 Generated with [Claude Code](https://claude.com/claude-code)