### PR TITLE
[#100] Wizard UX fixes: duplicate host, continue button, LXC select-all, container step

### DIFF
--- a/app/auth_router.py
+++ b/app/auth_router.py
@@ -487,6 +487,10 @@ async def setup_save_proxmox(
                         proxmox_node=node,
                     )
                     existing.add(px_host)
+            # Node auto-added — remove from SSH wizard queue to avoid duplicate
+            pending = request.session.get("setup_integration_pending", [])
+            pending = [h for h in pending if h.get("integration") != "proxmox"]
+            request.session["setup_integration_pending"] = pending
         except Exception:
             pass
 
@@ -517,6 +521,10 @@ async def setup_proxmox_discover(request: Request) -> HTMLResponse:
                     proxmox_node=node,
                 )
                 existing.add(px_host)
+        # Node auto-added — remove from SSH wizard queue to avoid duplicate
+        pending = request.session.get("setup_integration_pending", [])
+        pending = [h for h in pending if h.get("integration") != "proxmox"]
+        request.session["setup_integration_pending"] = pending
         return _proxmox_lxc_step(request, resources)
     except Exception as exc:
         return HTMLResponse(f'<p class="text-sm text-red-400">Discovery failed: {exc}</p>')
@@ -1646,9 +1654,13 @@ async def setup_containers_page(request: Request) -> HTMLResponse:
     ssh_cfg = get_ssh_config()
 
     host_data = []
+    pct_exec_count = 0
     for h in hosts:
         from .credentials import get_credentials
 
+        if h.get("proxmox_vmid") is not None:
+            pct_exec_count += 1
+            continue
         creds = get_credentials(h["slug"])
         containers = await discover_containers(h, ssh_cfg, creds)
         host_data.append(
@@ -1665,6 +1677,7 @@ async def setup_containers_page(request: Request) -> HTMLResponse:
         {
             "request": request,
             "hosts": host_data,
+            "pct_exec_count": pct_exec_count,
         },
     )
 

--- a/app/templates/partials/setup_proxmox_section.html
+++ b/app/templates/partials/setup_proxmox_section.html
@@ -1,4 +1,4 @@
-<div id="proxmox-section" class="bg-slate-800/60 border border-slate-700 rounded-2xl overflow-hidden">
+<div id="proxmox-section" class="bg-slate-800/60 border border-slate-700 rounded-2xl overflow-hidden" data-step="{{ proxmox_step or '' }}">
   <div class="flex items-center justify-between px-5 py-4 border-b border-slate-700">
     <div>
       <h2 class="text-sm font-semibold text-slate-200">Proxmox VE</h2>
@@ -65,12 +65,18 @@
   {% set lxcs = proxmox_resources | selectattr('type', 'equalto', 'lxc') | list %}
   <p class="text-xs text-slate-400">Select the LXC containers you want Keepup to monitor.</p>
   <div class="space-y-1.5">
+    <label class="flex items-center gap-3 px-3 py-2 rounded-lg bg-slate-700/50 cursor-pointer hover:bg-slate-700 transition-colors">
+      <input type="checkbox" id="proxmox-lxc-select-all"
+             class="w-4 h-4 rounded accent-blue-500"
+             onchange="proxmoxLxcToggleAll(this.checked)">
+      <span class="text-sm font-medium text-slate-200">Select all / none</span>
+    </label>
     {% for r in lxcs %}
     <label class="flex items-center gap-3 px-3 py-2 rounded-lg bg-slate-700/50 cursor-pointer hover:bg-slate-700 transition-colors">
       <input type="checkbox" name="selected_lxcs"
              value="{{ r.node }}:{{ r.vmid }}:{{ r.name }}:{{ r.ip or '' }}"
              class="proxmox-lxc-check w-4 h-4 rounded accent-blue-500 flex-shrink-0"
-             onchange="proxmoxUpdateLxcPanel()">
+             onchange="proxmoxUpdateLxcPanel(); proxmoxUpdateLxcSelectAll()">
       <div class="min-w-0">
         <span class="text-sm text-slate-200 font-medium">{{ r.name }}</span>
         <span class="text-xs text-slate-500 ml-2">LXC {{ r.vmid }} · {{ r.node }}{% if r.ip %} · {{ r.ip }}{% endif %}</span>
@@ -164,9 +170,20 @@
   </div>
 
   <script>
