### PR TITLE
Fix wizard step 7 showing 'No containers found' for Proxmox LXC hosts

### DIFF
--- a/app/auth_router.py
+++ b/app/auth_router.py
@@ -1661,7 +1661,13 @@ async def setup_containers_page(request: Request) -> HTMLResponse:
     for h in hosts:
         from .credentials import get_credentials
 
-        if h.get("proxmox_vmid") is not None:
+        proxmox_node = h.get("proxmox_node")
+        proxmox_vmid = h.get("proxmox_vmid")
+        # Skip the Proxmox hypervisor node itself — it doesn't run Docker
+        if proxmox_node and proxmox_vmid is None:
+            continue
+        # Skip LXC/VM hosts that don't have Docker monitoring enabled
+        if proxmox_vmid is not None and not h.get("docker_mode"):
             pct_exec_count += 1
             continue
         creds = get_credentials(h["slug"])

--- a/app/templates/setup_containers.html
+++ b/app/templates/setup_containers.html
@@ -138,8 +138,8 @@
           <div class="w-10 h-10 rounded-full bg-[#21262d] flex items-center justify-center mx-auto mb-3">
             <svg width="18" height="18" viewBox="0 0 16 16" fill="none"><circle cx="8" cy="8" r="6.5" stroke="#484f58" stroke-width="1.2"/><path d="M8 5v3.5l2 2" stroke="#484f58" stroke-width="1.2" stroke-linecap="round"/></svg>
           </div>
-          <p class="text-sm font-medium text-slate-400">Your Proxmox LXC containers are already configured</p>
-          <p class="text-xs text-slate-600 mt-1">Package monitoring for Proxmox LXC containers runs via <code class="text-slate-500">pct exec</code>, not Docker. They don't appear here.</p>
+          <p class="text-sm font-medium text-slate-400">Your Proxmox containers are configured</p>
+          <p class="text-xs text-slate-600 mt-1">Proxmox LXC containers without Docker monitoring use <code class="text-slate-500">pct exec</code> for package updates and don't appear here.</p>
         </div>
 
       {% else %}

--- a/tests/test_setup_connect.py
+++ b/tests/test_setup_connect.py
@@ -844,7 +844,7 @@ def test_proxmox_discover_removes_proxmox_from_integration_pending(setup_client,
 
 
 def test_setup_containers_excludes_pct_exec_hosts(setup_client, data_dir, config_file):
-    """Container monitoring step skips hosts with proxmox_vmid (pct exec)."""
+    """LXC hosts without docker_mode are skipped in container discovery."""
     from app.config_manager import add_host
     _create_admin()
     add_host(name="My LXC", host="192.168.5.50", user=None, port=None,
@@ -852,12 +852,11 @@ def test_setup_containers_excludes_pct_exec_hosts(setup_client, data_dir, config
     with patch("app.auth_router.discover_containers", new=AsyncMock(return_value=[])):
         response = setup_client.get("/setup/containers")
     assert response.status_code == 200
-    # LXC host should not appear as a discoverable SSH Docker host
     assert "My LXC" not in response.text
 
 
 def test_setup_containers_pct_exec_count_passed_to_template(setup_client, data_dir, config_file):
-    """pct exec hosts are not shown as discoverable SSH hosts in container step."""
+    """LXC hosts without docker_mode increment pct_exec_count."""
     from app.config_manager import add_host
     _create_admin()
     add_host(name="LXC 101", host="192.168.5.51", user=None, port=None,
@@ -865,5 +864,32 @@ def test_setup_containers_pct_exec_count_passed_to_template(setup_client, data_d
     with patch("app.auth_router.discover_containers", new=AsyncMock(return_value=[])):
         response = setup_client.get("/setup/containers")
     assert response.status_code == 200
-    # LXC host should not appear as a discoverable SSH host
     assert "LXC 101" not in response.text
+
+
+def test_setup_containers_excludes_proxmox_node(setup_client, data_dir, config_file):
+    """Proxmox hypervisor node (proxmox_node set, no vmid) is excluded from container discovery."""
+    from app.config_manager import add_host
+    _create_admin()
+    add_host(name="Proxmox VE", host="192.168.5.226", user=None, port=None,
+             proxmox_node="pve")
+    mock_discover = AsyncMock(return_value=[])
+    with patch("app.auth_router.discover_containers", new=mock_discover):
+        response = setup_client.get("/setup/containers")
+    assert response.status_code == 200
+    called_hosts = [call.args[0]["host"] for call in mock_discover.call_args_list]
+    assert "192.168.5.226" not in called_hosts
+
+
+def test_setup_containers_includes_lxc_with_docker_mode(setup_client, data_dir, config_file):
+    """LXC hosts with docker_mode set are included in container discovery."""
+    from app.config_manager import add_host
+    _create_admin()
+    add_host(name="NGINX", host="192.168.5.235", user=None, port=None,
+             proxmox_node="pve", proxmox_vmid=102, docker_mode="all")
+    fake_containers = [{"id": "nginx", "name": "nginx", "image": "nginx:latest"}]
+    with patch("app.auth_router.discover_containers", new=AsyncMock(return_value=fake_containers)):
+        response = setup_client.get("/setup/containers")
+    assert response.status_code == 200
+    assert "NGINX" in response.text
+    assert "nginx:latest" in response.text


### PR DESCRIPTION
OP#101

## Summary
- Wizard step 7 (Container monitoring) was showing "No containers found" when the only hosts were Proxmox LXC containers
- Root cause: the Proxmox hypervisor node (proxmox_node set, vmid=None) was being passed to `discover_containers` via SSH and returning empty, while LXC hosts with `docker_mode` set were being skipped entirely
- Fix: skip the Proxmox node from discovery; include LXC hosts that have `docker_mode` set so their containers appear for selection

## Test plan
- [ ] `test_setup_containers_excludes_proxmox_node` — Proxmox node IP not passed to `discover_containers`
- [ ] `test_setup_containers_includes_lxc_with_docker_mode` — LXC with docker_mode shows containers in step 7
- [ ] All 805 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)