### PR TITLE
OP#99 — Add Docker monitoring prompt step to Proxmox setup wizard

### DIFF
--- a/app/auth_router.py
+++ b/app/auth_router.py
@@ -50,7 +50,9 @@ from .config_manager import (
     save_timezone,
     save_update_check_schedule,
     save_wizard_container_selection,
+    set_docker_monitoring,
     set_host_auto_update,
+    slugify,
 )
 from .credentials import (
     delete_credentials,
@@ -637,6 +639,7 @@ async def setup_proxmox_save_lxcs(
     save_integration_credentials("proxmox", **cred_kwargs)
 
     existing = {h["host"] for h in get_hosts()}
+    added_lxcs: list[dict] = []
     for entry in selected:
         parts = entry.split(":", 3)
         if len(parts) < 3:
@@ -647,15 +650,49 @@ async def setup_proxmox_save_lxcs(
             continue
         vmid = int(vmid_str) if vmid_str.isdigit() else None
         if vmid is not None:
-            add_host(name=name, host=ip, user=None, port=None, proxmox_node=node, proxmox_vmid=vmid, docker_mode="all")
+            add_host(name=name, host=ip, user=None, port=None, proxmox_node=node, proxmox_vmid=vmid)
             existing.add(ip)
+            added_lxcs.append({"name": name, "slug": slugify(name)})
 
     resources = request.session.get("setup_proxmox_resources", [])
+    if added_lxcs:
+        return _proxmox_docker_step(request, added_lxcs, resources)
     return _proxmox_vm_step(request, resources)
 
 
 @router.post("/setup/connect/proxmox/skip-lxcs", response_class=HTMLResponse)
 async def setup_proxmox_skip_lxcs(request: Request) -> HTMLResponse:
+    resources = request.session.get("setup_proxmox_resources", [])
+    return _proxmox_vm_step(request, resources)
+
+
+def _proxmox_docker_step(
+    request: Request, lxcs: list[dict], resources: list[dict]
+) -> HTMLResponse:
+    request.session["setup_proxmox_docker_lxcs"] = lxcs
+    return templates.TemplateResponse(
+        "partials/setup_proxmox_section.html",
+        {
+            "request": request,
+            "proxmox_connected": True,
+            "proxmox_step": "docker",
+            "proxmox_lxcs": lxcs,
+        },
+    )
+
+
+@router.post("/setup/connect/proxmox/save-docker", response_class=HTMLResponse)
+async def setup_proxmox_save_docker(request: Request) -> HTMLResponse:
+    form = await request.form()
+    selected_slugs = form.getlist("docker_lxcs")
+    for slug in selected_slugs:
+        set_docker_monitoring(slug=slug, mode="all")
+    resources = request.session.get("setup_proxmox_resources", [])
+    return _proxmox_vm_step(request, resources)
+
+
+@router.post("/setup/connect/proxmox/skip-docker", response_class=HTMLResponse)
+async def setup_proxmox_skip_docker(request: Request) -> HTMLResponse:
     resources = request.session.get("setup_proxmox_resources", [])
     return _proxmox_vm_step(request, resources)
 

--- a/app/templates/partials/setup_proxmox_section.html
+++ b/app/templates/partials/setup_proxmox_section.html
@@ -13,7 +13,54 @@
 
   <div class="px-5 py-4 space-y-3">
 
-  {% if proxmox_step == 'lxcs' %}
+  {% if proxmox_step == 'docker' %}
+  <!-- ── Step: Docker monitoring ── -->
+  <p class="text-xs text-slate-400">Which LXC containers should Keepup monitor for Docker container updates?</p>
+  <div class="space-y-1">
+    <label class="flex items-center gap-3 px-3 py-2 rounded-lg bg-slate-700/50 cursor-pointer hover:bg-slate-700 transition-colors">
+      <input type="checkbox" id="proxmox-docker-select-all"
+             class="w-4 h-4 rounded accent-blue-500"
+             onchange="proxmoxDockerToggleAll(this.checked)">
+      <span class="text-sm font-medium text-slate-200">Enable for all</span>
+    </label>
+    {% for lxc in proxmox_lxcs %}
+    <label class="flex items-center gap-3 px-3 py-2 rounded-lg bg-slate-700/40 cursor-pointer hover:bg-slate-700 transition-colors">
+      <input type="checkbox" name="docker_lxcs" value="{{ lxc.slug }}"
+             class="proxmox-docker-check w-4 h-4 rounded accent-blue-500"
+             onchange="proxmoxDockerUpdateSelectAll()">
+      <span class="text-sm text-slate-200">{{ lxc.name }}</span>
+    </label>
+    {% endfor %}
+  </div>
+  <div class="flex gap-2">
+    <button type="button"
+      hx-post="/setup/connect/proxmox/save-docker"
+      hx-include=".proxmox-docker-check"
+      hx-target="#proxmox-section"
+      hx-swap="outerHTML"
+      class="px-4 py-2 rounded-lg bg-blue-600 hover:bg-blue-500 text-sm font-medium text-white transition-colors">
+      Save
+    </button>
+    <button type="button"
+      hx-post="/setup/connect/proxmox/skip-docker"
+      hx-target="#proxmox-section"
+      hx-swap="outerHTML"
+      class="px-4 py-2 rounded-lg bg-slate-700 hover:bg-slate-600 text-sm font-medium text-slate-300 transition-colors">
+      Skip
+    </button>
+  </div>
+  <script>
+  function proxmoxDockerToggleAll(checked) {
+    document.querySelectorAll('.proxmox-docker-check').forEach(cb => cb.checked = checked);
+  }
+  function proxmoxDockerUpdateSelectAll() {
+    const all = document.querySelectorAll('.proxmox-docker-check');
+    const checked = document.querySelectorAll('.proxmox-docker-check:checked');
+    document.getElementById('proxmox-docker-select-all').checked = all.length === checked.length;
+  }
+  </script>
+
+  {% elif proxmox_step == 'lxcs' %}
   <!-- ── Step 3: LXC containers ── -->
   {% set lxcs = proxmox_resources | selectattr('type', 'equalto', 'lxc') | list %}
   <p class="text-xs text-slate-400">Select the LXC containers you want Keepup to monitor.</p>

--- a/tests/test_setup_connect.py
+++ b/tests/test_setup_connect.py
@@ -395,7 +395,73 @@ def test_proxmox_save_lxcs(setup_client, data_dir):
     hosts = get_hosts()
     lxc = next((h for h in hosts if h.get("proxmox_vmid") == 100), None)
     assert lxc is not None
+    # docker_mode is not set at this stage — user is prompted next
+    assert lxc.get("docker_mode") is None
+
+
+def test_proxmox_save_lxcs_shows_docker_step(setup_client, data_dir):
+    """After saving LXCs, wizard shows Docker monitoring prompt."""
+    _create_admin()
+    response = setup_client.post(
+        "/setup/connect/proxmox/save-lxcs",
+        data={
+            "selected_lxcs": ["pve:100:debian:192.168.1.100"],
+            "proxmox_ssh_user": "root",
+            "proxmox_ssh_auth": "password",
+            "proxmox_ssh_password": "secret",
+        },
+    )
+    assert response.status_code == 200
+    assert "docker_lxcs" in response.text
+    assert "debian" in response.text
+    assert "Enable for all" in response.text
+
+
+def test_proxmox_save_docker_sets_monitoring(setup_client, data_dir, config_file):
+    """Saving docker selections sets docker_mode=all on chosen LXCs."""
+    import yaml
+    _create_admin()
+    # First add an LXC
+    setup_client.post(
+        "/setup/connect/proxmox/save-lxcs",
+        data={
+            "selected_lxcs": ["pve:100:debian:192.168.1.100"],
+            "proxmox_ssh_user": "root",
+            "proxmox_ssh_auth": "password",
+            "proxmox_ssh_password": "secret",
+        },
+    )
+    # Then submit docker selection
+    response = setup_client.post(
+        "/setup/connect/proxmox/save-docker",
+        data={"docker_lxcs": ["debian"]},
+    )
+    assert response.status_code == 200
+    raw = yaml.safe_load(config_file.read_text())
+    lxc = next((h for h in raw["hosts"] if h.get("proxmox_vmid") == 100), None)
+    assert lxc is not None
     assert lxc.get("docker_mode") == "all"
+
+
+def test_proxmox_skip_docker_sets_no_monitoring(setup_client, data_dir, config_file):
+    """Skipping docker step leaves docker_mode unset."""
+    import yaml
+    _create_admin()
+    setup_client.post(
+        "/setup/connect/proxmox/save-lxcs",
+        data={
+            "selected_lxcs": ["pve:100:debian:192.168.1.100"],
+            "proxmox_ssh_user": "root",
+            "proxmox_ssh_auth": "password",
+            "proxmox_ssh_password": "secret",
+        },
+    )
+    response = setup_client.post("/setup/connect/proxmox/skip-docker")
+    assert response.status_code == 200
+    raw = yaml.safe_load(config_file.read_text())
+    lxc = next((h for h in raw["hosts"] if h.get("proxmox_vmid") == 100), None)
+    assert lxc is not None
+    assert lxc.get("docker_mode") is None
 
 
 def test_proxmox_skip_lxcs(setup_client, data_dir):


### PR DESCRIPTION
OP#99

## Summary
- Added `proxmox_step: "docker"` screen after LXC selection — lists added LXCs with individual checkboxes, "Enable for all" shortcut, and a Skip option
- `POST /setup/connect/proxmox/save-docker` — calls `set_docker_monitoring(mode="all")` for selected slugs, proceeds to VM step
- `POST /setup/connect/proxmox/skip-docker` — skips without configuring Docker monitoring
- Removed automatic `docker_mode="all"` from `save_lxcs` — user is now asked explicitly

## Test plan
- [x] Docker step shown after LXC selection
- [x] Selecting LXCs and saving sets `docker_mode=all`
- [x] Skipping leaves `docker_mode` unset
- [x] 798 tests passing, 96% coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)