+  function proxmoxLxcToggleAll(checked) {
+    document.querySelectorAll('.proxmox-lxc-check').forEach(cb => cb.checked = checked);
+    proxmoxUpdateLxcPanel();
+  }
+  function proxmoxUpdateLxcSelectAll() {
+    const all = document.querySelectorAll('.proxmox-lxc-check');
+    const checked = document.querySelectorAll('.proxmox-lxc-check:checked');
+    const sa = document.getElementById('proxmox-lxc-select-all');
+    if (sa) sa.checked = all.length > 0 && all.length === checked.length;
+  }
   function proxmoxUpdateLxcPanel() {
     const anyChecked = document.querySelectorAll('.proxmox-lxc-check:checked').length > 0;
     document.getElementById('proxmox-lxc-ssh-panel').classList.toggle('hidden', !anyChecked);
+    proxmoxUpdateLxcSelectAll();
     proxmoxUpdateAddBtn();
   }
   function proxmoxToggleSshAuth() {

--- a/app/templates/setup_connect.html
+++ b/app/templates/setup_connect.html
@@ -515,7 +515,7 @@
     </div>
 
     <!-- Navigation -->
-    <div class="flex justify-between items-center pt-4">
+    <div id="wizard-nav" class="flex justify-between items-center pt-4">
       <a href="/setup/hosts" class="text-sm text-slate-500 hover:text-slate-300">Skip — configure later</a>
       <a href="/setup/hosts"
         class="px-6 py-2.5 rounded-xl bg-blue-600 hover:bg-blue-500 text-sm font-semibold text-white transition-colors">
@@ -560,6 +560,21 @@
     tile.classList.add('active');
     section.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
   }
