### PR TITLE
[#105] Exclude self-container/stack from discovery and updates

### DIFF
--- a/app/backends/ssh_docker_backend.py
+++ b/app/backends/ssh_docker_backend.py
@@ -20,6 +20,7 @@ from ..ssh_client import _connect
 from ..registry_client import check_image_update, extract_local_digest
 from ..credentials import get_credentials, get_integration_credentials
 from ..config_manager import get_hosts, get_ssh_config, get_proxmox_config
+from ..self_identity import get_self_container_id
 
 log = logging.getLogger(__name__)
 
@@ -198,6 +199,24 @@ class SSHDockerBackend:
             )
             containers = _parse_json_output(ps_result.stdout)
 
+            # Identify own container and its compose project (if any) so we can
+            # exclude both the container itself and all siblings in the same project.
+            self_id = get_self_container_id()
+            self_projects: set[str] = set()
+            if self_id:
+                for c in containers:
+                    if (c.get("ID", "") or "")[:12] == self_id:
+                        labels = _parse_docker_ps_labels(c.get("Labels", "") or "")
+                        project = labels.get("com.docker.compose.project", "")
+                        name = (c.get("Names", "") or "").split(",")[0].lstrip("/").strip()
+                        log.info(
+                            "Docker SSH: %s — excluding self-container %s"
+                            " (project=%r) from discovery",
+                            h, name, project or "(standalone)",
+                        )
+                        if project:
+                            self_projects.add(project)
+
             # First pass: collect qualifying containers and unique images
             raw: list[tuple[str, str, str]] = []  # (container_name, image, project)
             for c in containers:
@@ -208,6 +227,12 @@ class SSHDockerBackend:
                 image = c.get("Image", "")
 
                 if not container_name or not image:
+                    continue
+
+                # Skip self-container (by ID) and its entire compose project
+                if self_id and (c.get("ID", "") or "")[:12] == self_id:
+                    continue
+                if project and project in self_projects:
                     continue
 
                 # In "selected" mode only include containers from chosen projects
@@ -356,6 +381,18 @@ class SSHDockerBackend:
         ssh_cfg = get_ssh_config()
         host_entry, ssh_creds, wrap = self._ssh_params_for(host)
         async with await _connect(host_entry, ssh_cfg, ssh_creds) as conn:
+            # Safety net: refuse to update a project that contains the self-container.
+            self_id = get_self_container_id()
+            if self_id:
+                ps = await conn.run(wrap("docker ps -a --format '{{json .}}'"), check=False)
+                for c in _parse_json_output(ps.stdout):
+                    if (c.get("ID", "") or "")[:12] == self_id:
+                        labels = _parse_docker_ps_labels(c.get("Labels", "") or "")
+                        if labels.get("com.docker.compose.project", "") == project_name:
+                            raise ValueError(
+                                f"Self-update refused: Keepup is part of"
+                                f" compose project {project_name!r} on {h}"
+                            )
             binary = await self._detect_compose_binary(conn, wrap, h)
             config_file = await self._get_config_file(conn, project_name, wrap)
             args = f"-f {config_file}" if config_file else f"-p {shlex.quote(project_name)}"
@@ -382,6 +419,14 @@ class SSHDockerBackend:
             if inspect_result.returncode != 0 or not inspect_result.stdout.strip():
                 raise RuntimeError(f"Container {container_name!r} not found")
             inspect_data = json.loads(inspect_result.stdout)[0]
+
+            # Safety net: refuse to recreate the self-container.
+            self_id = get_self_container_id()
+            if self_id and (inspect_data.get("Id", "") or "")[:12] == self_id:
+                raise ValueError(
+                    f"Self-update refused: Keepup is standalone container"
+                    f" {container_name!r} on {h}"
+                )
 
             image = inspect_data["Config"]["Image"]
             log.info("Docker SSH: pulling %s for container %s", image, container_name)

--- a/app/portainer_client.py
+++ b/app/portainer_client.py
@@ -14,6 +14,7 @@ import logging
 import httpx
 
 from .registry_client import extract_local_digest, check_image_update
+from .self_identity import get_self_container_id
 
 log = logging.getLogger(__name__)
 
@@ -69,6 +70,27 @@ class PortainerClient:
 
     async def update_stack(self, stack_id: int, endpoint_id: int) -> dict:
         """Pull latest images and redeploy the stack."""
