### PR TITLE
OP#103 SSHDockerBackend: support legacy docker-compose v1 hosts

### DIFF
--- a/app/backends/ssh_docker_backend.py
+++ b/app/backends/ssh_docker_backend.py
@@ -105,22 +105,24 @@ class SSHDockerBackend:
     # ------------------------------------------------------------------
 
     async def discover_stacks(self, host: dict) -> list[dict]:
-        """Return all Compose projects on the host (for admin discovery only)."""
+        """Return all Compose projects on the host (for admin discovery only).
+
+        Reads `docker ps -a` labels instead of `docker compose ls`, so
+        hosts running legacy `docker-compose` v1 (no v2 plugin) are also
+        supported. Also routes through `_ssh_params_for` so Proxmox LXC
+        hosts are reached via `pct exec`.
+        """
         ssh_cfg = get_ssh_config()
-        creds = get_credentials(host["slug"])
+        host_entry, ssh_creds, wrap = self._ssh_params_for(host)
         try:
-            async with await _connect(host, ssh_cfg, creds) as conn:
+            async with await _connect(host_entry, ssh_cfg, ssh_creds) as conn:
                 result = await conn.run(
-                    "docker compose ls --all --format json", check=False
+                    wrap("docker ps -a --format '{{json .}}'"), check=False
                 )
-                if result.returncode != 0 or not result.stdout.strip():
+                if result.returncode != 0:
                     return []
-                rows = _parse_json_output(result.stdout)
-                return [
-                    {"name": r["Name"], "config_file": r.get("ConfigFiles", "")}
-                    for r in rows
-                    if r.get("Name")
-                ]
+                containers = _parse_json_output(result.stdout)
+                return _compose_projects_from_ps(containers)
         except Exception:
             return []
 
@@ -306,11 +308,48 @@ class SSHDockerBackend:
         project_name: str,
         wrap: Callable[[str], str] | None = None,
     ) -> str:
+        """Look up the compose config file for a project via container labels.
+
+        Version-agnostic: reads `com.docker.compose.project.config_files`
+        from `docker ps -a` labels, which both compose v1 and v2 write.
+        """
         wrap = wrap or (lambda c: c)
-        result = await conn.run(wrap("docker compose ls --all --format json"), check=False)
-        rows = _parse_json_output(result.stdout)
-        match = next((r for r in rows if r.get("Name") == project_name), None)
-        return match.get("ConfigFiles", "") if match else ""
+        result = await conn.run(
+            wrap("docker ps -a --format '{{json .}}'"), check=False
+        )
+        containers = _parse_json_output(result.stdout)
+        for c in containers:
+            labels = _parse_docker_ps_labels(c.get("Labels", "") or "")
+            if labels.get("com.docker.compose.project", "") != project_name:
+                continue
+            cf = labels.get(
+                "com.docker.compose.project.config_files", ""
+            ).split(",")[0].strip()
+            if cf:
+                return cf
+        return ""
+
+    async def _detect_compose_binary(
+        self,
+        conn,
+        wrap: Callable[[str], str],
+        host_label: str,
+    ) -> str:
+        """Return the compose binary command (`docker compose` or `docker-compose`).
+
+        Raises RuntimeError if neither is available on the host.
+        """
+        result = await conn.run(wrap(_COMPOSE_PROBE), check=False)
+        lines = (result.stdout or "").strip().splitlines()
+        flavour = lines[-1].strip() if lines else ""
+        if flavour == "v2":
+            return "docker compose"
+        if flavour == "v1":
+            return "docker-compose"
+        raise RuntimeError(
+            f"Neither 'docker compose' (v2) nor 'docker-compose' (v1) "
+            f"is available on {host_label}"
+        )
 
     # ------------------------------------------------------------------
     # Internals — updates
@@ -323,16 +362,17 @@ class SSHDockerBackend:
         ssh_cfg = get_ssh_config()
         host_entry, ssh_creds, wrap = self._ssh_params_for(host)
         async with await _connect(host_entry, ssh_cfg, ssh_creds) as conn:
+            binary = await self._detect_compose_binary(conn, wrap, h)
             config_file = await self._get_config_file(conn, project_name, wrap)
             args = f"-f {config_file}" if config_file else f"-p {shlex.quote(project_name)}"
-            pull = await conn.run(wrap(f"docker compose {args} pull 2>&1"), check=False)
+            pull = await conn.run(wrap(f"{binary} {args} pull 2>&1"), check=False)
             if pull.returncode != 0:
                 log.error("Docker SSH: pull failed for %s on %s", project_name, h)