+
+  // Hide the continue nav while a Proxmox sub-step is active
+  const PROXMOX_ACTIVE_STEPS = ['lxcs', 'vms', 'docker'];
+  function syncWizardNav() {
+    const section = document.getElementById('proxmox-section');
+    const nav = document.getElementById('wizard-nav');
+    if (!section || !nav) return;
+    const step = section.dataset.step || '';
+    nav.classList.toggle('hidden', PROXMOX_ACTIVE_STEPS.includes(step));
+  }
+  document.addEventListener('htmx:afterSwap', function(e) {
+    if (e.detail && e.detail.target && e.detail.target.id === 'proxmox-section') {
+      syncWizardNav();
+    }
+  });
 
   // Auto-open config sections for already-connected integrations
   document.addEventListener('DOMContentLoaded', function() {

--- a/app/templates/setup_containers.html
+++ b/app/templates/setup_containers.html
@@ -132,11 +132,24 @@
         {% endif %}
 
       {% else %}
+        <!-- No SSH hosts — check if only pct exec LXC hosts exist -->
+        {% if pct_exec_count and pct_exec_count > 0 %}
+        <div class="bg-[#161b22] border border-[#21262d] rounded-xl px-5 py-8 text-center mb-6">
+          <div class="w-10 h-10 rounded-full bg-[#21262d] flex items-center justify-center mx-auto mb-3">
+            <svg width="18" height="18" viewBox="0 0 16 16" fill="none"><circle cx="8" cy="8" r="6.5" stroke="#484f58" stroke-width="1.2"/><path d="M8 5v3.5l2 2" stroke="#484f58" stroke-width="1.2" stroke-linecap="round"/></svg>
+          </div>
+          <p class="text-sm font-medium text-slate-400">Your Proxmox LXC containers are already configured</p>
+          <p class="text-xs text-slate-600 mt-1">Package monitoring for Proxmox LXC containers runs via <code class="text-slate-500">pct exec</code>, not Docker. They don't appear here.</p>
+        </div>
+
+      {% else %}
         <!-- No SSH hosts -->
         <div class="bg-[#161b22] border border-[#21262d] rounded-xl px-5 py-8 text-center mb-6">
           <p class="text-sm font-medium text-slate-400">No SSH hosts configured</p>
           <p class="text-xs text-slate-600 mt-1">Go back and add SSH hosts first.</p>
         </div>
+      {% endif %}
+
       {% endif %}
 
       <!-- Bottom buttons -->

--- a/tests/test_setup_connect.py
+++ b/tests/test_setup_connect.py
@@ -771,3 +771,72 @@ def test_generate_ssh_key_public_key_valid_format(setup_client, data_dir, tmp_pa
     assert response.status_code == 200
     assert "ssh-ed25519" in response.text
     assert "authorized_keys" in response.text
+
+
+# ---------------------------------------------------------------------------
+# OP#100 — Wizard UX fixes
+# ---------------------------------------------------------------------------
+
+
+def test_proxmox_save_removes_proxmox_from_integration_pending(setup_client, data_dir):
+    """After node auto-add, _queue_integration_host entry is cleared for proxmox."""
+    _create_admin()
+    with patch("app.auth_router.ProxmoxClient") as MockClient:
+        instance = AsyncMock()
+        instance.get_nodes = AsyncMock(return_value=["pve"])
+        instance.discover_resources = AsyncMock(return_value=[])
+        MockClient.return_value = instance
+        setup_client.post(
+            "/setup/connect/proxmox/save",
+            data={
+                "proxmox_url": "https://192.168.5.228:8006",
+                "proxmox_token_id": "root@pam!Keepup",
+                "proxmox_secret": "abc123",
+            },
+        )
+    hosts_resp = setup_client.get("/setup/hosts")
+    # "hosts detected" banner only renders when proxmox_pending is non-empty
+    assert "hosts detected" not in hosts_resp.text
+
+
+def test_proxmox_discover_removes_proxmox_from_integration_pending(setup_client, data_dir):
+    """discover endpoint also removes Proxmox from SSH Hosts pending queue."""
+    from app.config_manager import save_proxmox_config
+    from app.credentials import save_integration_credentials
+    _create_admin()
+    save_proxmox_config(url="https://192.168.5.229:8006", verify_ssl=False)
+    save_integration_credentials("proxmox", token_id="root@pam!t", secret="s", api_user="root@pam")
+    with patch("app.auth_router.ProxmoxClient") as MockClient:
+        instance = AsyncMock()
+        instance.get_nodes = AsyncMock(return_value=["pve"])
+        instance.discover_resources = AsyncMock(return_value=[])
+        MockClient.return_value = instance
+        setup_client.post("/setup/connect/proxmox/discover")
+    hosts_resp = setup_client.get("/setup/hosts")
+    assert "hosts detected" not in hosts_resp.text
+
+
+def test_setup_containers_excludes_pct_exec_hosts(setup_client, data_dir, config_file):
+    """Container monitoring step skips hosts with proxmox_vmid (pct exec)."""
+    from app.config_manager import add_host
+    _create_admin()
+    add_host(name="My LXC", host="192.168.5.50", user=None, port=None,
+             proxmox_node="pve", proxmox_vmid=101)
+    with patch("app.auth_router.discover_containers", new=AsyncMock(return_value=[])):
+        response = setup_client.get("/setup/containers")
+    assert response.status_code == 200
+    # LXC host should not appear as a discoverable SSH Docker host
+    assert "My LXC" not in response.text
+
+
+def test_setup_containers_pct_exec_count_passed_to_template(setup_client, data_dir, config_file):
+    """pct exec hosts are not shown as discoverable SSH hosts in container step."""
+    from app.config_manager import add_host
+    _create_admin()
+    add_host(name="LXC 101", host="192.168.5.51", user=None, port=None,
+             proxmox_node="pve", proxmox_vmid=101)
+    with patch("app.auth_router.discover_containers", new=AsyncMock(return_value=[])):
+        response = setup_client.get("/setup/containers")
+    assert response.status_code == 200
+    # LXC host should not appear as a discoverable SSH host
+    assert "LXC 101" not in response.text


### PR DESCRIPTION
OP#100

## Summary
- Remove Proxmox from `setup_integration_pending` after node auto-add so the host doesn't reappear in SSH Hosts wizard step (duplicate fix)
- Add `id="wizard-nav"` and `htmx:afterSwap` JS listener to hide the "Continue to SSH setup →" button while a Proxmox sub-step (`lxcs`, `vms`, `docker`) is active
- Add "Select all / none" checkbox to LXC selection step (consistent with Docker monitoring step)
- Skip pct exec hosts (`proxmox_vmid` set) in container monitoring wizard step; show informative message when only pct exec hosts exist

## Test plan
- [ ] 107 tests pass, 96% coverage
- [ ] After saving Proxmox credentials, SSH Hosts step should not show Proxmox VE as a pending host
- [ ] "Continue to SSH setup →" button hidden while mid-Proxmox sub-flow; visible after `done`
- [ ] LXC selection has select-all checkbox
- [ ] Container monitoring step shows informative message when only Proxmox LXC hosts are configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)