+        # Safety net: refuse to redeploy a stack that contains the self-container.
+        self_id = get_self_container_id()
+        if self_id:
+            try:
+                containers = await self._get_containers(endpoint_id)
+                stack_meta = await self.get(f"/api/stacks/{stack_id}")
+                stack_name_lower = stack_meta.get("Name", "").lower()
+                stack_containers = [
+                    c for c in containers
+                    if c.get("Labels", {}).get("com.docker.compose.project", "").lower()
+                    == stack_name_lower
+                ]
+                if any((c.get("Id", "") or "")[:12] == self_id for c in stack_containers):
+                    raise ValueError(
+                        f"Self-update refused: Keepup is in Portainer stack {stack_id}"
+                    )
+            except ValueError:
+                raise
+            except Exception as exc:
+                log.warning("Portainer: self-update check failed for stack %s — %s", stack_id, exc)
+
         # Fetch current stack definition
         stack = await self.get(f"/api/stacks/{stack_id}")
         stack_name = stack.get("Name", str(stack_id))
@@ -132,6 +154,8 @@ class PortainerClient:
             except Exception:
                 endpoint_containers[ep["Id"]] = []
 
+        self_id = get_self_container_id()
+
         results = []
         for stack in stacks:
             stack_id = stack["Id"]
@@ -149,6 +173,17 @@ class PortainerClient:
                 if c.get("Labels", {}).get("com.docker.compose.project", "").lower()
                 == stack_name_lower
             ]
+
+            # Skip the stack that contains the running Keepup container.
+            if self_id and any(
+                (c.get("Id", "") or "")[:12] == self_id for c in stack_containers
+            ):
+                endpoint_name = endpoint_map.get(endpoint_id, f"env-{endpoint_id}")
+                log.info(
+                    "Portainer: excluding self-stack %s on %s from discovery",
+                    stack_name, endpoint_name,
+                )
+                continue
 
             # Check each unique image in this stack
             seen_images: set[str] = set()

--- a/app/self_identity.py
+++ b/app/self_identity.py
@@ -1,0 +1,16 @@
+import os
+import re
+
+_CONTAINER_ID_RE = re.compile(r"^[0-9a-f]{12}$")
+
+
+def get_self_container_id() -> str | None:
+    """Return the short container ID when Keepup runs inside Docker, else None.
+
+    Docker sets HOSTNAME to the 12-char hex short ID by default. Returns None
+    on bare-metal or in test environments where HOSTNAME looks like a real hostname.
+    """
+    hostname = os.environ.get("HOSTNAME", "")
+    if _CONTAINER_ID_RE.match(hostname):
+        return hostname
+    return None

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -1914,3 +1914,184 @@ async def test_update_compose_v1_relative_path_resolved(config_file, data_dir):
     calls = [c.args[0] for c in conn.run.call_args_list]
     pull_call = next(c for c in calls if "pull" in c)
     assert "docker-compose -f /root/NGINX/docker-compose.yaml pull" in pull_call
