### PR TITLE
Fix wizard step 7 'No containers found' for Proxmox LXC Docker hosts

### DIFF
--- a/app/auth_router.py
+++ b/app/auth_router.py
@@ -1658,6 +1658,7 @@ async def setup_containers_page(request: Request) -> HTMLResponse:
 
     host_data = []
     pct_exec_count = 0
+    proxmox_docker_hosts: list[dict] = []
     for h in hosts:
         from .credentials import get_credentials
 
@@ -1666,9 +1667,12 @@ async def setup_containers_page(request: Request) -> HTMLResponse:
         # Skip the Proxmox hypervisor node itself — it doesn't run Docker
         if proxmox_node and proxmox_vmid is None:
             continue
-        # Skip LXC/VM hosts that don't have Docker monitoring enabled
-        if proxmox_vmid is not None and not h.get("docker_mode"):
-            pct_exec_count += 1
+        if proxmox_vmid is not None:
+            if h.get("docker_mode"):
+                # Pre-configured via the Proxmox wizard — don't attempt SSH
+                proxmox_docker_hosts.append({"name": h["name"], "ip": h.get("host", "")})
+            else:
+                pct_exec_count += 1
             continue
         creds = get_credentials(h["slug"])
         containers = await discover_containers(h, ssh_cfg, creds)
@@ -1687,6 +1691,7 @@ async def setup_containers_page(request: Request) -> HTMLResponse:
             "request": request,
             "hosts": host_data,
             "pct_exec_count": pct_exec_count,
+            "proxmox_docker_hosts": proxmox_docker_hosts,
         },
     )
 

--- a/app/templates/setup_containers.html
+++ b/app/templates/setup_containers.html
@@ -61,6 +61,29 @@
 
     <form method="post" action="/setup/containers/save">
 
+      {% if proxmox_docker_hosts %}
+      <!-- Proxmox LXC hosts with Docker monitoring pre-configured -->
+      <div class="bg-[#161b22] border border-[#21262d] rounded-xl px-5 py-6 mb-4">
+        <div class="flex items-center gap-3 mb-3">
+          <div class="w-8 h-8 rounded-full bg-[#0c2045] flex items-center justify-center flex-shrink-0">
+            <svg width="14" height="14" viewBox="0 0 16 16" fill="none"><path d="M13 5H3a1 1 0 00-1 1v6a1 1 0 001 1h10a1 1 0 001-1V6a1 1 0 00-1-1z" stroke="#388bfd" stroke-width="1.2"/><circle cx="6" cy="9" r="1" fill="#388bfd"/><circle cx="10" cy="9" r="1" fill="#388bfd"/></svg>
+          </div>
+          <div>
+            <p class="text-sm font-medium text-slate-200">Docker monitoring configured</p>
+            <p class="text-xs text-slate-500 mt-0.5">All containers on these LXC hosts will be monitored</p>
+          </div>
+        </div>
+        <div class="space-y-1">
+          {% for h in proxmox_docker_hosts %}
+          <div class="flex items-center justify-between px-3 py-2 rounded-lg bg-slate-700/30">
+            <span class="text-sm text-slate-300">{{ h.name }}</span>
+            <span class="text-xs text-slate-500 font-mono">{{ h.ip }}</span>
+          </div>
+          {% endfor %}
+        </div>
+      </div>
+      {% endif %}
+
       {% if hosts %}
 
         {% set has_any_containers = hosts | selectattr('containers') | list | length > 0 %}
@@ -120,8 +143,8 @@
             {% endif %}
           {% endfor %}
 
-        {% else %}
-          <!-- No containers on any host -->
+        {% elif not proxmox_docker_hosts %}
+          <!-- No containers on any host and no Proxmox docker hosts -->
           <div class="bg-[#161b22] border border-[#21262d] rounded-xl px-5 py-8 text-center mb-6">
             <div class="w-10 h-10 rounded-full bg-[#21262d] flex items-center justify-center mx-auto mb-3">
               <svg width="18" height="18" viewBox="0 0 16 16" fill="none"><rect x="1" y="3" width="14" height="10" rx="2" stroke="#484f58" stroke-width="1.2"/><path d="M5 8h6M8 5v6" stroke="#484f58" stroke-width="1.2" stroke-linecap="round"/></svg>