-                raise RuntimeError(f"docker compose pull failed:\n{pull.stdout}")
-            up = await conn.run(wrap(f"docker compose {args} up -d 2>&1"), check=False)
+                raise RuntimeError(f"{binary} pull failed:\n{pull.stdout}")
+            up = await conn.run(wrap(f"{binary} {args} up -d 2>&1"), check=False)
             if up.returncode != 0:
                 log.error("Docker SSH: up -d failed for %s on %s", project_name, h)
-                raise RuntimeError(f"docker compose up -d failed:\n{up.stdout}")
+                raise RuntimeError(f"{binary} up -d failed:\n{up.stdout}")
         log.info("Docker SSH: %s on %s — compose update complete", project_name, h)
 
     async def _update_standalone_container(self, host: dict, container_name: str) -> None:
@@ -373,6 +413,36 @@ class SSHDockerBackend:
 # ------------------------------------------------------------------
 # Helpers
 # ------------------------------------------------------------------
+
+
+# One-shot probe that prints exactly one line: v2 | v1 | none
+_COMPOSE_PROBE = (
+    "docker compose version >/dev/null 2>&1 && echo v2 "
+    "|| { docker-compose --version >/dev/null 2>&1 && echo v1 || echo none; }"
+)
+
+
+def _compose_projects_from_ps(containers: list[dict]) -> list[dict]:
+    """
+    Group `docker ps -a --format json` output by compose project.
+
+    Returns `[{'name': project, 'config_file': path_or_empty}, ...]` using
+    the `com.docker.compose.project` and `com.docker.compose.project.config_files`
+    labels. Both compose v1 and v2 write these labels, so the result is
+    the same whether the host runs the legacy standalone or the v2 plugin.
+    """
+    by_project: dict[str, str] = {}
+    for c in containers:
+        labels = _parse_docker_ps_labels(c.get("Labels", "") or "")
+        name = labels.get("com.docker.compose.project", "")
+        if not name:
+            continue
+        cf = labels.get(
+            "com.docker.compose.project.config_files", ""
+        ).split(",")[0].strip()
+        if name not in by_project or (cf and not by_project[name]):
+            by_project[name] = cf
+    return [{"name": n, "config_file": f} for n, f in by_project.items()]
 
 
 def _parse_json_output(text: str) -> list[dict]:

--- a/app/backends/ssh_docker_backend.py
+++ b/app/backends/ssh_docker_backend.py
@@ -312,22 +312,16 @@ class SSHDockerBackend:
 
         Version-agnostic: reads `com.docker.compose.project.config_files`
         from `docker ps -a` labels, which both compose v1 and v2 write.
+        Relative paths (common on v1) are normalized against the
+        `working_dir` label by `_compose_projects_from_ps`.
         """
         wrap = wrap or (lambda c: c)
         result = await conn.run(
             wrap("docker ps -a --format '{{json .}}'"), check=False
         )
-        containers = _parse_json_output(result.stdout)
-        for c in containers:
-            labels = _parse_docker_ps_labels(c.get("Labels", "") or "")
-            if labels.get("com.docker.compose.project", "") != project_name:
-                continue
-            cf = labels.get(
-                "com.docker.compose.project.config_files", ""
-            ).split(",")[0].strip()
-            if cf:
-                return cf
-        return ""
+        projects = _compose_projects_from_ps(_parse_json_output(result.stdout))
+        match = next((p for p in projects if p["name"] == project_name), None)
+        return match["config_file"] if match else ""
 
     async def _detect_compose_binary(
         self,
@@ -430,6 +424,11 @@ def _compose_projects_from_ps(containers: list[dict]) -> list[dict]:
     the `com.docker.compose.project` and `com.docker.compose.project.config_files`
     labels. Both compose v1 and v2 write these labels, so the result is
     the same whether the host runs the legacy standalone or the v2 plugin.
+
+    v1 stores `config_files` as the literal value originally passed to the
+    CLI — often a bare filename like `docker-compose.yaml`. When relative,
+    it's joined with `com.docker.compose.project.working_dir` so the
+    returned path is always absolute (v2 already normalizes this).
     """
     by_project: dict[str, str] = {}
     for c in containers:
@@ -440,6 +439,11 @@ def _compose_projects_from_ps(containers: list[dict]) -> list[dict]:
         cf = labels.get(
             "com.docker.compose.project.config_files", ""
         ).split(",")[0].strip()