+
+
+# ---------------------------------------------------------------------------
+# SSHDockerBackend — self-container exclusion (OP#105)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_self_container_excluded_from_discovery(config_file, data_dir, monkeypatch):
+    """Self-container (matched by HOSTNAME) is excluded from get_stacks_with_update_status."""
+    import yaml
+
+    monkeypatch.setenv("HOSTNAME", "aabbccddeeff")
+
+    raw = yaml.safe_load(config_file.read_text())
+    raw["hosts"][0]["docker_mode"] = "all"
+    config_file.write_text(yaml.dump(raw))
+
+    docker_ps_output = "\n".join([
+        # Self-container — must be excluded
+        json.dumps({"ID": "aabbccddeeff", "Names": "/keepup", "Image": "keepup:latest", "Labels": ""}),
+        # Other container — must appear
+        json.dumps({"ID": "112233445566", "Names": "/sonarr", "Image": "sonarr:latest", "Labels": ""}),
+    ])
+    inspect_output = '["sonarr@sha256:abc"]'
+
+    conn = _make_multi_conn([
+        MagicMock(stdout=docker_ps_output, returncode=0),
+        MagicMock(stdout=inspect_output, returncode=0),
+    ])
+
+    with (
+        patch("app.backends.ssh_docker_backend._connect", new=AsyncMock(return_value=conn)),
+        patch("app.backends.ssh_docker_backend.check_image_update",
+              new=AsyncMock(return_value="up_to_date")),
+    ):
+        backend = SSHDockerBackend()
+        stacks = await backend.get_stacks_with_update_status()
+
+    names = {s["name"] for s in stacks}
+    assert "keepup" not in names
+    assert "sonarr" in names
+
+
+@pytest.mark.asyncio
+async def test_self_compose_project_excluded_from_discovery(config_file, data_dir, monkeypatch):
+    """All containers in the self-container's compose project are excluded."""
+    import yaml
+
+    monkeypatch.setenv("HOSTNAME", "aabbccddeeff")
+
+    raw = yaml.safe_load(config_file.read_text())
+    raw["hosts"][0]["docker_mode"] = "all"
+    config_file.write_text(yaml.dump(raw))
+
+    docker_ps_output = "\n".join([
+        # Self-container in a compose project
+        json.dumps({"ID": "aabbccddeeff", "Names": "/keepup_app_1", "Image": "keepup:latest",
+                    "Labels": "com.docker.compose.project=keepup"}),
+        # Sibling container in same project — also excluded
+        json.dumps({"ID": "ffeeddccbbaa", "Names": "/keepup_db_1", "Image": "postgres:latest",
+                    "Labels": "com.docker.compose.project=keepup"}),
+        # Unrelated container — must appear
+        json.dumps({"ID": "112233445566", "Names": "/sonarr", "Image": "sonarr:latest",
+                    "Labels": "com.docker.compose.project=sonarr"}),
+    ])
+    inspect_output = '["sonarr@sha256:abc"]'
+
+    conn = _make_multi_conn([
+        MagicMock(stdout=docker_ps_output, returncode=0),
+        MagicMock(stdout=inspect_output, returncode=0),
+    ])
+
+    with (
+        patch("app.backends.ssh_docker_backend._connect", new=AsyncMock(return_value=conn)),
+        patch("app.backends.ssh_docker_backend.check_image_update",
+              new=AsyncMock(return_value="up_to_date")),
+    ):
+        backend = SSHDockerBackend()
+        stacks = await backend.get_stacks_with_update_status()
+
+    names = {s["name"] for s in stacks}
+    assert "keepup_app_1" not in names
+    assert "keepup_db_1" not in names
+    assert "sonarr" in names
+
+
+@pytest.mark.asyncio
+async def test_no_self_exclusion_when_not_in_docker(config_file, data_dir, monkeypatch):
+    """Non-container HOSTNAME must not exclude any containers."""
+    import yaml
+
+    monkeypatch.setenv("HOSTNAME", "myserver")
+
+    raw = yaml.safe_load(config_file.read_text())
+    raw["hosts"][0]["docker_mode"] = "all"
+    config_file.write_text(yaml.dump(raw))
+
+    docker_ps_output = json.dumps(
+        {"ID": "aabbccddeeff", "Names": "/keepup", "Image": "keepup:latest", "Labels": ""}
+    )
+    inspect_output = '["keepup@sha256:abc"]'
+
+    conn = _make_multi_conn([
+        MagicMock(stdout=docker_ps_output, returncode=0),
+        MagicMock(stdout=inspect_output, returncode=0),
+    ])
+
+    with (
+        patch("app.backends.ssh_docker_backend._connect", new=AsyncMock(return_value=conn)),
+        patch("app.backends.ssh_docker_backend.check_image_update",
+              new=AsyncMock(return_value="up_to_date")),
+    ):
+        backend = SSHDockerBackend()
+        stacks = await backend.get_stacks_with_update_status()
+
+    assert len(stacks) == 1
+    assert stacks[0]["name"] == "keepup"
+
+
+@pytest.mark.asyncio
+async def test_compose_update_refused_for_self_project(config_file, data_dir, monkeypatch):
+    """_update_compose_project raises ValueError when self-container is in the project."""
+    import yaml
+
+    monkeypatch.setenv("HOSTNAME", "aabbccddeeff")
+
+    raw = yaml.safe_load(config_file.read_text())
+    raw["hosts"][0]["docker_mode"] = "all"
+    config_file.write_text(yaml.dump(raw))
+
+    ps_output = json.dumps({
+        "ID": "aabbccddeeff",
+        "Names": "/keepup_app_1",
+        "Labels": "com.docker.compose.project=keepup",
+    })
+
+    conn = _make_multi_conn([
+        MagicMock(stdout=ps_output, returncode=0),  # safety-net docker ps
+    ])
+
+    with patch("app.backends.ssh_docker_backend._connect", new=AsyncMock(return_value=conn)):
+        backend = SSHDockerBackend()
+        with pytest.raises(ValueError, match="Self-update refused"):
+            await backend.update_stack("test-host/keepup:keepup_app_1")
+
+
+@pytest.mark.asyncio
+async def test_standalone_update_refused_for_self_container(config_file, data_dir, monkeypatch):
+    """_update_standalone_container raises ValueError when the target is the self-container."""
+    import yaml
+
+    monkeypatch.setenv("HOSTNAME", "aabbccddeeff")
+
+    raw = yaml.safe_load(config_file.read_text())
+    raw["hosts"][0]["docker_mode"] = "all"
+    config_file.write_text(yaml.dump(raw))
+
+    inspect_data = json.dumps([{
+        "Name": "/keepup", "Id": "aabbccddeeff112233",
+        "Config": {"Image": "keepup:latest", "Env": [], "Cmd": None,
+                   "Entrypoint": None, "Labels": {}, "Hostname": "keepup"},
+        "HostConfig": {
+            "RestartPolicy": {"Name": "unless-stopped", "MaximumRetryCount": 0},
+            "NetworkMode": "bridge", "Privileged": False,
+            "Binds": None, "PortBindings": {}, "Devices": None,
+            "CapAdd": None, "CapDrop": None, "Dns": None,
+            "ExtraHosts": None, "Tmpfs": None, "PidMode": "",
+            "IpcMode": "private", "LogConfig": {"Type": "json-file", "Config": {}},
+        },
+        "NetworkSettings": {"Networks": {}},
+    }])
+
+    conn = _make_multi_conn([
+        MagicMock(stdout=inspect_data, returncode=0),  # docker inspect
+    ])
+
+    with patch("app.backends.ssh_docker_backend._connect", new=AsyncMock(return_value=conn)):
+        backend = SSHDockerBackend()
+        with pytest.raises(ValueError, match="Self-update refused"):
+            await backend.update_stack("test-host/~keepup")

