### PR TITLE
[#101] Fix: LXC containers not monitored for Docker after wizard

### DIFF
--- a/app/auth_router.py
+++ b/app/auth_router.py
@@ -658,7 +658,7 @@ async def setup_proxmox_save_lxcs(
             continue
         vmid = int(vmid_str) if vmid_str.isdigit() else None
         if vmid is not None:
-            add_host(name=name, host=ip, user=None, port=None, proxmox_node=node, proxmox_vmid=vmid)
+            add_host(name=name, host=ip, user=None, port=None, proxmox_node=node, proxmox_vmid=vmid, docker_mode="all")
             existing.add(ip)
             added_lxcs.append({"name": name, "slug": slugify(name)})
 
@@ -692,9 +692,12 @@ def _proxmox_docker_step(
 @router.post("/setup/connect/proxmox/save-docker", response_class=HTMLResponse)
 async def setup_proxmox_save_docker(request: Request) -> HTMLResponse:
     form = await request.form()
-    selected_slugs = form.getlist("docker_lxcs")
-    for slug in selected_slugs:
-        set_docker_monitoring(slug=slug, mode="all")
+    checked_slugs = set(form.getlist("docker_lxcs"))
+    all_lxcs = request.session.get("setup_proxmox_docker_lxcs") or []
+    for lxc in all_lxcs:
+        slug = lxc.get("slug", "")
+        if slug not in checked_slugs:
+            set_docker_monitoring(slug=slug, mode="none")
     resources = request.session.get("setup_proxmox_resources", [])
     return _proxmox_vm_step(request, resources)
 

--- a/app/templates/partials/setup_proxmox_section.html
+++ b/app/templates/partials/setup_proxmox_section.html
@@ -18,14 +18,14 @@
   <p class="text-xs text-slate-400">Which LXC containers should Keepup monitor for Docker container updates?</p>
   <div class="space-y-1">
     <label class="flex items-center gap-3 px-3 py-2 rounded-lg bg-slate-700/50 cursor-pointer hover:bg-slate-700 transition-colors">
-      <input type="checkbox" id="proxmox-docker-select-all"
+      <input type="checkbox" id="proxmox-docker-select-all" checked
              class="w-4 h-4 rounded accent-blue-500"
              onchange="proxmoxDockerToggleAll(this.checked)">
       <span class="text-sm font-medium text-slate-200">Enable for all</span>
     </label>
     {% for lxc in proxmox_lxcs %}
     <label class="flex items-center gap-3 px-3 py-2 rounded-lg bg-slate-700/40 cursor-pointer hover:bg-slate-700 transition-colors">
-      <input type="checkbox" name="docker_lxcs" value="{{ lxc.slug }}"
+      <input type="checkbox" name="docker_lxcs" value="{{ lxc.slug }}" checked
              class="proxmox-docker-check w-4 h-4 rounded accent-blue-500"
              onchange="proxmoxDockerUpdateSelectAll()">
       <span class="text-sm text-slate-200">{{ lxc.name }}</span>

--- a/tests/test_setup_connect.py
+++ b/tests/test_setup_connect.py
@@ -395,8 +395,7 @@ def test_proxmox_save_lxcs(setup_client, data_dir):
     hosts = get_hosts()
     lxc = next((h for h in hosts if h.get("proxmox_vmid") == 100), None)
     assert lxc is not None
-    # docker_mode is not set at this stage — user is prompted next
-    assert lxc.get("docker_mode") is None
+    assert lxc.get("docker_mode") == "all"
 
 
 def test_proxmox_save_lxcs_shows_docker_step(setup_client, data_dir):
@@ -443,8 +442,8 @@ def test_proxmox_save_docker_sets_monitoring(setup_client, data_dir, config_file
     assert lxc.get("docker_mode") == "all"
 
 
-def test_proxmox_skip_docker_sets_no_monitoring(setup_client, data_dir, config_file):
-    """Skipping docker step leaves docker_mode unset."""
+def test_proxmox_skip_docker_retains_monitoring(setup_client, data_dir, config_file):
+    """Skipping the docker step leaves docker_mode=all set by add_host()."""
     import yaml
     _create_admin()
     setup_client.post(
@@ -461,7 +460,35 @@ def test_proxmox_skip_docker_sets_no_monitoring(setup_client, data_dir, config_f
     raw = yaml.safe_load(config_file.read_text())
     lxc = next((h for h in raw["hosts"] if h.get("proxmox_vmid") == 100), None)
     assert lxc is not None
-    assert lxc.get("docker_mode") is None
+    assert lxc.get("docker_mode") == "all"
+
+
+def test_proxmox_save_docker_opt_out(setup_client, data_dir, config_file):
+    """Unchecking an LXC in save-docker removes docker_mode (explicit opt-out)."""
+    import yaml
+    _create_admin()
+    setup_client.post(
+        "/setup/connect/proxmox/save-lxcs",
+        data={
+            "selected_lxcs": ["pve:100:debian:192.168.1.100", "pve:101:alpine:192.168.1.101"],
+            "proxmox_ssh_user": "root",
+            "proxmox_ssh_auth": "password",
+            "proxmox_ssh_password": "secret",
+        },
+    )
+    # Only check debian; alpine is unchecked (opt-out)
+    response = setup_client.post(
+        "/setup/connect/proxmox/save-docker",
+        data={"docker_lxcs": ["debian"]},
+    )
+    assert response.status_code == 200
+    raw = yaml.safe_load(config_file.read_text())
+    debian = next((h for h in raw["hosts"] if h.get("proxmox_vmid") == 100), None)
+    alpine = next((h for h in raw["hosts"] if h.get("proxmox_vmid") == 101), None)
+    assert debian is not None
+    assert debian.get("docker_mode") == "all"
+    assert alpine is not None
+    assert alpine.get("docker_mode") is None
 
 
 def test_proxmox_skip_lxcs(setup_client, data_dir):


### PR DESCRIPTION
OP#101

## Summary
- `add_host()` now sets `docker_mode="all"` for all LXC containers added via the wizard, so they are monitored by default regardless of what the user does in the Docker step
- Docker step checkboxes are pre-checked (opt-out UX instead of opt-in)
- `save-docker` now loops ALL session LXCs and removes `docker_mode` for any that were unchecked, enabling explicit opt-out; guards against missing session key

## Test plan
- [x] `test_proxmox_save_lxcs` — asserts `docker_mode="all"` is set immediately on `add_host()`
- [x] `test_proxmox_save_docker_sets_monitoring` — checked LXC retains `docker_mode="all"`
- [x] `test_proxmox_save_docker_opt_out` (new) — unchecked LXC gets `docker_mode` removed
- [x] `test_proxmox_skip_docker_retains_monitoring` (renamed) — skip path leaves `docker_mode="all"` intact
- [x] Full suite: 803 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)