+        if cf and not cf.startswith("/"):
+            wd = labels.get(
+                "com.docker.compose.project.working_dir", ""
+            ).strip().rstrip("/")
+            cf = f"{wd}/{cf}" if wd else ""
         if name not in by_project or (cf and not by_project[name]):
             by_project[name] = cf
     return [{"name": n, "config_file": f} for n, f in by_project.items()]

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -1813,3 +1813,104 @@ def test_compose_projects_from_ps_multifile_takes_first():
     ]
     result = _compose_projects_from_ps(containers)
     assert result == [{"name": "proj", "config_file": "/one.yml"}]
+
+
+def test_compose_projects_from_ps_joins_relative_config_files_with_working_dir():
+    """v1 often stores a relative `config_files` — join with `working_dir` to absolutize."""
+    containers = [
+        {
+            "Names": "/nginx",
+            "Labels": (
+                "com.docker.compose.project=nginx,"
+                "com.docker.compose.project.config_files=docker-compose.yaml,"
+                "com.docker.compose.project.working_dir=/root/NGINX"
+            ),
+        }
+    ]
+    result = _compose_projects_from_ps(containers)
+    assert result == [{"name": "nginx", "config_file": "/root/NGINX/docker-compose.yaml"}]
+
+
+def test_compose_projects_from_ps_strips_trailing_slash_from_working_dir():
+    """Joining must not emit a double slash when working_dir ends with `/`."""
+    containers = [
+        {
+            "Names": "/svc",
+            "Labels": (
+                "com.docker.compose.project=svc,"
+                "com.docker.compose.project.config_files=dc.yml,"
+                "com.docker.compose.project.working_dir=/srv/svc/"
+            ),
+        }
+    ]
+    result = _compose_projects_from_ps(containers)
+    assert result == [{"name": "svc", "config_file": "/srv/svc/dc.yml"}]
+
+
+def test_compose_projects_from_ps_relative_without_working_dir_is_empty():
+    """Relative config_files with no working_dir label falls back to empty (→ `-p` fallback)."""
+    containers = [
+        {
+            "Names": "/orphan",
+            "Labels": (
+                "com.docker.compose.project=orphan,"
+                "com.docker.compose.project.config_files=docker-compose.yml"
+            ),
+        }
+    ]
+    result = _compose_projects_from_ps(containers)
+    assert result == [{"name": "orphan", "config_file": ""}]
+
+
+def test_compose_projects_from_ps_absolute_path_unchanged():
+    """Absolute paths (v2 normal case) are passed through as-is."""
+    containers = [
+        {
+            "Names": "/app",
+            "Labels": (
+                "com.docker.compose.project=app,"
+                "com.docker.compose.project.config_files=/opt/app/dc.yml,"
+                "com.docker.compose.project.working_dir=/opt/app"
+            ),
+        }
+    ]
+    result = _compose_projects_from_ps(containers)
+    assert result == [{"name": "app", "config_file": "/opt/app/dc.yml"}]
+
+
+@pytest.mark.asyncio
+async def test_update_compose_v1_relative_path_resolved(config_file, data_dir):
+    """End-to-end: v1 project with a relative config_files label gets an absolute `-f` path."""
+    import yaml
+
+    raw = yaml.safe_load(config_file.read_text())
+    raw["hosts"][0]["docker_mode"] = "all"
+    config_file.write_text(yaml.dump(raw))
+
+    ps_output = json.dumps(
+        {
+            "Names": "/nginx_app_1",
+            "Labels": (
+                "com.docker.compose.project=nginx,"
+                "com.docker.compose.project.config_files=docker-compose.yaml,"
+                "com.docker.compose.project.working_dir=/root/NGINX"
+            ),
+        }
+    )
+    conn = _make_multi_conn(
+        [
+            MagicMock(stdout="v1\n", returncode=0),
+            MagicMock(stdout=ps_output, returncode=0),
+            MagicMock(stdout="Pulled", returncode=0),
+            MagicMock(stdout="Started", returncode=0),
+        ]
+    )
+    with patch(
+        "app.backends.ssh_docker_backend._connect", new=AsyncMock(return_value=conn)
+    ):
+        backend = SSHDockerBackend()
+        await backend.update_stack("test-host/nginx:nginx_app_1")
+
+    calls = [c.args[0] for c in conn.run.call_args_list]
+    pull_call = next(c for c in calls if "pull" in c)
+    assert "docker-compose -f /root/NGINX/docker-compose.yaml pull" in pull_call

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -8,6 +8,7 @@ import pytest
 from app.backends import ContainerBackend, PortainerBackend, SSHDockerBackend
 from app.backends.ssh_docker_backend import (
     _build_docker_run_cmd,
+    _compose_projects_from_ps,
     _parse_docker_ps_labels,
     _parse_json_output,
     _rollup_status,
@@ -173,18 +174,29 @@ def _make_ssh_conn(stdout: str = "", returncode: int = 0) -> MagicMock:
 
 @pytest.mark.asyncio
 async def test_discover_stacks_returns_projects(config_file, data_dir):
-    output = json.dumps(
+    # Label-based discovery from `docker ps -a` — works on v1 and v2.
+    output = "\n".join(
         [
-            {
-                "Name": "sonarr",
-                "Status": "running(1)",
-                "ConfigFiles": "/opt/stacks/sonarr/docker-compose.yml",
-            },
-            {
-                "Name": "radarr",
-                "Status": "running(1)",
-                "ConfigFiles": "/opt/stacks/radarr/docker-compose.yml",
-            },
+            json.dumps(
+                {
+                    "Names": "/sonarr",
+                    "Image": "sonarr:latest",
+                    "Labels": (
+                        "com.docker.compose.project=sonarr,"
+                        "com.docker.compose.project.config_files=/opt/stacks/sonarr/docker-compose.yml"
+                    ),
+                }
+            ),
+            json.dumps(
+                {
+                    "Names": "/radarr",
+                    "Image": "radarr:latest",
+                    "Labels": (
+                        "com.docker.compose.project=radarr,"
+                        "com.docker.compose.project.config_files=/opt/stacks/radarr/docker-compose.yml"
+                    ),
+                }
+            ),
         ]
     )
     conn = _make_ssh_conn(stdout=output)
@@ -196,9 +208,12 @@ async def test_discover_stacks_returns_projects(config_file, data_dir):
         backend = SSHDockerBackend()
         stacks = await backend.discover_stacks(host)
 
-    assert len(stacks) == 2
-    assert stacks[0]["name"] == "sonarr"
-    assert stacks[1]["name"] == "radarr"
+    names = {s["name"] for s in stacks}
+    assert names == {"sonarr", "radarr"}
+    by_name = {s["name"]: s["config_file"] for s in stacks}
+    assert by_name["sonarr"] == "/opt/stacks/sonarr/docker-compose.yml"
+    # Probe command must be the version-agnostic `docker ps -a`.
+    assert "docker ps -a" in conn.run.call_args_list[0].args[0]
 
 
 @pytest.mark.asyncio
@@ -216,6 +231,40 @@ async def test_discover_stacks_empty_returns_empty(config_file, data_dir):
 
 
 @pytest.mark.asyncio
+async def test_discover_stacks_skips_standalone_containers(config_file, data_dir):
+    """Containers without a compose project label are excluded from discovery."""
+    output = "\n".join(
+        [
+            json.dumps(
+                {
+                    "Names": "/standalone",
+                    "Image": "standalone:latest",
+                    "Labels": "",
+                }
+            ),
+            json.dumps(
+                {
+                    "Names": "/sonarr",
+                    "Image": "sonarr:latest",
+                    "Labels": (
+                        "com.docker.compose.project=sonarr,"
+                        "com.docker.compose.project.config_files=/opt/stacks/sonarr/dc.yml"
+                    ),
+                }
+            ),
+        ]
+    )
+    conn = _make_ssh_conn(stdout=output)
+    host = {"name": "Test Host", "host": "192.168.1.10", "slug": "test-host"}
+    with patch(
+        "app.backends.ssh_docker_backend._connect", new=AsyncMock(return_value=conn)
+    ):
+        backend = SSHDockerBackend()
+        stacks = await backend.discover_stacks(host)
+    assert [s["name"] for s in stacks] == ["sonarr"]
+
+
+@pytest.mark.asyncio
 async def test_discover_stacks_ssh_error_returns_empty(config_file, data_dir):
     host = {"name": "Test Host", "host": "192.168.1.10", "slug": "test-host"}
 
@@ -227,6 +276,58 @@ async def test_discover_stacks_ssh_error_returns_empty(config_file, data_dir):
         stacks = await backend.discover_stacks(host)
 
     assert stacks == []
+
+
+@pytest.mark.asyncio
+async def test_discover_stacks_returncode_nonzero_returns_empty(config_file, data_dir):
+    conn = _make_ssh_conn(stdout="error", returncode=1)
+    host = {"name": "Test Host", "host": "192.168.1.10", "slug": "test-host"}
+    with patch(
+        "app.backends.ssh_docker_backend._connect", new=AsyncMock(return_value=conn)
+    ):
+        backend = SSHDockerBackend()
+        stacks = await backend.discover_stacks(host)
+    assert stacks == []
+
+
+@pytest.mark.asyncio
+async def test_discover_stacks_pct_host_uses_pct_exec(config_file, data_dir):
+    """Discovery on a Proxmox LXC host routes through `pct exec`."""
+    import yaml
+    from app.config_manager import save_proxmox_config
+    from app.credentials import save_integration_credentials
+
+    save_proxmox_config(url="https://pve.example:8006", verify_ssl=False)
+    save_integration_credentials("proxmox", ssh_user="root", ssh_key="id_proxmox")
+
+    raw = yaml.safe_load(config_file.read_text())
+    raw["hosts"][0]["docker_mode"] = "all"
+    raw["hosts"][0]["proxmox_node"] = "pve"
+    raw["hosts"][0]["proxmox_vmid"] = 707
+    config_file.write_text(yaml.dump(raw))
+
+    output = json.dumps(
+        {
+            "Names": "/sonarr",
+            "Image": "sonarr:latest",
+            "Labels": (
+                "com.docker.compose.project=sonarr,"
+                "com.docker.compose.project.config_files=/opt/sonarr/dc.yml"
+            ),
+        }
+    )
+    conn = _make_ssh_conn(stdout=output)
+    host = dict(raw["hosts"][0])
+    with patch(
+        "app.backends.ssh_docker_backend._connect", new=AsyncMock(return_value=conn)
+    ):
+        backend = SSHDockerBackend()
+        stacks = await backend.discover_stacks(host)
+
+    assert [s["name"] for s in stacks] == ["sonarr"]
+    cmd = conn.run.call_args_list[0].args[0]
+    assert cmd.startswith("pct exec 707 -- sh -c ")
+    assert "docker ps -a" in cmd
 
 
 # ---------------------------------------------------------------------------
@@ -251,9 +352,16 @@ async def test_update_stack_runs_pull_and_up(config_file, data_dir, monkeypatch)
     raw["hosts"][0]["docker_mode"] = "all"
     config_file.write_text(yaml.dump(raw))
 
-    ls_output = json.dumps(
-        [{"Name": "sonarr", "ConfigFiles": "/opt/sonarr/docker-compose.yml"}]
+    ps_output = json.dumps(
+        {
+            "Names": "/sonarr",
+            "Labels": (
+                "com.docker.compose.project=sonarr,"
+                "com.docker.compose.project.config_files=/opt/sonarr/docker-compose.yml"
+            ),
+        }
     )
+    probe = MagicMock(stdout="v2\n", returncode=0)
     pull_result = MagicMock(stdout="Pulled", returncode=0)
     up_result = MagicMock(stdout="Started", returncode=0)
 
@@ -262,7 +370,8 @@ async def test_update_stack_runs_pull_and_up(config_file, data_dir, monkeypatch)
     conn.__aexit__ = AsyncMock(return_value=False)
     conn.run = AsyncMock(
         side_effect=[
-            MagicMock(stdout=ls_output, returncode=0),  # ls for config file
+            probe,                                              # compose version probe
+            MagicMock(stdout=ps_output, returncode=0),          # docker ps -a (config file lookup)
             pull_result,
             up_result,
         ]
@@ -474,10 +583,19 @@ async def test_update_stack_pull_failure_raises(config_file, data_dir):
     raw["hosts"][0]["docker_mode"] = "all"
     config_file.write_text(yaml.dump(raw))
 
-    ls_output = json.dumps([{"Name": "sonarr", "ConfigFiles": "/opt/sonarr/dc.yml"}])
+    ps_output = json.dumps(
+        {
+            "Names": "/sonarr",
+            "Labels": (
+                "com.docker.compose.project=sonarr,"
+                "com.docker.compose.project.config_files=/opt/sonarr/dc.yml"
+            ),
+        }
+    )
     conn = _make_multi_conn(
         [
-            MagicMock(stdout=ls_output, returncode=0),
+            MagicMock(stdout="v2\n", returncode=0),
+            MagicMock(stdout=ps_output, returncode=0),
             MagicMock(stdout="error output", returncode=1),  # pull fails
         ]
     )
@@ -498,10 +616,19 @@ async def test_update_stack_up_failure_raises(config_file, data_dir):
     raw["hosts"][0]["docker_mode"] = "all"
     config_file.write_text(yaml.dump(raw))
 
-    ls_output = json.dumps([{"Name": "sonarr", "ConfigFiles": "/opt/sonarr/dc.yml"}])
+    ps_output = json.dumps(
+        {
+            "Names": "/sonarr",
+            "Labels": (
+                "com.docker.compose.project=sonarr,"
+                "com.docker.compose.project.config_files=/opt/sonarr/dc.yml"
+            ),
+        }
+    )
     conn = _make_multi_conn(
         [
-            MagicMock(stdout=ls_output, returncode=0),
+            MagicMock(stdout="v2\n", returncode=0),
+            MagicMock(stdout=ps_output, returncode=0),
             MagicMock(stdout="Pulled", returncode=0),  # pull succeeds
             MagicMock(stdout="error output", returncode=1),  # up fails
         ]
@@ -748,10 +875,19 @@ async def test_update_compose_ref_triggers_compose_update(config_file, data_dir)
     raw["hosts"][0]["docker_mode"] = "all"
     config_file.write_text(yaml.dump(raw))
 
-    ls_output = json.dumps([{"Name": "mystack", "ConfigFiles": "/opt/mystack/dc.yml"}])
+    ps_output = json.dumps(
+        {
+            "Names": "/mystack-myapp",
+            "Labels": (
+                "com.docker.compose.project=mystack,"
+                "com.docker.compose.project.config_files=/opt/mystack/dc.yml"
+            ),
+        }
+    )
     conn = _make_multi_conn(
         [
-            MagicMock(stdout=ls_output, returncode=0),     # compose ls (get config file)
+            MagicMock(stdout="v2\n", returncode=0),        # compose binary probe
+            MagicMock(stdout=ps_output, returncode=0),     # docker ps -a (config file lookup)
             MagicMock(stdout="Pulled", returncode=0),      # compose pull
             MagicMock(stdout="Started", returncode=0),     # compose up -d
         ]
@@ -763,8 +899,8 @@ async def test_update_compose_ref_triggers_compose_update(config_file, data_dir)
         await backend.update_stack("test-host/mystack:myapp")
 
     calls = [call.args[0] for call in conn.run.call_args_list]
-    assert any("compose" in c and "pull" in c for c in calls)
-    assert any("compose" in c and "up" in c and "-d" in c for c in calls)
+    assert any("docker compose" in c and "pull" in c for c in calls)
+    assert any("docker compose" in c and "up" in c and "-d" in c for c in calls)
 
 
 @pytest.mark.asyncio
@@ -1291,10 +1427,19 @@ async def test_update_compose_pct_wraps_commands(config_file, data_dir):
     raw["hosts"][0]["proxmox_vmid"] = 202
     config_file.write_text(yaml.dump(raw))
 
-    ls_output = json.dumps([{"Name": "sonarr", "ConfigFiles": "/opt/sonarr/dc.yml"}])
+    ps_output = json.dumps(
+        {
+            "Names": "/sonarr",
+            "Labels": (
+                "com.docker.compose.project=sonarr,"
+                "com.docker.compose.project.config_files=/opt/sonarr/dc.yml"
+            ),
+        }
+    )
     conn = _make_multi_conn(
         [
-            MagicMock(stdout=ls_output, returncode=0),
+            MagicMock(stdout="v2\n", returncode=0),
+            MagicMock(stdout=ps_output, returncode=0),
             MagicMock(stdout="Pulled", returncode=0),
             MagicMock(stdout="Started", returncode=0),
         ]
@@ -1426,3 +1571,245 @@ async def test_get_stacks_proxmox_node_connection_badge(config_file, data_dir):
         stacks = await backend.get_stacks_with_update_status()
 
     assert stacks[0]["connection_badge"] == "Node · Proxmox API"
+
+
+# ---------------------------------------------------------------------------
+# Compose v1/v2 detection (OP#103)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_update_compose_v1_uses_legacy_binary(config_file, data_dir):
+    """When the probe reports v1, updates must invoke `docker-compose` (no space)."""
+    import yaml
+
+    raw = yaml.safe_load(config_file.read_text())
+    raw["hosts"][0]["docker_mode"] = "all"
+    config_file.write_text(yaml.dump(raw))
+
+    ps_output = json.dumps(
+        {
+            "Names": "/sonarr",
+            "Labels": (
+                "com.docker.compose.project=sonarr,"
+                "com.docker.compose.project.config_files=/opt/sonarr/dc.yml"
+            ),
+        }
+    )
+    conn = _make_multi_conn(
+        [
+            MagicMock(stdout="v1\n", returncode=0),     # probe → v1
+            MagicMock(stdout=ps_output, returncode=0),  # docker ps -a
+            MagicMock(stdout="Pulled", returncode=0),
+            MagicMock(stdout="Started", returncode=0),
+        ]
+    )
+    with patch(
+        "app.backends.ssh_docker_backend._connect", new=AsyncMock(return_value=conn)
+    ):
+        backend = SSHDockerBackend()
+        await backend.update_stack("test-host/sonarr:sonarr")
+
+    calls = [c.args[0] for c in conn.run.call_args_list]
+    assert any("docker-compose" in c and "pull" in c for c in calls)
+    assert any("docker-compose" in c and "up -d" in c for c in calls)
+    # Must NOT fall back to the v2 `docker compose` form.
+    assert not any(
+        " docker compose " in f" {c} " and "pull" in c for c in calls
+    )
+
+
+@pytest.mark.asyncio
+async def test_update_compose_v2_uses_plugin_binary(config_file, data_dir):
+    """When the probe reports v2, updates invoke `docker compose` (space, plugin form)."""
+    import yaml
+
+    raw = yaml.safe_load(config_file.read_text())
+    raw["hosts"][0]["docker_mode"] = "all"
+    config_file.write_text(yaml.dump(raw))
+
+    ps_output = json.dumps(
+        {
+            "Names": "/sonarr",
+            "Labels": (
+                "com.docker.compose.project=sonarr,"
+                "com.docker.compose.project.config_files=/opt/sonarr/dc.yml"
+            ),
+        }
+    )
+    conn = _make_multi_conn(
+        [
+            MagicMock(stdout="v2\n", returncode=0),
+            MagicMock(stdout=ps_output, returncode=0),
+            MagicMock(stdout="Pulled", returncode=0),
+            MagicMock(stdout="Started", returncode=0),
+        ]
+    )
+    with patch(
+        "app.backends.ssh_docker_backend._connect", new=AsyncMock(return_value=conn)
+    ):
+        backend = SSHDockerBackend()
+        await backend.update_stack("test-host/sonarr:sonarr")
+
+    calls = [c.args[0] for c in conn.run.call_args_list]
+    # Exclude the probe command itself — it mentions both binaries by design.
+    update_calls = [c for c in calls if "pull" in c or "up -d" in c]
+    assert update_calls and all("docker compose" in c for c in update_calls)
+    assert not any("docker-compose" in c for c in update_calls)
+
+
+@pytest.mark.asyncio
+async def test_update_compose_no_binary_raises_clear_error(config_file, data_dir):
+    """When neither binary is available, the probe reports `none` and we raise."""
+    import yaml
+
+    raw = yaml.safe_load(config_file.read_text())
+    raw["hosts"][0]["docker_mode"] = "all"
+    config_file.write_text(yaml.dump(raw))
+
+    conn = _make_multi_conn(
+        [
+            MagicMock(stdout="none\n", returncode=0),  # probe → none
+        ]
+    )
+    with patch(
+        "app.backends.ssh_docker_backend._connect", new=AsyncMock(return_value=conn)
+    ):
+        backend = SSHDockerBackend()
+        with pytest.raises(RuntimeError, match="Neither 'docker compose'"):
+            await backend.update_stack("test-host/sonarr:sonarr")
+
+
+@pytest.mark.asyncio
+async def test_update_compose_probe_empty_output_raises(config_file, data_dir):
+    """A blank/garbled probe output is treated as `none` and raises."""
+    import yaml
+
+    raw = yaml.safe_load(config_file.read_text())
+    raw["hosts"][0]["docker_mode"] = "all"
+    config_file.write_text(yaml.dump(raw))
+
+    conn = _make_multi_conn(
+        [
+            MagicMock(stdout="", returncode=0),
+        ]
+    )
+    with patch(
+        "app.backends.ssh_docker_backend._connect", new=AsyncMock(return_value=conn)
+    ):
+        backend = SSHDockerBackend()
+        with pytest.raises(RuntimeError, match="Neither 'docker compose'"):
+            await backend.update_stack("test-host/sonarr:sonarr")
+
+
+@pytest.mark.asyncio
+async def test_update_compose_v1_fallback_uses_project_flag(config_file, data_dir):
+    """When labels don't carry a config_files path, the v1 binary falls back to `-p`."""
+    import yaml
+
+    raw = yaml.safe_load(config_file.read_text())
+    raw["hosts"][0]["docker_mode"] = "all"
+    config_file.write_text(yaml.dump(raw))
+
+    ps_output = json.dumps(
+        {
+            "Names": "/sonarr",
+            # No project.config_files label — older v1 containers.
+            "Labels": "com.docker.compose.project=sonarr",
+        }
+    )
+    conn = _make_multi_conn(
+        [
+            MagicMock(stdout="v1\n", returncode=0),
+            MagicMock(stdout=ps_output, returncode=0),
+            MagicMock(stdout="Pulled", returncode=0),
+            MagicMock(stdout="Started", returncode=0),
+        ]
+    )
+    with patch(
+        "app.backends.ssh_docker_backend._connect", new=AsyncMock(return_value=conn)
+    ):
+        backend = SSHDockerBackend()
+        await backend.update_stack("test-host/sonarr:sonarr")
+
+    calls = [c.args[0] for c in conn.run.call_args_list]
+    pull_call = next(c for c in calls if "pull" in c)
+    assert "docker-compose" in pull_call
+    assert "-p sonarr" in pull_call
+    assert "-f " not in pull_call
+
+
+# ---------------------------------------------------------------------------
+# _compose_projects_from_ps helper
+# ---------------------------------------------------------------------------
+
+
+def test_compose_projects_from_ps_groups_by_project():
+    containers = [
+        {
+            "Names": "/sonarr",
+            "Labels": (
+                "com.docker.compose.project=media,"
+                "com.docker.compose.project.config_files=/opt/media/dc.yml"
+            ),
+        },
+        {
+            "Names": "/radarr",
+            "Labels": (
+                "com.docker.compose.project=media,"
+                "com.docker.compose.project.config_files=/opt/media/dc.yml"
+            ),
+        },
+        {
+            "Names": "/db",
+            "Labels": (
+                "com.docker.compose.project=infra,"
+                "com.docker.compose.project.config_files=/opt/infra/dc.yml"
+            ),
+        },
+    ]
+    result = _compose_projects_from_ps(containers)
+    by_name = {r["name"]: r["config_file"] for r in result}
+    assert by_name == {
+        "media": "/opt/media/dc.yml",
+        "infra": "/opt/infra/dc.yml",
+    }
+
+
+def test_compose_projects_from_ps_prefers_non_empty_config_file():
+    """If one container has an empty config_files label and another has it set, keep the set one."""
+    containers = [
+        {
+            "Names": "/a",
+            "Labels": "com.docker.compose.project=proj",
+        },
+        {
+            "Names": "/b",
+            "Labels": (
+                "com.docker.compose.project=proj,"
+                "com.docker.compose.project.config_files=/srv/proj/dc.yml"
+            ),
+        },
+    ]
+    result = _compose_projects_from_ps(containers)
+    assert result == [{"name": "proj", "config_file": "/srv/proj/dc.yml"}]
+
+
+def test_compose_projects_from_ps_skips_unlabeled():
+    containers = [{"Names": "/nolabel", "Labels": ""}]
+    assert _compose_projects_from_ps(containers) == []
+
+
+def test_compose_projects_from_ps_multifile_takes_first():
+    """The config_files label can be comma-separated — take the first path."""
+    containers = [
+        {
+            "Names": "/a",
+            "Labels": (
+                "com.docker.compose.project=proj,"
+                "com.docker.compose.project.config_files=/one.yml,/override.yml"
+            ),
+        }
+    ]
+    result = _compose_projects_from_ps(containers)
+    assert result == [{"name": "proj", "config_file": "/one.yml"}]


### PR DESCRIPTION
OP#103

## Summary
- Fixes compose stack updates on hosts that only ship legacy `docker-compose` v1 (no v2 plugin) — previously every update surfaced a `RuntimeError: docker compose pull failed` because `docker compose` isn't a command on those hosts.
- Probes compose flavour once per connection and picks the right binary (`docker compose` vs `docker-compose`); raises a clear error if neither is present.
- Replaces `docker compose ls --all` with label-based discovery (`docker ps -a` → `com.docker.compose.project{,.config_files}`) so admin discovery and config-file lookup are version-agnostic.
- Routes admin `discover_stacks` through `_ssh_params_for` so Proxmox LXC hosts are reached via `pct exec` (previously only the dashboard path did this — admin discovery was silently failing on pct hosts even on v2).

## Test plan
- [x] `pytest tests/test_backends.py` — 93 passed, incl. new v1/v2/none detection, label-based discovery, pct-wrapped discovery, and `_compose_projects_from_ps` helper branches
- [x] Full suite: 825 passed
- [x] Coverage on `app/backends/ssh_docker_backend.py` — 96% (above the 95% bar)
- [ ] Manual QA on `pve`: update a compose stack on an LXC with v1 only (e.g. LXC 100/102/103) and one with v2 (LXC 101)
- [ ] Manual QA: admin-panel docker discovery on a v1 pct host returns the compose projects

🤖 Generated with [Claude Code](https://claude.com/claude-code)