@@ -131,8 +154,8 @@
           </div>
         {% endif %}
 
-      {% else %}
-        <!-- No SSH hosts — check if only pct exec LXC hosts exist -->
+      {% elif not proxmox_docker_hosts %}
+        <!-- No regular SSH hosts and no Proxmox docker hosts -->
         {% if pct_exec_count and pct_exec_count > 0 %}
         <div class="bg-[#161b22] border border-[#21262d] rounded-xl px-5 py-8 text-center mb-6">
           <div class="w-10 h-10 rounded-full bg-[#21262d] flex items-center justify-center mx-auto mb-3">
@@ -141,15 +164,12 @@
           <p class="text-sm font-medium text-slate-400">Your Proxmox containers are configured</p>
           <p class="text-xs text-slate-600 mt-1">Proxmox LXC containers without Docker monitoring use <code class="text-slate-500">pct exec</code> for package updates and don't appear here.</p>
         </div>
-
-      {% else %}
-        <!-- No SSH hosts -->
+        {% else %}
         <div class="bg-[#161b22] border border-[#21262d] rounded-xl px-5 py-8 text-center mb-6">
           <p class="text-sm font-medium text-slate-400">No SSH hosts configured</p>
           <p class="text-xs text-slate-600 mt-1">Go back and add SSH hosts first.</p>
         </div>
-      {% endif %}
-
+        {% endif %}
       {% endif %}
 
       <!-- Bottom buttons -->

--- a/tests/test_setup_connect.py
+++ b/tests/test_setup_connect.py
@@ -881,15 +881,19 @@ def test_setup_containers_excludes_proxmox_node(setup_client, data_dir, config_f
     assert "192.168.5.226" not in called_hosts
 
 
-def test_setup_containers_includes_lxc_with_docker_mode(setup_client, data_dir, config_file):
-    """LXC hosts with docker_mode set are included in container discovery."""
+def test_setup_containers_shows_proxmox_docker_hosts(setup_client, data_dir, config_file):
+    """LXC hosts with docker_mode are shown as pre-configured without SSH discovery."""
     from app.config_manager import add_host
     _create_admin()
     add_host(name="NGINX", host="192.168.5.235", user=None, port=None,
              proxmox_node="pve", proxmox_vmid=102, docker_mode="all")
-    fake_containers = [{"id": "nginx", "name": "nginx", "image": "nginx:latest"}]
-    with patch("app.auth_router.discover_containers", new=AsyncMock(return_value=fake_containers)):
+    mock_discover = AsyncMock(return_value=[])
+    with patch("app.auth_router.discover_containers", new=mock_discover):
         response = setup_client.get("/setup/containers")
     assert response.status_code == 200
+    # LXC host should appear in the pre-configured section, not via SSH discovery
     assert "NGINX" in response.text
-    assert "nginx:latest" in response.text
+    assert "Docker monitoring configured" in response.text
+    # discover_containers should NOT be called for LXC hosts
+    called_hosts = [call.args[0].get("host") for call in mock_discover.call_args_list]
+    assert "192.168.5.235" not in called_hosts


### PR DESCRIPTION
OP#101

## Summary
- The v0.25.2 fix included LXC hosts with `docker_mode` in SSH discovery, but those hosts have no SSH credentials stored — `discover_containers` silently failed and returned empty
- Root cause: LXC containers added via the Proxmox wizard don't go through SSH credential setup, so direct SSH discovery doesn't work for them
- Fix: LXC hosts with `docker_mode` are treated as pre-configured and shown in a dedicated "Docker monitoring configured" card — no SSH discovery attempted. Their `docker_mode="all"` (set in wizard step 6) is preserved.

## Test plan
- [ ] `test_setup_containers_shows_proxmox_docker_hosts` — LXC with docker_mode shows in pre-configured section, `discover_containers` NOT called for it
- [ ] `test_setup_containers_excludes_proxmox_node` — Proxmox hypervisor node not passed to discovery
- [ ] All 805 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)