### PR TITLE
OP#97 — Fix docker_mode missing for LXCs added via admin Proxmox screen

### DIFF
--- a/app/admin.py
+++ b/app/admin.py
@@ -318,6 +318,7 @@ async def admin_proxmox_select_hosts(request: Request) -> HTMLResponse:
                 proxmox_node=node,
                 proxmox_vmid=vmid,
                 proxmox_type="lxc",
+                docker_mode="all",
             )
             lxc_added.append(name)
         else:

--- a/tests/test_admin_routes.py
+++ b/tests/test_admin_routes.py
@@ -659,6 +659,8 @@ def test_admin_integrations_test_portainer_generic_error(client):
 
 def test_admin_proxmox_select_hosts_correct_format(client, data_dir, config_file):
     """selected_hosts field uses node:vmid:type:name:ip format."""
+    import yaml
+
     response = client.post(
         "/admin/integrations/proxmox/select-hosts",
         data={
@@ -670,6 +672,23 @@ def test_admin_proxmox_select_hosts_correct_format(client, data_dir, config_file
     )
     assert response.status_code == 200
     assert "added" in response.text.lower()
+    raw = yaml.safe_load(config_file.read_text())
+    lxc = next(h for h in raw["hosts"] if h["host"] == "192.168.1.21")
+    assert lxc.get("docker_mode") == "all"
+
+
+def test_admin_proxmox_select_hosts_lxc_docker_mode_special_chars(client, data_dir, config_file):
+    """LXC names with special chars still get docker_mode=all."""
+    import yaml
+
+    response = client.post(
+        "/admin/integrations/proxmox/select-hosts",
+        data={"selected_hosts": ["pve:101:lxc:My CT (test):192.168.1.55"]},
+    )
+    assert response.status_code == 200
+    raw = yaml.safe_load(config_file.read_text())
+    lxc = next(h for h in raw["hosts"] if h["host"] == "192.168.1.55")
+    assert lxc.get("docker_mode") == "all"
 
 
 def test_admin_proxmox_select_hosts_skips_no_ip(client):


### PR DESCRIPTION
OP#97

## Summary
- Add `docker_mode="all"` to `add_host()` call in `admin_proxmox_select_hosts` for LXC containers
- Same fix as OP#96 which patched the setup wizard path

## Test plan
- [x] `test_admin_proxmox_select_hosts_correct_format` asserts `docker_mode == "all"` on added LXCs
- [x] `test_admin_proxmox_select_hosts_lxc_docker_mode_special_chars` verifies special-char names still get `docker_mode="all"`
- [x] 794 tests passing, 96% coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)