--- a/tests/test_portainer_client.py
+++ b/tests/test_portainer_client.py
@@ -334,3 +334,117 @@ async def test_stacks_sorted_by_endpoint_then_name(client):
 
     assert results[0]["name"] == "app"
     assert results[1]["name"] == "zoo"
+
+
+# ---------------------------------------------------------------------------
+# Portainer — self-container exclusion (OP#105)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_self_stack_excluded_from_discovery(client, monkeypatch):
+    """Stack containing the self-container is excluded from get_stacks_with_update_status."""
+    monkeypatch.setenv("HOSTNAME", "aabbccddeeff")
+
+    self_container = {
+        "Id": "aabbccddeeff112233445566",
+        "Image": "keepup:latest",
+        "ImageID": "sha256:keepup",
+        "Labels": {"com.docker.compose.project": "keepup"},
+    }
+    other_container = {
+        "Id": "112233445566aabbccddeeff",
+        "Image": "linuxserver/sonarr:latest",
+        "ImageID": "sha256:sonarr",
+        "Labels": {"com.docker.compose.project": "sonarr"},
+    }
+    stacks = [
+        {"Id": 20, "Name": "keepup", "EndpointId": 1, "Env": []},
+        {"Id": 21, "Name": "sonarr", "EndpointId": 1, "Env": []},
+    ]
+
+    with (
+        patch.object(client, "get_endpoints", new=AsyncMock(return_value=ENDPOINTS[:1])),
+        patch.object(client, "get_stacks", new=AsyncMock(return_value=stacks)),
+        patch.object(
+            client, "_get_containers",
+            new=AsyncMock(return_value=[self_container, other_container])
+        ),
+        patch.object(client, "_get_image_info", new=AsyncMock(return_value=IMAGE_INFO)),
+        patch("app.portainer_client.check_image_update", new=AsyncMock(return_value="up_to_date")),
+        patch("app.portainer_client.extract_local_digest", return_value="sha256:x"),
+    ):
+        results = await client.get_stacks_with_update_status()
+
+    names = {r["name"] for r in results}
+    assert "keepup" not in names
+    assert "sonarr" in names
+
+
+@pytest.mark.asyncio
+async def test_self_stack_not_excluded_when_not_in_docker(client, monkeypatch):
+    """Non-container HOSTNAME must not exclude any stack."""
+    monkeypatch.setenv("HOSTNAME", "myserver")
+
+    self_container = {
+        "Id": "aabbccddeeff112233445566",
+        "Image": "keepup:latest",
+        "ImageID": "sha256:keepup",
+        "Labels": {"com.docker.compose.project": "keepup"},
+    }
+    stacks = [{"Id": 20, "Name": "keepup", "EndpointId": 1, "Env": []}]
+
+    with (
+        patch.object(client, "get_endpoints", new=AsyncMock(return_value=ENDPOINTS[:1])),
+        patch.object(client, "get_stacks", new=AsyncMock(return_value=stacks)),
+        patch.object(client, "_get_containers", new=AsyncMock(return_value=[self_container])),
+        patch.object(client, "_get_image_info", new=AsyncMock(return_value=IMAGE_INFO)),
+        patch("app.portainer_client.check_image_update", new=AsyncMock(return_value="up_to_date")),
+        patch("app.portainer_client.extract_local_digest", return_value="sha256:x"),
+    ):
+        results = await client.get_stacks_with_update_status()
+
+    assert len(results) == 1
+    assert results[0]["name"] == "keepup"
+
+
+@pytest.mark.asyncio
+async def test_portainer_update_refused_for_self_stack(client, monkeypatch):
+    """update_stack raises ValueError when the stack contains the self-container."""
+    monkeypatch.setenv("HOSTNAME", "aabbccddeeff")
+
+    self_container = {
+        "Id": "aabbccddeeff112233445566",
+        "Image": "keepup:latest",
+        "Labels": {"com.docker.compose.project": "keepup"},
+    }
+    stack_meta = {"Id": 20, "Name": "keepup", "Env": []}
+
+    with (
+        patch.object(client, "_get_containers", new=AsyncMock(return_value=[self_container])),
+        patch.object(client, "get", new=AsyncMock(return_value=stack_meta)),
+    ):
+        with pytest.raises(ValueError, match="Self-update refused"):
+            await client.update_stack(20, 1)
+
+
+@pytest.mark.asyncio
+async def test_portainer_update_proceeds_when_check_fails(client, monkeypatch):
+    """If the safety-net container fetch fails, the update still proceeds (non-fatal check)."""
+    monkeypatch.setenv("HOSTNAME", "aabbccddeeff")
+
+    stack_meta = {"Id": 20, "Name": "keepup", "Env": []}
+    put_mock = AsyncMock(return_value={"Id": 20})
+
+    with (
+        patch.object(
+            client, "_get_containers", new=AsyncMock(side_effect=Exception("network error"))
+        ),
+        patch.object(client, "get", new=AsyncMock(return_value=stack_meta)),
+        patch.object(client, "get_stack_file", new=AsyncMock(return_value="version: '3'")),
+        patch.object(client, "put", new=put_mock),
+    ):
+        result = await client.update_stack(20, 1)
+
+    assert result == {"Id": 20}
+    put_mock.assert_called_once()

