### PR TITLE
[#102] Docker backend: add pct exec path for Proxmox LXCs

### DIFF
--- a/app/backends/ssh_docker_backend.py
+++ b/app/backends/ssh_docker_backend.py
@@ -13,12 +13,13 @@ import asyncio
 import json
 import logging
 import shlex
-from urllib.parse import quote, unquote
+from typing import Callable
+from urllib.parse import quote, unquote, urlparse
 
 from ..ssh_client import _connect
 from ..registry_client import check_image_update, extract_local_digest
-from ..credentials import get_credentials
-from ..config_manager import get_hosts, get_ssh_config
+from ..credentials import get_credentials, get_integration_credentials
+from ..config_manager import get_hosts, get_ssh_config, get_proxmox_config
 
 log = logging.getLogger(__name__)
 
@@ -45,6 +46,45 @@ class SSHDockerBackend:
         elif proxmox_node and proxmox_type == "vm":
             return f"VM {proxmox_vmid} · SSH"
         return "SSH"
+
+    def _is_pct_host(self, host: dict) -> bool:
+        """True when this host's docker daemon is reached via `pct exec` on a Proxmox node."""
+        if not host.get("proxmox_node"):
+            return False
+        if host.get("proxmox_vmid") is None:
+            return False
+        return (host.get("proxmox_type") or "lxc") == "lxc"
+
+    def _ssh_params_for(self, host: dict) -> tuple[dict, dict, Callable[[str], str]]:
+        """
+        Resolve `(host_entry, ssh_creds, wrap)` for Docker I/O against this host.
+
+        For Proxmox LXCs, SSH targets the Proxmox node and every docker command
+        is wrapped as `pct exec {vmid} -- sh -c '<cmd>'`. For everything else,
+        the existing direct-SSH parameters are returned and `wrap` is identity.
+        """
+        if not self._is_pct_host(host):
+            return host, get_credentials(host["slug"]), lambda c: c
+
+        vmid = host["proxmox_vmid"]
+        px_cfg = get_proxmox_config()
+        px_creds = get_integration_credentials("proxmox")
+        px_host = urlparse(px_cfg.get("url", "")).hostname or host.get("host", "")
+        ssh_user = px_creds.get("ssh_user") or "root"
+        ssh_key = px_creds.get("ssh_key") or ""
+        ssh_password = px_creds.get("ssh_password") or ""
+
+        host_entry: dict = {"host": px_host, "user": ssh_user, "port": 22}
+        if ssh_key:
+            host_entry["key"] = f"/app/keys/{ssh_key}"
+        ssh_creds: dict = {}
+        if not ssh_key and ssh_password:
+            ssh_creds["ssh_password"] = ssh_password
+
+        def wrap(cmd: str) -> str:
+            return f"pct exec {vmid} -- sh -c {shlex.quote(cmd)}"
+
+        return host_entry, ssh_creds, wrap
 
     def _make_compose_ref(self, slug: str, project: str, container: str) -> str:
         return f"{slug}/{quote(project, safe='')}:{quote(container, safe='')}"
@@ -98,9 +138,18 @@ class SSHDockerBackend:
         all_entries = []
         for host, r in zip(hosts, results):
             if isinstance(r, Exception):
-                log.warning(
-                    "Docker SSH: skipping %s — %s", host.get("host", host["slug"]), r
-                )
+                if self._is_pct_host(host):
+                    log.error(
+                        "Docker SSH: pct exec failed for %s (node %s vmid %s) — %s",
+                        host.get("host", host["slug"]),
+                        host.get("proxmox_node"),
+                        host.get("proxmox_vmid"),
+                        r,
+                    )
+                else:
+                    log.warning(
+                        "Docker SSH: skipping %s — %s", host.get("host", host["slug"]), r
+                    )
             elif isinstance(r, list):
                 all_entries.extend(r)
         return sorted(all_entries, key=lambda s: (s["endpoint_name"], s["name"]))
@@ -138,12 +187,12 @@ class SSHDockerBackend:
         if docker_mode == "selected":
             allowed_projects = set(host.get("docker_stacks") or [])
 
-        creds = get_credentials(slug)
+        host_entry, ssh_creds, wrap = self._ssh_params_for(host)
         entries = []
 
-        async with await _connect(host, ssh_cfg, creds) as conn:
+        async with await _connect(host_entry, ssh_cfg, ssh_creds) as conn:
             ps_result = await conn.run(
-                "docker ps -a --format '{{json .}}'", check=False
+                wrap("docker ps -a --format '{{json .}}'"), check=False
             )
             containers = _parse_json_output(ps_result.stdout)
 
@@ -169,7 +218,7 @@ class SSHDockerBackend:
             # Check all unique images concurrently (deduplicates registry lookups)
             unique_images = list({image for _, image, _ in raw})
             statuses = await asyncio.gather(
-                *[self._check_image_status(conn, img, dockerhub_creds) for img in unique_images],
+                *[self._check_image_status(conn, img, dockerhub_creds, wrap) for img in unique_images],
                 return_exceptions=True,
             )
             image_status: dict[str, str] = {
@@ -211,10 +260,14 @@ class SSHDockerBackend:
         conn,
         image_name: str,
         dockerhub_creds: dict | None,
+        wrap: Callable[[str], str] | None = None,
     ) -> str:
+        wrap = wrap or (lambda c: c)
         try:
             inspect = await conn.run(
-                f"docker image inspect {shlex.quote(image_name)} --format '{{{{json .RepoDigests}}}}'",
+                wrap(
+                    f"docker image inspect {shlex.quote(image_name)} --format '{{{{json .RepoDigests}}}}'"
+                ),
                 check=False,
             )
             repo_digests: list[str] = []
@@ -247,8 +300,14 @@ class SSHDockerBackend:
         checked = await asyncio.gather(*tasks, return_exceptions=True)
         return [{"name": img, "status": r} for img, r in zip(seen, checked) if isinstance(r, str)]
 
-    async def _get_config_file(self, conn, project_name: str) -> str:
-        result = await conn.run("docker compose ls --all --format json", check=False)
+    async def _get_config_file(
+        self,
+        conn,
+        project_name: str,
+        wrap: Callable[[str], str] | None = None,
+    ) -> str:
+        wrap = wrap or (lambda c: c)
+        result = await conn.run(wrap("docker compose ls --all --format json"), check=False)
         rows = _parse_json_output(result.stdout)
         match = next((r for r in rows if r.get("Name") == project_name), None)
         return match.get("ConfigFiles", "") if match else ""
@@ -262,15 +321,15 @@ class SSHDockerBackend:
         h = host.get("host", slug)
         log.info("Docker SSH: updating compose project %s on %s", project_name, h)
         ssh_cfg = get_ssh_config()
-        creds = get_credentials(slug)
-        async with await _connect(host, ssh_cfg, creds) as conn:
-            config_file = await self._get_config_file(conn, project_name)
+        host_entry, ssh_creds, wrap = self._ssh_params_for(host)
+        async with await _connect(host_entry, ssh_cfg, ssh_creds) as conn:
+            config_file = await self._get_config_file(conn, project_name, wrap)
             args = f"-f {config_file}" if config_file else f"-p {shlex.quote(project_name)}"
-            pull = await conn.run(f"docker compose {args} pull 2>&1", check=False)
+            pull = await conn.run(wrap(f"docker compose {args} pull 2>&1"), check=False)
             if pull.returncode != 0:
                 log.error("Docker SSH: pull failed for %s on %s", project_name, h)
                 raise RuntimeError(f"docker compose pull failed:\n{pull.stdout}")
-            up = await conn.run(f"docker compose {args} up -d 2>&1", check=False)
+            up = await conn.run(wrap(f"docker compose {args} up -d 2>&1"), check=False)
             if up.returncode != 0:
                 log.error("Docker SSH: up -d failed for %s on %s", project_name, h)
                 raise RuntimeError(f"docker compose up -d failed:\n{up.stdout}")
@@ -281,10 +340,10 @@ class SSHDockerBackend:
         h = host.get("host", slug)
         log.info("Docker SSH: updating standalone container %s on %s", container_name, h)
         ssh_cfg = get_ssh_config()
-        creds = get_credentials(slug)
-        async with await _connect(host, ssh_cfg, creds) as conn:
+        host_entry, ssh_creds, wrap = self._ssh_params_for(host)
+        async with await _connect(host_entry, ssh_cfg, ssh_creds) as conn:
             inspect_result = await conn.run(
-                f"docker inspect {shlex.quote(container_name)}", check=False
+                wrap(f"docker inspect {shlex.quote(container_name)}"), check=False
             )
             if inspect_result.returncode != 0 or not inspect_result.stdout.strip():
                 raise RuntimeError(f"Container {container_name!r} not found")
@@ -292,18 +351,18 @@ class SSHDockerBackend:
 
             image = inspect_data["Config"]["Image"]
             log.info("Docker SSH: pulling %s for container %s", image, container_name)
-            pull = await conn.run(f"docker pull {shlex.quote(image)} 2>&1", check=False)
+            pull = await conn.run(wrap(f"docker pull {shlex.quote(image)} 2>&1"), check=False)
             if pull.returncode != 0:
                 log.error("Docker SSH: pull failed for %s on %s", container_name, h)
                 raise RuntimeError(f"docker pull failed:\n{pull.stdout}")
 
             log.info("Docker SSH: stopping and removing %s", container_name)
-            await conn.run(f"docker stop {shlex.quote(container_name)}", check=False)
-            await conn.run(f"docker rm {shlex.quote(container_name)}", check=False)
+            await conn.run(wrap(f"docker stop {shlex.quote(container_name)}"), check=False)
+            await conn.run(wrap(f"docker rm {shlex.quote(container_name)}"), check=False)
 
             run_cmd = _build_docker_run_cmd(inspect_data)
             log.info("Docker SSH: recreating %s", container_name)
-            run = await conn.run(f"{run_cmd} 2>&1", check=False)
+            run = await conn.run(wrap(f"{run_cmd} 2>&1"), check=False)
             if run.returncode != 0:
                 log.error("Docker SSH: recreate failed for %s on %s", container_name, h)
                 raise RuntimeError(f"docker run failed:\n{run.stdout}")

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -1156,6 +1156,245 @@ async def test_get_stacks_includes_connection_badge(config_file, data_dir):
     assert stacks[0]["connection_badge"] == "SSH"
 
 
+def test_is_pct_host_matrix():
+    b = SSHDockerBackend()
+    assert b._is_pct_host({}) is False
+    assert b._is_pct_host({"proxmox_node": "pve"}) is False
+    assert b._is_pct_host({"proxmox_vmid": 101}) is False
+    assert b._is_pct_host({"proxmox_node": "pve", "proxmox_vmid": 101}) is True
+    assert (
+        b._is_pct_host({"proxmox_node": "pve", "proxmox_vmid": 101, "proxmox_type": "lxc"})
+        is True
+    )
+    assert (
+        b._is_pct_host({"proxmox_node": "pve", "proxmox_vmid": 101, "proxmox_type": "vm"})
+        is False
+    )
+
+
+def test_ssh_params_for_non_pct_host_returns_identity_wrap(config_file, data_dir):
+    b = SSHDockerBackend()
+    host = {"name": "Test Host", "host": "192.168.1.10", "slug": "test-host"}
+    host_entry, ssh_creds, wrap = b._ssh_params_for(host)
+    assert host_entry is host
+    assert wrap("docker ps -a") == "docker ps -a"
+
+
+def test_ssh_params_for_pct_host_wraps_with_pct_exec(config_file, data_dir):
+    from app.config_manager import save_proxmox_config
+    from app.credentials import save_integration_credentials
+
+    save_proxmox_config(url="https://pve.example:8006", verify_ssl=False)
+    save_integration_credentials(
+        "proxmox", ssh_user="root", ssh_key="id_proxmox", ssh_password=""
+    )
+
+    b = SSHDockerBackend()
+    host = {
+        "name": "LXC 101",
+        "host": "10.0.0.10",
+        "slug": "lxc-101",
+        "proxmox_node": "pve",
+        "proxmox_vmid": 101,
+        "proxmox_type": "lxc",
+    }
+    host_entry, ssh_creds, wrap = b._ssh_params_for(host)
+    assert host_entry["host"] == "pve.example"
+    assert host_entry["user"] == "root"
+    assert host_entry["port"] == 22
+    assert host_entry["key"] == "/app/keys/id_proxmox"
+    # Command wrapping: shell-quote the inner docker cmd so pipes/redirects work
+    wrapped = wrap("docker ps -a --format '{{json .}}'")
+    assert wrapped.startswith("pct exec 101 -- sh -c ")
+    assert "docker ps -a" in wrapped
+
+
+def test_ssh_params_for_pct_host_password_auth(config_file, data_dir):
+    from app.config_manager import save_proxmox_config
+    from app.credentials import save_integration_credentials
+
+    save_proxmox_config(url="https://pve.example:8006", verify_ssl=False)
+    save_integration_credentials(
+        "proxmox", ssh_user="root", ssh_key="", ssh_password="hunter2"
+    )
+
+    b = SSHDockerBackend()
+    host = {
+        "name": "LXC 101",
+        "host": "10.0.0.10",
+        "slug": "lxc-101",
+        "proxmox_node": "pve",
+        "proxmox_vmid": 101,
+    }
+    host_entry, ssh_creds, _wrap = b._ssh_params_for(host)
+    assert "key" not in host_entry
+    assert ssh_creds["ssh_password"] == "hunter2"
+
+
+@pytest.mark.asyncio
+async def test_containers_for_host_pct_wraps_docker_ps(config_file, data_dir):
+    """pct hosts: docker ps and image inspect are executed via `pct exec VMID -- sh -c`."""
+    import yaml
+    from app.config_manager import save_proxmox_config
+    from app.credentials import save_integration_credentials
+
+    save_proxmox_config(url="https://pve.example:8006", verify_ssl=False)
+    save_integration_credentials("proxmox", ssh_user="root", ssh_key="id_proxmox")
+
+    raw = yaml.safe_load(config_file.read_text())
+    raw["hosts"][0]["docker_mode"] = "all"
+    raw["hosts"][0]["proxmox_node"] = "pve"
+    raw["hosts"][0]["proxmox_vmid"] = 101
+    raw["hosts"][0]["proxmox_type"] = "lxc"
+    config_file.write_text(yaml.dump(raw))
+
+    docker_ps_output = json.dumps(
+        {"Names": "/app", "Image": "app:latest", "Labels": ""}
+    )
+    inspect_output = '["app@sha256:abc"]'
+    conn = _make_multi_conn(
+        [
+            MagicMock(stdout=docker_ps_output, returncode=0),
+            MagicMock(stdout=inspect_output, returncode=0),
+        ]
+    )
+
+    with (
+        patch("app.backends.ssh_docker_backend._connect", new=AsyncMock(return_value=conn)),
+        patch("app.backends.ssh_docker_backend.check_image_update",
+              new=AsyncMock(return_value="up_to_date")),
+    ):
+        backend = SSHDockerBackend()
+        stacks = await backend.get_stacks_with_update_status()
+
+    assert len(stacks) == 1
+    calls = [call.args[0] for call in conn.run.call_args_list]
+    assert all(c.startswith("pct exec 101 -- sh -c ") for c in calls)
+    assert any("docker ps -a" in c for c in calls)
+    assert any("docker image inspect" in c for c in calls)
+    assert stacks[0]["connection_badge"] == "LXC 101 · pct exec"
+
+
+@pytest.mark.asyncio
+async def test_update_compose_pct_wraps_commands(config_file, data_dir):
+    """Compose updates on pct hosts wrap every docker command with pct exec."""
+    import yaml
+    from app.config_manager import save_proxmox_config
+    from app.credentials import save_integration_credentials
+
+    save_proxmox_config(url="https://pve.example:8006", verify_ssl=False)
+    save_integration_credentials("proxmox", ssh_user="root", ssh_key="id_proxmox")
+
+    raw = yaml.safe_load(config_file.read_text())
+    raw["hosts"][0]["docker_mode"] = "all"
+    raw["hosts"][0]["proxmox_node"] = "pve"
+    raw["hosts"][0]["proxmox_vmid"] = 202
+    config_file.write_text(yaml.dump(raw))
+
+    ls_output = json.dumps([{"Name": "sonarr", "ConfigFiles": "/opt/sonarr/dc.yml"}])
+    conn = _make_multi_conn(
+        [
+            MagicMock(stdout=ls_output, returncode=0),
+            MagicMock(stdout="Pulled", returncode=0),
+            MagicMock(stdout="Started", returncode=0),
+        ]
+    )
+
+    with patch(
+        "app.backends.ssh_docker_backend._connect", new=AsyncMock(return_value=conn)
+    ):
+        backend = SSHDockerBackend()
+        await backend.update_stack("test-host/sonarr:sonarr")
+
+    calls = [call.args[0] for call in conn.run.call_args_list]
+    assert all(c.startswith("pct exec 202 -- sh -c ") for c in calls)
+    assert any("docker compose" in c and "pull" in c for c in calls)
+    assert any("docker compose" in c and "up -d" in c for c in calls)
+
+
+@pytest.mark.asyncio
+async def test_update_standalone_pct_wraps_commands(config_file, data_dir):
+    """Standalone updates on pct hosts wrap inspect/pull/stop/rm/run with pct exec."""
+    import yaml
+    from app.config_manager import save_proxmox_config
+    from app.credentials import save_integration_credentials
+
+    save_proxmox_config(url="https://pve.example:8006", verify_ssl=False)
+    save_integration_credentials("proxmox", ssh_user="root", ssh_key="id_proxmox")
+
+    raw = yaml.safe_load(config_file.read_text())
+    raw["hosts"][0]["docker_mode"] = "all"
+    raw["hosts"][0]["proxmox_node"] = "pve"
+    raw["hosts"][0]["proxmox_vmid"] = 303
+    config_file.write_text(yaml.dump(raw))
+
+    inspect_data = json.dumps([{
+        "Name": "/myapp", "Id": "abc123",
+        "Config": {"Image": "myimage:latest", "Env": [], "Cmd": None,
+                   "Entrypoint": None, "Labels": {}, "Hostname": "myapp"},
+        "HostConfig": {
+            "RestartPolicy": {"Name": "no", "MaximumRetryCount": 0},
+            "NetworkMode": "bridge", "Privileged": False,
+            "Binds": None, "PortBindings": {}, "Devices": None,
+            "CapAdd": None, "CapDrop": None, "Dns": None,
+            "ExtraHosts": None, "Tmpfs": None, "PidMode": "",
+            "IpcMode": "private", "LogConfig": {"Type": "json-file", "Config": {}},
+        },
+        "NetworkSettings": {"Networks": {}},
+    }])
+    conn = _make_multi_conn(
+        [
+            MagicMock(stdout=inspect_data, returncode=0),
+            MagicMock(stdout="Pulled", returncode=0),
+            MagicMock(stdout="", returncode=0),
+            MagicMock(stdout="", returncode=0),
+            MagicMock(stdout="new-id", returncode=0),
+        ]
+    )
+
+    with patch(
+        "app.backends.ssh_docker_backend._connect", new=AsyncMock(return_value=conn)
+    ):
+        backend = SSHDockerBackend()
+        await backend.update_stack("test-host/~myapp")
+
+    calls = [call.args[0] for call in conn.run.call_args_list]
+    assert all(c.startswith("pct exec 303 -- sh -c ") for c in calls)
+    assert any("docker inspect" in c for c in calls)
+    assert any("docker pull" in c for c in calls)
+    assert any("docker stop" in c for c in calls)
+    assert any("docker rm" in c for c in calls)
+    assert any("docker run" in c for c in calls)
+
+
+@pytest.mark.asyncio
+async def test_pct_host_connection_error_logs_at_error_level(
+    config_file, data_dir, caplog
+):
+    """pct host failures must surface at ERROR (not WARNING) so they're not silent."""
+    import logging
+    import yaml
+
+    raw = yaml.safe_load(config_file.read_text())
+    raw["hosts"][0]["docker_mode"] = "all"
+    raw["hosts"][0]["proxmox_node"] = "pve"
+    raw["hosts"][0]["proxmox_vmid"] = 404
+    config_file.write_text(yaml.dump(raw))
+
+    with patch(
+        "app.backends.ssh_docker_backend._connect",
+        new=AsyncMock(side_effect=ConnectionError("refused")),
+    ):
+        backend = SSHDockerBackend()
+        with caplog.at_level(logging.ERROR, logger="app.backends.ssh_docker_backend"):
+            stacks = await backend.get_stacks_with_update_status()
+
+    assert stacks == []
+    error_records = [r for r in caplog.records if r.levelno == logging.ERROR]
+    assert any("pct exec failed" in r.getMessage() for r in error_records)
+    assert any("404" in r.getMessage() for r in error_records)
+
+
 @pytest.mark.asyncio
 async def test_get_stacks_proxmox_node_connection_badge(config_file, data_dir):
     """A host flagged as a Proxmox node gets the Node · Proxmox API badge."""


### PR DESCRIPTION
OP#102

## Summary
- Adds a `pct exec` runtime path to `SSHDockerBackend` so Docker containers inside Proxmox LXCs added via the wizard (`proxmox_node + proxmox_vmid`) are discovered, image-checked, and updatable. Previously the backend always tried a direct SSH connection to the LXC IP, which failed silently and showed "No containers found" on the dashboard.
- Threads a `wrap` callable through the docker command call sites. LXC hosts SSH to the Proxmox node and every docker command is wrapped as `pct exec {vmid} -- sh -c '<cmd>'`. Non-LXC hosts use identity `wrap` and behave exactly as before.
- Escalates pct-host failures to `log.error` (vs `log.warning` for direct-SSH hosts) in `get_stacks_with_update_status`, so regressions are loud instead of silently zeroing the host.

## Scope
- `app/backends/ssh_docker_backend.py` — pct-aware I/O across `_containers_for_host`, `_update_compose_project`, `_update_standalone_container`, `_check_image_status`, `_get_config_file`.
- `tests/test_backends.py` — 8 new tests covering the `_is_pct_host` matrix, `_ssh_params_for` (key + password auth), wrapped commands on discovery/compose-update/standalone-update, and ERROR-level logging on pct-host failure.
- Admin-only `discover_stacks()` still uses the direct-SSH path — that's a separate flow and not the cause of this bug.

## Test plan
- [x] `pytest tests/test_backends.py` — 81 passed
- [x] Full suite — 813 passed, 96% overall coverage; `ssh_docker_backend.py` at 95%
- [ ] Manual: verify a Proxmox LXC with `docker_mode=all` now shows containers on the dashboard
- [ ] Manual: verify a non-Proxmox SSH host still discovers and updates as before
- [ ] Manual: verify both compose redeploy and standalone container recreate work through the pct branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)