### PR TITLE
OP#98 — Auto-add Proxmox node on connect, remove manual prompt step

### DIFF
--- a/app/auth_router.py
+++ b/app/auth_router.py
@@ -464,33 +464,37 @@ async def setup_save_proxmox(
         save_integration_credentials("proxmox", **cred_kwargs)
     _queue_integration_host(request, "proxmox", "Proxmox VE", url)
 
-    nodes: list[str] = []
     resources: list[dict] = []
     if url and token_id and secret:
         try:
+            import urllib.parse
             token = f"{token_id}={secret}"
             client = ProxmoxClient(url=url, api_token=token, verify_ssl=verify_ssl)
             nodes = await client.get_nodes()
             resources = await client.discover_resources()
             request.session["setup_proxmox_resources"] = resources
+            px_host = urllib.parse.urlparse(url).hostname or ""
+            existing = {h["host"] for h in get_hosts()}
+            for node in nodes:
+                if px_host and px_host not in existing:
+                    add_host(
+                        name=f"Proxmox VE ({node})",
+                        host=px_host,
+                        user=None,
+                        port=None,
+                        proxmox_node=node,
+                    )
+                    existing.add(px_host)
         except Exception:
             pass
 
-    return templates.TemplateResponse(
-        "partials/setup_proxmox_section.html",
-        {
-            "request": request,
-            "proxmox_connected": True,
-            "proxmox_step": "node",
-            "proxmox_nodes": nodes,
-            "proxmox_url": url,
-        },
-    )
+    return _proxmox_lxc_step(request, resources)
 
 
 @router.post("/setup/connect/proxmox/discover", response_class=HTMLResponse)
 async def setup_proxmox_discover(request: Request) -> HTMLResponse:
     """For already-connected Proxmox: discover resources and enter the guided flow."""
+    import urllib.parse
     url, token, verify_ssl = _setup_proxmox_client_parts()
     if not url or not token:
         return HTMLResponse('<p class="text-sm text-red-400">Proxmox not configured.</p>')
@@ -499,51 +503,22 @@ async def setup_proxmox_discover(request: Request) -> HTMLResponse:
         nodes = await client.get_nodes()
         resources = await client.discover_resources()
         request.session["setup_proxmox_resources"] = resources
-        return templates.TemplateResponse(
-            "partials/setup_proxmox_section.html",
-            {
-                "request": request,
-                "proxmox_connected": True,
-                "proxmox_step": "node",
-                "proxmox_nodes": nodes,
-                "proxmox_url": url,
-            },
-        )
+        px_host = urllib.parse.urlparse(url).hostname or ""
+        existing = {h["host"] for h in get_hosts()}
+        for node in nodes:
+            if px_host and px_host not in existing:
+                add_host(
+                    name=f"Proxmox VE ({node})",
+                    host=px_host,
+                    user=None,
+                    port=None,
+                    proxmox_node=node,
+                )
+                existing.add(px_host)
+        return _proxmox_lxc_step(request, resources)
     except Exception as exc:
         return HTMLResponse(f'<p class="text-sm text-red-400">Discovery failed: {exc}</p>')
 
-
-@router.post("/setup/connect/proxmox/add-node", response_class=HTMLResponse)
-async def setup_proxmox_add_node(request: Request) -> HTMLResponse:
-    import urllib.parse
-    url, token, verify_ssl = _setup_proxmox_client_parts()
-    px_host = urllib.parse.urlparse(url).hostname or ""
-    try:
-        client = ProxmoxClient(url=url, api_token=token, verify_ssl=verify_ssl)
-        nodes = await client.get_nodes()
-    except Exception as exc:
-        return HTMLResponse(
-            f'<p class="text-sm text-red-400">Could not reach Proxmox API: {exc}</p>'
-        )
-    existing = {h["host"] for h in get_hosts()}
-    for node in nodes:
-        if px_host and px_host not in existing:
-            add_host(
-                name=f"Proxmox VE ({node})",
-                host=px_host,
-                user=None,
-                port=None,
-                proxmox_node=node,
-            )
-            existing.add(px_host)
-    resources = request.session.get("setup_proxmox_resources", [])
-    return _proxmox_lxc_step(request, resources)
-
-
-@router.post("/setup/connect/proxmox/skip-node", response_class=HTMLResponse)
-async def setup_proxmox_skip_node(request: Request) -> HTMLResponse:
-    resources = request.session.get("setup_proxmox_resources", [])
-    return _proxmox_lxc_step(request, resources)
 
 
 @router.post("/setup/connect/proxmox/test-ssh", response_class=HTMLResponse)

--- a/app/templates/partials/setup_proxmox_section.html
+++ b/app/templates/partials/setup_proxmox_section.html
@@ -13,37 +13,7 @@
 
   <div class="px-5 py-4 space-y-3">
 
-  {% if proxmox_step == 'node' %}
-  <!-- ── Step 2: Proxmox node ── -->
-  <p class="text-xs text-slate-400">Would you like to monitor OS updates on the Proxmox host itself?</p>
-  {% if proxmox_nodes %}
-  <div class="space-y-1">
-    {% for node in proxmox_nodes %}
-    <div class="flex items-center gap-2 px-3 py-2 rounded-lg bg-slate-700/40 text-sm text-slate-200">
-      <span class="text-slate-500">◈</span> {{ node }}
-      <span class="text-xs text-slate-500 ml-1">Proxmox node</span>
-    </div>
-    {% endfor %}
-  </div>
-  {% endif %}
-  <div class="flex gap-2">
-    <button
-      hx-post="/setup/connect/proxmox/add-node"
-      hx-target="#proxmox-section"
-      hx-swap="outerHTML"
-      class="px-4 py-2 rounded-lg bg-blue-600 hover:bg-blue-500 text-sm font-medium text-white transition-colors">
-      Add Proxmox node to monitoring
-    </button>
-    <button
-      hx-post="/setup/connect/proxmox/skip-node"
-      hx-target="#proxmox-section"
-      hx-swap="outerHTML"
-      class="px-4 py-2 rounded-lg bg-slate-700 hover:bg-slate-600 text-sm font-medium text-slate-300 transition-colors">
-      Skip
-    </button>
-  </div>
-
-  {% elif proxmox_step == 'lxcs' %}
+  {% if proxmox_step == 'lxcs' %}
   <!-- ── Step 3: LXC containers ── -->
   {% set lxcs = proxmox_resources | selectattr('type', 'equalto', 'lxc') | list %}
   <p class="text-xs text-slate-400">Select the LXC containers you want Keepup to monitor.</p>

--- a/tests/test_setup_connect.py
+++ b/tests/test_setup_connect.py
@@ -126,6 +126,69 @@ def test_proxmox_save_derives_api_user_from_token_id(setup_client, data_dir):
     assert creds.get("token_id") == "root@pam!Keepup"
 
 
+def test_proxmox_save_auto_adds_node(setup_client, data_dir, config_file):
+    """Proxmox node is added automatically on save — no manual prompt needed."""
+    import yaml
+    _create_admin()
+    with patch("app.auth_router.ProxmoxClient") as MockClient:
+        instance = AsyncMock()
+        instance.get_nodes = AsyncMock(return_value=["pve"])
+        instance.discover_resources = AsyncMock(return_value=[])
+        MockClient.return_value = instance
+        setup_client.post(
+            "/setup/connect/proxmox/save",
+            data={
+                "proxmox_url": "https://192.168.5.226:8006",
+                "proxmox_token_id": "root@pam!Keepup",
+                "proxmox_secret": "abc123",
+            },
+        )
+    raw = yaml.safe_load(config_file.read_text())
+    hosts = raw.get("hosts", [])
+    assert any(h["host"] == "192.168.5.226" and h.get("proxmox_node") == "pve" for h in hosts)
+
+
+def test_proxmox_save_node_not_duplicated(setup_client, data_dir, config_file):
+    """Proxmox node is not added twice if already present."""
+    import yaml
+    _create_admin()
+    with patch("app.auth_router.ProxmoxClient") as MockClient:
+        instance = AsyncMock()
+        instance.get_nodes = AsyncMock(return_value=["pve"])
+        instance.discover_resources = AsyncMock(return_value=[])
+        MockClient.return_value = instance
+        for _ in range(2):
+            setup_client.post(
+                "/setup/connect/proxmox/save",
+                data={
+                    "proxmox_url": "https://192.168.5.226:8006",
+                    "proxmox_token_id": "root@pam!Keepup",
+                    "proxmox_secret": "abc123",
+                },
+            )
+    raw = yaml.safe_load(config_file.read_text())
+    node_hosts = [h for h in raw.get("hosts", []) if h.get("host") == "192.168.5.226"]
+    assert len(node_hosts) == 1
+
+
+def test_proxmox_discover_auto_adds_node(setup_client, data_dir, config_file):
+    """discover endpoint also auto-adds the node."""
+    import yaml
+    _create_admin()
+    from app.config_manager import save_proxmox_config
+    from app.credentials import save_integration_credentials
+    save_proxmox_config(url="https://192.168.5.227:8006", verify_ssl=False)
+    save_integration_credentials("proxmox", token_id="root@pam!t", secret="s", api_user="root@pam")
+    with patch("app.auth_router.ProxmoxClient") as MockClient:
+        instance = AsyncMock()
+        instance.get_nodes = AsyncMock(return_value=["pve"])
+        instance.discover_resources = AsyncMock(return_value=[])
+        MockClient.return_value = instance
+        setup_client.post("/setup/connect/proxmox/discover")
+    raw = yaml.safe_load(config_file.read_text())
+    assert any(h["host"] == "192.168.5.227" and h.get("proxmox_node") == "pve" for h in raw.get("hosts", []))
+
+
 def test_proxmox_existing_api_user_in_config_still_readable(data_dir):
     """Existing configs with api_user stored explicitly continue to work."""
     from app.credentials import save_integration_credentials, get_integration_credentials
@@ -243,8 +306,8 @@ def test_proxmox_discover_success(setup_client, data_dir):
         response = setup_client.post("/setup/connect/proxmox/discover")
 
     assert response.status_code == 200
-    # Discover now returns the node step
-    assert "pve" in response.text or "Proxmox node" in response.text or "Add Proxmox node" in response.text
+    # Discover auto-adds the node and proceeds to LXC/done step
+    assert "proxmox-section" in response.text
 
 
 def test_proxmox_discover_failure(setup_client, data_dir):
@@ -271,31 +334,6 @@ def test_proxmox_discover_failure(setup_client, data_dir):
 # ---------------------------------------------------------------------------
 
 
-def test_proxmox_add_node(setup_client, data_dir):
-    _create_admin()
-    from app.config_manager import save_proxmox_config
-    from app.credentials import save_integration_credentials
-
-    save_proxmox_config(url="https://192.168.1.10:8006", verify_ssl=False)
-    save_integration_credentials("proxmox", token_id="user@pam!token", secret="abc")
-
-    with patch("app.auth_router.ProxmoxClient") as MockClient:
-        instance = AsyncMock()
-        instance.get_nodes = AsyncMock(return_value=["pve"])
-        MockClient.return_value = instance
-        response = setup_client.post("/setup/connect/proxmox/add-node")
-
-    assert response.status_code == 200
-    # Proceeds to LXC step (or done if no resources in session)
-    assert "proxmox-section" in response.text
-
-
-def test_proxmox_skip_node(setup_client, data_dir):
-    _create_admin()
-    response = setup_client.post("/setup/connect/proxmox/skip-node")
-    assert response.status_code == 200
-    # No LXCs in session → skips to done or VMs
-    assert "proxmox-section" in response.text
 
 
 def test_proxmox_test_ssh_no_config(setup_client, data_dir):


### PR DESCRIPTION
OP#98

## Summary
- Proxmox node is now added automatically when credentials are saved in the wizard
- Removed the "Would you like to monitor OS updates on the Proxmox host itself?" prompt step
- Removed `/setup/connect/proxmox/add-node` and `/setup/connect/proxmox/skip-node` routes
- Same auto-add logic applied to the `/discover` endpoint (used when re-entering the wizard)

## Test plan
- [x] `test_proxmox_save_auto_adds_node` — node added to config on save
- [x] `test_proxmox_save_node_not_duplicated` — no duplicate on repeated saves
- [x] `test_proxmox_discover_auto_adds_node` — discover endpoint also auto-adds
- [x] 795 tests passing, 96% coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)