--- a/tests/test_self_identity.py
+++ b/tests/test_self_identity.py
@@ -1,0 +1,41 @@
+"""Tests for app.self_identity."""
+
+import pytest
+
+from app.self_identity import get_self_container_id
+
+
+def test_returns_none_when_hostname_absent(monkeypatch):
+    monkeypatch.delenv("HOSTNAME", raising=False)
+    assert get_self_container_id() is None
+
+
+def test_returns_none_for_regular_hostname(monkeypatch):
+    monkeypatch.setenv("HOSTNAME", "myserver")
+    assert get_self_container_id() is None
+
+
+def test_returns_none_for_partial_hex(monkeypatch):
+    monkeypatch.setenv("HOSTNAME", "abc123")
+    assert get_self_container_id() is None
+
+
+def test_returns_none_for_uppercase_hex(monkeypatch):
+    # Docker short IDs are always lowercase; uppercase is not a container ID.
+    monkeypatch.setenv("HOSTNAME", "ABC123DEF456")
+    assert get_self_container_id() is None
+
+
+def test_returns_short_id_for_docker_hostname(monkeypatch):
+    monkeypatch.setenv("HOSTNAME", "a1b2c3d4e5f6")
+    assert get_self_container_id() == "a1b2c3d4e5f6"
+
+
+def test_returns_none_for_13_char_hex(monkeypatch):
+    monkeypatch.setenv("HOSTNAME", "a1b2c3d4e5f60")
+    assert get_self_container_id() is None
+
+
+def test_returns_none_for_11_char_hex(monkeypatch):
+    monkeypatch.setenv("HOSTNAME", "a1b2c3d4e5f")
+    assert get_self_container_id() is None


### PR DESCRIPTION
OP#105

## Summary
- Added `app/self_identity.py`: detects when Keepup runs inside Docker by checking if `HOSTNAME` is a 12-char hex short container ID
- SSH backend: filters self-container (and its entire compose project siblings) from `get_stacks_with_update_status`; raises `ValueError` on `update_stack` if self-container is targeted
- Portainer client: excludes self-stack from `get_stacks_with_update_status`; raises `ValueError` on `update_stack` if self-stack targeted (falls through to update if the safety-net check itself fails)
- 16 new tests covering both backends and the identity module

## Test plan
- [ ] `test_self_identity.py` — HOSTNAME patterns (Docker vs bare-metal)
- [ ] `test_backends.py` — self-container excluded from SSH discovery, sibling exclusion, non-Docker HOSTNAME does not exclude, compose/standalone update safety nets
- [ ] `test_portainer_client.py` — self-stack excluded from Portainer discovery, update refused for self-stack, update proceeds when safety-net fetch fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)