### PR TITLE
[#109] Manage container monitoring for existing hosts

### DIFF
--- a/app/admin.py
+++ b/app/admin.py
@@ -630,6 +630,20 @@ async def admin_test_host(request: Request, slug: str) -> HTMLResponse:
 # ---------------------------------------------------------------------------
 
 
+def _group_containers(
+    containers: list[dict],
+) -> tuple[dict[str, list[dict]], list[dict]]:
+    """Split containers into (compose_groups_dict, standalone_list), groups sorted."""
+    compose_groups: dict[str, list[dict]] = {}
+    standalone: list[dict] = []
+    for c in containers:
+        if c.get("compose_project"):
+            compose_groups.setdefault(c["compose_project"], []).append(c)
+        else:
+            standalone.append(c)
+    return dict(sorted(compose_groups.items())), standalone
+
+
 @router.delete("/hosts/{slug}/docker-prompt", response_class=HTMLResponse)
 async def admin_dismiss_docker_prompt(request: Request, slug: str) -> HTMLResponse:
     """Dismiss the Docker discovery prompt without saving anything."""
@@ -638,7 +652,7 @@ async def admin_dismiss_docker_prompt(request: Request, slug: str) -> HTMLRespon
 
 @router.get("/hosts/{slug}/docker-discover", response_class=HTMLResponse)
 async def admin_docker_discover(request: Request, slug: str) -> HTMLResponse:
-    """SSH into the host and return found Compose stacks, or empty if none."""
+    """SSH into the host and return found containers, or empty if none."""
     hosts = get_hosts()
     host = next((h for h in hosts if h["slug"] == slug), None)
     if not host:
@@ -646,12 +660,53 @@ async def admin_docker_discover(request: Request, slug: str) -> HTMLResponse:
     from .backends.ssh_docker_backend import SSHDockerBackend
 
     backend = SSHDockerBackend()
-    stacks = await backend.discover_stacks(host)
-    if not stacks:
+    try:
+        containers = await backend.discover_containers(host)
+    except Exception:
         return HTMLResponse("")
+    if not containers:
+        return HTMLResponse("")
+    compose_groups, standalone = _group_containers(containers)
     return templates.TemplateResponse(
         "partials/admin_docker_prompt.html",
-        {"request": request, "slug": slug, "host": host, "stacks": stacks},
+        {
+            "request": request,
+            "slug": slug,
+            "host": host,
+            "compose_groups": compose_groups,
+            "standalone": standalone,
+            "container_count": len(containers),
+        },
+    )
+
+
+@router.get("/hosts/{slug}/docker-manage", response_class=HTMLResponse)
+async def admin_docker_manage(request: Request, slug: str) -> HTMLResponse:
+    """Return the inline container monitoring management panel."""
+    hosts = get_hosts()
+    host = next((h for h in hosts if h["slug"] == slug), None)
+    if not host:
+        return HTMLResponse("")
+    from .backends.ssh_docker_backend import SSHDockerBackend
+
+    backend = SSHDockerBackend()
+    containers: list[dict] = []
+    error: str | None = None
+    try:
+        containers = await backend.discover_containers(host)
+    except Exception as exc:
+        error = str(exc)
+    compose_groups, standalone = _group_containers(containers)
+    return templates.TemplateResponse(
+        "partials/admin_docker_manage.html",
+        {
+            "request": request,
+            "slug": slug,
+            "host": host,
+            "compose_groups": compose_groups,
+            "standalone": standalone,
+            "error": error,
+        },
     )
 
 
@@ -660,13 +715,13 @@ async def admin_save_docker_monitoring(
     request: Request,
     slug: str,
     docker_mode: str = Form("none"),
-    docker_stacks: list[str] = Form(default=[]),
+    docker_containers: list[str] = Form(default=[]),
 ) -> HTMLResponse:
     try:
         set_docker_monitoring(
             slug=slug,
             mode=docker_mode,
-            stacks=docker_stacks if docker_mode == "selected" else None,
+            containers=docker_containers if docker_mode == "selected" else None,
         )
     except Exception as exc:
         return templates.TemplateResponse(
@@ -675,7 +730,7 @@ async def admin_save_docker_monitoring(
         )
     return templates.TemplateResponse(
         "partials/admin_hosts.html",
-        {"request": request, "hosts": _hosts_with_status()},
+        {"request": request, "hosts": _hosts_with_status(), "save_success": True},
     )
 
 

--- a/app/auth_router.py
+++ b/app/auth_router.py
@@ -61,7 +61,7 @@ from .credentials import (
     save_integration_credentials,
 )
 from .proxmox_client import ProxmoxClient
-from .ssh_client import detect_docker_stacks, discover_containers, verify_connection
+from .ssh_client import discover_containers, verify_connection
 from .backend_loader import reload_backends
 from .templates_env import make_templates
 
@@ -1261,11 +1261,12 @@ async def setup_add_host(
         )
 
     # Connection succeeded — check for Docker before committing
-    stack_count = await detect_docker_stacks(host_entry, get_ssh_config(), creds)
+    found_containers = await discover_containers(host_entry, get_ssh_config(), creds)
+    container_count = len(found_containers)
 
-    if stack_count > 0:
+    if container_count > 0:
         # Store pending host in session (avoids putting credentials in HTML hidden fields)
-        label = f"{stack_count} stack{'s' if stack_count != 1 else ''}"
+        label = f"{container_count} container{'s' if container_count != 1 else ''}"
         request.session["pending_ssh_host"] = {
             "name": name,
             "host": host_addr,
@@ -1280,7 +1281,7 @@ async def setup_add_host(
             "partials/setup_ssh_section.html",
             _ssh_section_ctx(
                 request,
-                docker_prompt={"name": name, "stack_label": label},
+                docker_prompt={"name": name, "container_label": label},
             ),
         )
 

--- a/app/backends/ssh_docker_backend.py
+++ b/app/backends/ssh_docker_backend.py
@@ -12,6 +12,7 @@ Update strategy (per container):
 import asyncio
 import json
 import logging
+import re
 import shlex
 from typing import Callable
 from urllib.parse import quote, unquote, urlparse
@@ -19,7 +20,7 @@ from urllib.parse import quote, unquote, urlparse
 from ..ssh_client import _connect
 from ..registry_client import check_image_update, extract_local_digest
 from ..credentials import get_credentials, get_integration_credentials
-from ..config_manager import get_hosts, get_ssh_config, get_proxmox_config
+from ..config_manager import get_hosts, get_ssh_config, get_proxmox_config, set_docker_monitoring
 from ..self_identity import get_self_container_id
 
 log = logging.getLogger(__name__)
@@ -127,6 +128,26 @@ class SSHDockerBackend:
         except Exception:
             return []
 
+    async def discover_containers(self, host: dict) -> list[dict]:
+        """Return all containers on the host for admin container selection.
+
+        Returns list of dicts: name, image, status, running (bool),
+        compose_project (str | None), css_id (CSS-safe id string).
+        Raises on connection failure — caller decides how to handle.
+        Also routes through _ssh_params_for so Proxmox LXC hosts are
+        reached via pct exec.
+        """
+        ssh_cfg = get_ssh_config()
+        host_entry, ssh_creds, wrap = self._ssh_params_for(host)
+        async with await _connect(host_entry, ssh_cfg, ssh_creds) as conn:
+            result = await conn.run(
+                wrap("docker ps -a --format '{{json .}}'"), check=False
+            )
+            if result.returncode != 0:
+                return []
+            raw = _parse_json_output(result.stdout)
+            return _containers_for_display(raw)
+
     # ------------------------------------------------------------------
     # ContainerBackend protocol
     # ------------------------------------------------------------------
@@ -186,9 +207,18 @@ class SSHDockerBackend:
         slug = host["slug"]
         h = host.get("host", slug)
         docker_mode = host.get("docker_mode", "all")
-        allowed_projects: set[str] | None = None
+
+        # Resolve which containers are allowed in "selected" mode.
+        # migration_stacks: set if we need to expand old docker_stacks → docker_containers.
+        allowed_containers: set[str] | None = None
+        migration_stacks: set[str] | None = None
         if docker_mode == "selected":
-            allowed_projects = set(host.get("docker_stacks") or [])
+            if "docker_containers" in host:
+                allowed_containers = set(host.get("docker_containers") or [])
+            elif "docker_stacks" in host:
+                migration_stacks = set(host["docker_stacks"])
+            else:
+                allowed_containers = set()
 
         host_entry, ssh_creds, wrap = self._ssh_params_for(host)
         entries = []
@@ -223,8 +253,9 @@ class SSHDockerBackend:
                         if project:
                             self_projects.add(project)
 
-            # First pass: collect qualifying containers and unique images
-            raw: list[tuple[str, str, str]] = []  # (container_name, image, project)
+            # First pass: collect ALL qualifying containers (no mode filter yet,
+            # so migration can inspect the full set).
+            raw_all: list[tuple[str, str, str]] = []  # (container_name, image, project)
             for c in containers:
                 labels = _parse_docker_ps_labels(c.get("Labels", "") or "")
                 project = labels.get("com.docker.compose.project", "")
@@ -245,12 +276,26 @@ class SSHDockerBackend:
                 if project and project in portainer_projects:
                     continue
 
-                # In "selected" mode only include containers from chosen projects
-                if allowed_projects is not None:
-                    if not project or project not in allowed_projects:
-                        continue
+                raw_all.append((container_name, image, project))
 
-                raw.append((container_name, image, project))
+            # One-shot migration: docker_stacks → docker_containers.
+            # Expand selected project names to their current container names.
+            if migration_stacks is not None:
+                container_names = [
+                    name for name, _, proj in raw_all if proj in migration_stacks
+                ]
+                set_docker_monitoring(slug, "selected", containers=container_names)
+                log.info(
+                    "Docker SSH: %s — migrated docker_stacks %s → %d container(s)",
+                    h, sorted(migration_stacks), len(container_names),
+                )
+                allowed_containers = set(container_names)
+
+            # Apply container-level filter for "selected" mode.
+            if allowed_containers is not None:
+                raw = [(n, img, proj) for n, img, proj in raw_all if n in allowed_containers]
+            else:
+                raw = raw_all
 
             # Check all unique images concurrently (deduplicates registry lookups)
             unique_images = list({image for _, image, _ in raw})
@@ -561,6 +606,37 @@ def _parse_docker_ps_labels(labels_str: str) -> dict[str, str]:
         if "=" in part:
             k, v = part.split("=", 1)
             result[k.strip()] = v.strip()
+    return result
+
+
+def _css_safe_id(name: str) -> str:
+    """Convert a string to a CSS-safe id: lowercase, only [a-z0-9-]."""
+    s = name.lower()
+    s = re.sub(r"[^a-z0-9]+", "-", s)
+    return s.strip("-") or "container"
+
+
+def _containers_for_display(containers: list[dict]) -> list[dict]:
+    """Parse docker ps -a NDJSON output into display-ready container dicts."""
+    result = []
+    for c in containers:
+        labels = _parse_docker_ps_labels(c.get("Labels", "") or "")
+        project = labels.get("com.docker.compose.project", "") or None
+        name = (c.get("Names", "") or "").split(",")[0].lstrip("/").strip()
+        image = c.get("Image", "")
+        status = c.get("Status", "")
+        if not name:
+            continue
+        result.append(
+            {
+                "name": name,
+                "image": image,
+                "status": status,
+                "running": (status or "").lower().startswith("up"),
+                "compose_project": project,
+                "css_id": _css_safe_id(name),
+            }
+        )
     return result
 
 

--- a/app/config_manager.py
+++ b/app/config_manager.py
@@ -143,21 +143,23 @@ def delete_host(slug: str) -> None:
 def set_docker_monitoring(
     slug: str,
     mode: str,  # "all" | "all_and_new" | "selected" | "none"
-    stacks: list[str] | None = None,
+    containers: list[str] | None = None,
 ) -> None:
-    """Configure Docker Compose monitoring for a host."""
+    """Configure container monitoring for a host."""
     config = load_config()
     for h in config.get("hosts", []):
         if slugify(h["name"]) == slug:
             if mode == "none":
                 h.pop("docker_mode", None)
+                h.pop("docker_containers", None)
                 h.pop("docker_stacks", None)
             else:
                 h["docker_mode"] = mode
-                if mode == "selected" and stacks is not None:
-                    h["docker_stacks"] = stacks
+                if mode == "selected" and containers is not None:
+                    h["docker_containers"] = containers
                 else:
-                    h.pop("docker_stacks", None)
+                    h.pop("docker_containers", None)
+                h.pop("docker_stacks", None)
             break
     save_config(config)
 
@@ -180,7 +182,8 @@ def save_wizard_container_selection(selections: list[str]) -> None:
         slug = slugify(h["name"])
         if slug in by_slug:
             h["docker_mode"] = "selected"
-            h["docker_stacks"] = by_slug[slug]
+            h["docker_containers"] = by_slug[slug]
+            h.pop("docker_stacks", None)
         # Hosts not in selections are left unchanged (user may not have docker)
     save_config(config)
 

--- a/app/templates/partials/admin_docker_manage.html
+++ b/app/templates/partials/admin_docker_manage.html
@@ -1,0 +1,150 @@
+<!-- Inline container monitoring management panel -->
+<div id="docker-manage-{{ slug }}" class="mt-2 rounded-xl border border-slate-700 bg-slate-900/80 p-4 space-y-4">
+
+  <!-- Header -->
+  <div class="flex items-center justify-between">
+    <p class="text-sm font-medium text-slate-200">Container monitoring — {{ host.name }}</p>
+    <button
+      onclick="document.getElementById('host-docker-manage-{{ slug }}').innerHTML=''"
+      class="text-slate-500 hover:text-slate-300 text-lg leading-none transition-colors"
+      title="Close">
+      &times;
+    </button>
+  </div>
+
+  {% if error %}
+  <!-- Docker unreachable state -->
+  <div class="flex items-start gap-2 rounded-lg bg-red-900/30 border border-red-700/50 px-3 py-2.5">
+    <svg class="w-4 h-4 text-red-400 flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+        d="M12 9v4m0 4h.01M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z"/>
+    </svg>
+    <div>
+      <p class="text-xs font-medium text-red-300">Could not reach Docker on this host</p>
+      <p class="text-xs text-slate-500 mt-0.5">{{ error }}</p>
+    </div>
+  </div>
+  <!-- Still allow changing mode even if Docker is unreachable -->
+  {% endif %}
+
+  <form
+    hx-post="/admin/hosts/{{ slug }}/docker-monitoring"
+    hx-target="#admin-hosts"
+    hx-swap="innerHTML"
+    class="space-y-4">
+
+    <input type="hidden" name="docker_mode" id="docker-manage-mode-{{ slug }}"
+      value="{{ host.docker_mode or 'none' }}" />
+
+    <!-- Mode options (4 tiles) -->
+    <div class="grid sm:grid-cols-2 lg:grid-cols-4 gap-2">
+
+      <label class="flex items-start gap-2 cursor-pointer rounded-lg border border-slate-700 hover:border-blue-600 p-3 transition-colors has-[:checked]:border-blue-500 has-[:checked]:bg-blue-900/20"
+        onclick="document.getElementById('docker-manage-mode-{{ slug }}').value='selected'; document.getElementById('docker-manage-ctr-{{ slug }}').style.display='block';">
+        <input type="radio" name="_mode_visual" value="selected"
+          {% if host.docker_mode == 'selected' %}checked{% endif %}
+          class="mt-0.5 accent-blue-500 flex-shrink-0" />
+        <div>
+          <p class="text-xs font-medium text-slate-200">Select containers</p>
+          <p class="text-xs text-slate-500 mt-0.5">Choose which ones to watch</p>
+        </div>
+      </label>
+
+      <label class="flex items-start gap-2 cursor-pointer rounded-lg border border-slate-700 hover:border-blue-600 p-3 transition-colors has-[:checked]:border-blue-500 has-[:checked]:bg-blue-900/20"
+        onclick="document.getElementById('docker-manage-mode-{{ slug }}').value='all'; document.getElementById('docker-manage-ctr-{{ slug }}').style.display='none';">
+        <input type="radio" name="_mode_visual" value="all"
+          {% if host.docker_mode == 'all' %}checked{% endif %}
+          class="mt-0.5 accent-blue-500 flex-shrink-0" />
+        <div>
+          <p class="text-xs font-medium text-slate-200">Monitor all</p>
+          <p class="text-xs text-slate-500 mt-0.5">Watch all current containers</p>
+        </div>
+      </label>
+
+      <label class="flex items-start gap-2 cursor-pointer rounded-lg border border-slate-700 hover:border-blue-600 p-3 transition-colors has-[:checked]:border-blue-500 has-[:checked]:bg-blue-900/20"
+        onclick="document.getElementById('docker-manage-mode-{{ slug }}').value='all_and_new'; document.getElementById('docker-manage-ctr-{{ slug }}').style.display='none';">
+        <input type="radio" name="_mode_visual" value="all_and_new"
+          {% if host.docker_mode == 'all_and_new' %}checked{% endif %}
+          class="mt-0.5 accent-blue-500 flex-shrink-0" />
+        <div>
+          <p class="text-xs font-medium text-slate-200">Monitor all + new</p>
+          <p class="text-xs text-slate-500 mt-0.5">Includes containers added later</p>
+        </div>
+      </label>
+
+      <label class="flex items-start gap-2 cursor-pointer rounded-lg border border-slate-700 hover:border-slate-500 p-3 transition-colors has-[:checked]:border-slate-500 has-[:checked]:bg-slate-800"
+        onclick="document.getElementById('docker-manage-mode-{{ slug }}').value='none'; document.getElementById('docker-manage-ctr-{{ slug }}').style.display='none';">
+        <input type="radio" name="_mode_visual" value="none"
+          {% if not host.docker_mode %}checked{% endif %}
+          class="mt-0.5 accent-blue-500 flex-shrink-0" />
+        <div>
+          <p class="text-xs font-medium text-slate-200">Stop monitoring</p>
+          <p class="text-xs text-slate-500 mt-0.5">Disable Docker monitoring</p>
+        </div>
+      </label>
+
+    </div>
+
+    <!-- Container list — shown only when "Select containers" is active -->
+    <div id="docker-manage-ctr-{{ slug }}"
+      style="display: {{ 'block' if host.docker_mode == 'selected' else 'none' }};">
+
+      {% if error %}
+      <p class="text-xs text-slate-500 italic">Container list unavailable — Docker unreachable.</p>
+      {% elif not compose_groups and not standalone %}
+      <p class="text-xs text-slate-500 italic">No containers found on this host.</p>
+      {% else %}
+      <div class="rounded-lg border border-slate-700 bg-slate-800/50 p-3 space-y-3">
+        {% for project, ctrs in compose_groups.items() %}
+        <div>
+          <p class="text-xs text-slate-500 mb-1.5 font-mono">{{ project }}</p>
+          <div class="space-y-1">
+            {% for c in ctrs %}
+            <label class="flex items-center gap-2 cursor-pointer py-0.5">
+              <input type="checkbox" name="docker_containers" value="{{ c.name }}"
+                {% if not host.docker_mode or host.docker_mode != 'selected' or c.name in (host.docker_containers or []) %}checked{% endif %}
+                class="accent-blue-500 flex-shrink-0" />
+              <span class="w-1.5 h-1.5 rounded-full flex-shrink-0 {{ 'bg-green-400' if c.running else 'bg-slate-500' }}"></span>
+              <span class="text-sm text-slate-200 font-mono flex-1 min-w-0 truncate">{{ c.name }}</span>
+              <span class="text-xs text-slate-600 font-mono truncate max-w-[180px] hidden sm:block">{{ c.image }}</span>
+            </label>
+            {% endfor %}
+          </div>
+        </div>
+        {% endfor %}
+        {% if standalone %}
+        <div>
+          <p class="text-xs text-slate-500 mb-1.5">Standalone</p>
+          <div class="space-y-1">
+            {% for c in standalone %}
+            <label class="flex items-center gap-2 cursor-pointer py-0.5">
+              <input type="checkbox" name="docker_containers" value="{{ c.name }}"
+                {% if not host.docker_mode or host.docker_mode != 'selected' or c.name in (host.docker_containers or []) %}checked{% endif %}
+                class="accent-blue-500 flex-shrink-0" />
+              <span class="w-1.5 h-1.5 rounded-full flex-shrink-0 {{ 'bg-green-400' if c.running else 'bg-slate-500' }}"></span>
+              <span class="text-sm text-slate-200 font-mono flex-1 min-w-0 truncate">{{ c.name }}</span>
+              <span class="text-xs text-slate-600 font-mono truncate max-w-[180px] hidden sm:block">{{ c.image }}</span>
+            </label>
+            {% endfor %}
+          </div>
+        </div>
+        {% endif %}
+      </div>
+      {% endif %}
+    </div>
+
+    <!-- Action buttons -->
+    <div class="flex gap-2 justify-end">
+      <button type="button"
+        onclick="document.getElementById('host-docker-manage-{{ slug }}').innerHTML=''"
+        class="text-xs px-3 py-1.5 rounded-lg bg-slate-700 hover:bg-slate-600 text-slate-300 transition-colors">
+        Cancel
+      </button>
+      <button type="submit"
+        class="text-xs px-3 py-1.5 rounded-lg bg-blue-600 hover:bg-blue-500 text-white font-medium transition-colors">
+        Save
+      </button>
+    </div>
+
+  </form>
+</div>

--- a/app/templates/partials/admin_docker_prompt.html
+++ b/app/templates/partials/admin_docker_prompt.html
@@ -1,4 +1,4 @@
-<!-- Docker monitoring prompt — injected after credential save if stacks are found -->
+<!-- Docker monitoring prompt — injected after credential save if containers are found -->
 <div id="docker-prompt-{{ slug }}" class="mt-2 rounded-xl border border-blue-700/60 bg-slate-900/80 p-4 space-y-4">
 
   <div class="flex items-start gap-2">
@@ -8,7 +8,7 @@
     </svg>
     <div>
       <p class="text-sm font-medium text-blue-300">
-        {{ stacks | length }} Docker Compose stack{{ 's' if stacks | length != 1 }} found on {{ host.name }}
+        {{ container_count }} container{{ 's' if container_count != 1 }} found on {{ host.name }}
       </p>
       <p class="text-xs text-slate-400 mt-0.5">Would you like to monitor container image updates for this host?</p>
     </div>
@@ -32,7 +32,7 @@
 
   <!-- Step 2: Monitoring mode (hidden until Yes clicked) -->
   <div id="docker-prompt-step2-{{ slug }}" style="display:none;" class="space-y-4">
-    <p class="text-xs font-medium text-slate-300">How would you like to monitor stacks?</p>
+    <p class="text-xs font-medium text-slate-300">How would you like to monitor containers?</p>
 
     <form
       hx-post="/admin/hosts/{{ slug }}/docker-monitoring"
@@ -45,51 +45,73 @@
       <!-- Mode options -->
       <div class="grid sm:grid-cols-3 gap-2">
         <label class="flex items-start gap-2 cursor-pointer rounded-lg border border-slate-700 hover:border-blue-600 p-3 transition-colors has-[:checked]:border-blue-500 has-[:checked]:bg-blue-900/20"
-          onclick="document.getElementById('docker-mode-{{ slug }}').value='all'; document.getElementById('docker-select-{{ slug }}').style.display='none'; document.getElementById('docker-submit-{{ slug }}').style.display='block';">
+          onclick="document.getElementById('docker-mode-{{ slug }}').value='all'; document.getElementById('docker-select-{{ slug }}').style.display='none';">
           <input type="radio" name="_mode_visual" value="all" checked class="mt-0.5 accent-blue-500 flex-shrink-0" />
           <div>
             <p class="text-xs font-medium text-slate-200">Monitor all</p>
-            <p class="text-xs text-slate-500 mt-0.5">Watch all current stacks</p>
+            <p class="text-xs text-slate-500 mt-0.5">Watch all current containers</p>
           </div>
         </label>
 
         <label class="flex items-start gap-2 cursor-pointer rounded-lg border border-slate-700 hover:border-blue-600 p-3 transition-colors has-[:checked]:border-blue-500 has-[:checked]:bg-blue-900/20"
-          onclick="document.getElementById('docker-mode-{{ slug }}').value='all_and_new'; document.getElementById('docker-select-{{ slug }}').style.display='none'; document.getElementById('docker-submit-{{ slug }}').style.display='block';">
+          onclick="document.getElementById('docker-mode-{{ slug }}').value='all_and_new'; document.getElementById('docker-select-{{ slug }}').style.display='none';">
           <input type="radio" name="_mode_visual" value="all_and_new" class="mt-0.5 accent-blue-500 flex-shrink-0" />
           <div>
             <p class="text-xs font-medium text-slate-200">Monitor all + new</p>
-            <p class="text-xs text-slate-500 mt-0.5">Includes stacks added later</p>
+            <p class="text-xs text-slate-500 mt-0.5">Includes containers added later</p>
           </div>
         </label>
 
         <label class="flex items-start gap-2 cursor-pointer rounded-lg border border-slate-700 hover:border-blue-600 p-3 transition-colors has-[:checked]:border-blue-500 has-[:checked]:bg-blue-900/20"
-          onclick="document.getElementById('docker-mode-{{ slug }}').value='selected'; document.getElementById('docker-select-{{ slug }}').style.display='block'; document.getElementById('docker-submit-{{ slug }}').style.display='block';">
+          onclick="document.getElementById('docker-mode-{{ slug }}').value='selected'; document.getElementById('docker-select-{{ slug }}').style.display='block';">
           <input type="radio" name="_mode_visual" value="selected" class="mt-0.5 accent-blue-500 flex-shrink-0" />
           <div>
-            <p class="text-xs font-medium text-slate-200">Select stacks</p>
+            <p class="text-xs font-medium text-slate-200">Select containers</p>
             <p class="text-xs text-slate-500 mt-0.5">Choose which ones to watch</p>
           </div>
         </label>
       </div>
 
-      <!-- Stack selector (shown only for "Select stacks") -->
+      <!-- Container selector (shown only for "Select containers") -->
       <div id="docker-select-{{ slug }}" style="display:none;"
-        class="rounded-lg border border-slate-700 bg-slate-800/50 p-3 space-y-2">
-        <p class="text-xs font-medium text-slate-400 mb-2">Select stacks to monitor:</p>
-        {% for stack in stacks %}
-        <label class="flex items-center gap-2 cursor-pointer">
-          <input type="checkbox" name="docker_stacks" value="{{ stack.name }}" checked
-            class="accent-blue-500" />
-          <span class="text-sm text-slate-200 font-mono">{{ stack.name }}</span>
-          {% if stack.config_file %}
-          <span class="text-xs text-slate-600 font-mono truncate">{{ stack.config_file }}</span>
-          {% endif %}
-        </label>
+        class="rounded-lg border border-slate-700 bg-slate-800/50 p-3 space-y-3">
+        <p class="text-xs font-medium text-slate-400">Select containers to monitor:</p>
+        {% for project, ctrs in compose_groups.items() %}
+        <div>
+          <p class="text-xs text-slate-500 mb-1.5 font-mono">{{ project }}</p>
+          <div class="space-y-1">
+            {% for c in ctrs %}
+            <label class="flex items-center gap-2 cursor-pointer py-0.5">
+              <input type="checkbox" name="docker_containers" value="{{ c.name }}" checked
+                class="accent-blue-500 flex-shrink-0" />
+              <span class="w-1.5 h-1.5 rounded-full flex-shrink-0 {{ 'bg-green-400' if c.running else 'bg-slate-500' }}"></span>
+              <span class="text-sm text-slate-200 font-mono flex-1">{{ c.name }}</span>
+              <span class="text-xs text-slate-600 font-mono truncate max-w-[160px]">{{ c.image }}</span>
+            </label>
+            {% endfor %}
+          </div>
+        </div>
         {% endfor %}
+        {% if standalone %}
+        <div>
+          <p class="text-xs text-slate-500 mb-1.5">Standalone</p>
+          <div class="space-y-1">
+            {% for c in standalone %}
+            <label class="flex items-center gap-2 cursor-pointer py-0.5">
+              <input type="checkbox" name="docker_containers" value="{{ c.name }}" checked
+                class="accent-blue-500 flex-shrink-0" />
+              <span class="w-1.5 h-1.5 rounded-full flex-shrink-0 {{ 'bg-green-400' if c.running else 'bg-slate-500' }}"></span>
+              <span class="text-sm text-slate-200 font-mono flex-1">{{ c.name }}</span>
+              <span class="text-xs text-slate-600 font-mono truncate max-w-[160px]">{{ c.image }}</span>
+            </label>
+            {% endfor %}
+          </div>
+        </div>
+        {% endif %}
       </div>
 
-      <!-- Submit (hidden until mode chosen, shown by default since "all" is pre-selected) -->
-      <div id="docker-submit-{{ slug }}" class="flex gap-2 justify-end">
+      <!-- Submit buttons -->
+      <div class="flex gap-2 justify-end">
         <button type="button"
           hx-delete="/admin/hosts/{{ slug }}/docker-prompt"
           hx-target="#docker-prompt-{{ slug }}"

--- a/app/templates/partials/admin_hosts.html
+++ b/app/templates/partials/admin_hosts.html
@@ -1,6 +1,12 @@
 {% if error is defined and error %}
 <div class="mb-3 px-4 py-2 rounded-lg bg-red-900/40 border border-red-700 text-red-300 text-sm">{{ error }}</div>
 {% endif %}
+{% if save_success is defined and save_success %}
+<div id="admin-save-flash" class="mb-3 px-4 py-2 rounded-lg bg-green-900/40 border border-green-700 text-green-300 text-sm">
+  Container monitoring settings saved.
+</div>
+<script>setTimeout(function(){var el=document.getElementById('admin-save-flash');if(el)el.remove();},3000);</script>
+{% endif %}
 
 <!-- Hosts table -->
 <div class="bg-slate-800/50 rounded-xl border border-slate-700 overflow-x-auto mb-4">
@@ -56,17 +62,27 @@
         </td>
         <td class="px-5 py-3">
           {% if host.docker_mode %}
-          <span class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs bg-blue-900/40 text-blue-300 border border-blue-800">
+          <button
+            hx-get="/admin/hosts/{{ host.slug }}/docker-manage"
+            hx-target="#host-docker-manage-{{ host.slug }}"
+            hx-swap="innerHTML"
+            class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs bg-blue-900/40 text-blue-300 border border-blue-800 hover:bg-blue-800/60 transition-colors cursor-pointer">
             <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
                 d="M20 7l-8-4-8 4m16 0v10l-8 4M4 7v10l8 4"/>
             </svg>
-            {% if host.docker_mode == "selected" %}{{ (host.docker_stacks or []) | length }} stack{{ 's' if (host.docker_stacks or []) | length != 1 }}
+            {% if host.docker_mode == "selected" %}{{ (host.docker_containers or []) | length }} container{{ 's' if (host.docker_containers or []) | length != 1 }}
             {% elif host.docker_mode == "all_and_new" %}All + new
             {% else %}All{% endif %}
-          </span>
+          </button>
           {% else %}
-          <span class="text-xs text-slate-600">—</span>
+          <button
+            hx-get="/admin/hosts/{{ host.slug }}/docker-manage"
+            hx-target="#host-docker-manage-{{ host.slug }}"
+            hx-swap="innerHTML"
+            class="text-xs text-slate-600 hover:text-slate-400 transition-colors cursor-pointer">
+            —
+          </button>
           {% endif %}
         </td>
         <td class="px-5 py-3 text-right">
@@ -93,6 +109,13 @@
               hx-swap="outerHTML"
               class="text-xs px-2.5 py-1 rounded bg-slate-700 hover:bg-slate-600 text-slate-300 transition-colors">
               Edit
+            </button>
+            <button
+              hx-get="/admin/hosts/{{ host.slug }}/docker-manage"
+              hx-target="#host-docker-manage-{{ host.slug }}"
+              hx-swap="innerHTML"
+              class="text-xs px-2.5 py-1 rounded bg-slate-700 hover:bg-slate-600 text-slate-300 transition-colors">
+              Containers
             </button>
             <button
               hx-delete="/admin/hosts/{{ host.slug }}"
@@ -123,6 +146,8 @@
             hx-swap="innerHTML"
             {% endif %}
           ></div>
+          <!-- Container monitoring management panel (opened on demand) -->
+          <div id="host-docker-manage-{{ host.slug }}" class="px-5 pb-2"></div>
         </td>
       </tr>
       {% endfor %}

--- a/app/templates/partials/setup_ssh_section.html
+++ b/app/templates/partials/setup_ssh_section.html
@@ -148,7 +148,7 @@
         <div>
           <p class="text-sm font-medium text-blue-300">Docker detected on {{ docker_prompt.name }}</p>
           <p class="text-xs text-slate-400 mt-0.5">
-            We found {{ docker_prompt.stack_label }} running. Enable container monitoring?
+            We found {{ docker_prompt.container_label }} running. Enable container monitoring?
           </p>
         </div>
       </div>

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -332,6 +332,355 @@ async def test_discover_stacks_pct_host_uses_pct_exec(config_file, data_dir):
 
 
 # ---------------------------------------------------------------------------
+# SSHDockerBackend — discover_containers
+# ---------------------------------------------------------------------------
+
+
+def _make_ssh_conn_with_status(stdout="", returncode=0):
+    result = MagicMock(stdout=stdout, returncode=returncode)
+    conn = MagicMock()
+    conn.__aenter__ = AsyncMock(return_value=conn)
+    conn.__aexit__ = AsyncMock(return_value=False)
+    conn.run = AsyncMock(return_value=result)
+    return conn
+
+
+@pytest.mark.asyncio
+async def test_discover_containers_returns_containers(config_file, data_dir):
+    """discover_containers returns name, image, status, compose_project, running, css_id."""
+    ps_output = "\n".join([
+        json.dumps({"Names": "/sonarr", "Image": "sonarr:latest",
+                    "Status": "Up 2 hours",
+                    "Labels": "com.docker.compose.project=arr"}),
+        json.dumps({"Names": "/plex", "Image": "plex:latest",
+                    "Status": "Exited (0) 1 minute ago",
+                    "Labels": ""}),
+    ])
+    conn = _make_ssh_conn_with_status(stdout=ps_output)
+    host = {"name": "Test Host", "host": "192.168.1.10", "slug": "test-host"}
+    with patch(
+        "app.backends.ssh_docker_backend._connect", new=AsyncMock(return_value=conn)
+    ):
+        backend = SSHDockerBackend()
+        containers = await backend.discover_containers(host)
+
+    assert len(containers) == 2
+    sonarr = next(c for c in containers if c["name"] == "sonarr")
+    assert sonarr["compose_project"] == "arr"
+    assert sonarr["running"] is True
+    assert sonarr["css_id"] == "sonarr"
+    plex = next(c for c in containers if c["name"] == "plex")
+    assert plex["compose_project"] is None
+    assert plex["running"] is False
+
+
+@pytest.mark.asyncio
+async def test_discover_containers_css_safe_id_strips_special_chars(config_file, data_dir):
+    """Container names with special chars (e.g. parens) are sanitized for CSS ids."""
+    from app.backends.ssh_docker_backend import _css_safe_id
+
+    assert _css_safe_id("my-container") == "my-container"
+    assert _css_safe_id("My Container (main)") == "my-container-main"
+    assert _css_safe_id("app(1)") == "app-1"
+    assert _css_safe_id("!!!") == "container"
+    assert _css_safe_id("abc_def") == "abc-def"
+
+
+@pytest.mark.asyncio
+async def test_discover_containers_pct_host_uses_pct_exec(config_file, data_dir):
+    """discover_containers routes through pct exec for Proxmox LXC hosts."""
+    import yaml
+    from app.config_manager import save_proxmox_config
+    from app.credentials import save_integration_credentials
+
+    save_proxmox_config(url="https://pve.example:8006", verify_ssl=False)
+    save_integration_credentials("proxmox", ssh_user="root", ssh_key="id_proxmox")
+
+    raw = yaml.safe_load(config_file.read_text())
+    raw["hosts"][0]["proxmox_node"] = "pve"
+    raw["hosts"][0]["proxmox_vmid"] = 707
+    config_file.write_text(yaml.dump(raw))
+
+    ps_output = json.dumps(
+        {"Names": "/nginx", "Image": "nginx:alpine", "Status": "Up 1 hour", "Labels": ""}
+    )
+    conn = _make_ssh_conn_with_status(stdout=ps_output)
+    host = dict(raw["hosts"][0])
+    with patch(
+        "app.backends.ssh_docker_backend._connect", new=AsyncMock(return_value=conn)
+    ):
+        backend = SSHDockerBackend()
+        containers = await backend.discover_containers(host)
+
+    assert len(containers) == 1
+    assert containers[0]["name"] == "nginx"
+    cmd = conn.run.call_args_list[0].args[0]
+    assert cmd.startswith("pct exec 707 -- sh -c ")
+    assert "docker ps -a" in cmd
+
+
+@pytest.mark.asyncio
+async def test_discover_containers_nonzero_returncode_returns_empty(config_file, data_dir):
+    conn = _make_ssh_conn_with_status(stdout="error output", returncode=1)
+    host = {"name": "Test Host", "host": "192.168.1.10", "slug": "test-host"}
+    with patch(
+        "app.backends.ssh_docker_backend._connect", new=AsyncMock(return_value=conn)
+    ):
+        backend = SSHDockerBackend()
+        containers = await backend.discover_containers(host)
+    assert containers == []
+
+
+# ---------------------------------------------------------------------------
+# SSHDockerBackend — docker_stacks migration
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_selected_mode_migrates_docker_stacks_to_containers(config_file, data_dir):
+    """When docker_stacks is set but docker_containers is not, expand to containers."""
+    import yaml
+
+    raw = yaml.safe_load(config_file.read_text())
+    raw["hosts"][0]["docker_mode"] = "selected"
+    raw["hosts"][0]["docker_stacks"] = ["mystack"]
+    config_file.write_text(yaml.dump(raw))
+
+    docker_ps_output = "\n".join([
+        json.dumps({"Names": "/app1", "Image": "app1:latest",
+                    "Labels": "com.docker.compose.project=mystack"}),
+        json.dumps({"Names": "/app2", "Image": "app2:latest",
+                    "Labels": "com.docker.compose.project=mystack"}),
+        json.dumps({"Names": "/other", "Image": "other:latest",
+                    "Labels": "com.docker.compose.project=other-stack"}),
+    ])
+    inspect_app1 = '["app1@sha256:aaa"]'
+    inspect_app2 = '["app2@sha256:bbb"]'
+
+    conn = _make_multi_conn(
+        [
+            MagicMock(stdout=docker_ps_output, returncode=0),
+            MagicMock(stdout=inspect_app1, returncode=0),
+            MagicMock(stdout=inspect_app2, returncode=0),
+        ]
+    )
+
+    with (
+        patch("app.backends.ssh_docker_backend._connect", new=AsyncMock(return_value=conn)),
+        patch("app.backends.ssh_docker_backend.check_image_update",
+              new=AsyncMock(return_value="up_to_date")),
+    ):
+        backend = SSHDockerBackend()
+        stacks = await backend.get_stacks_with_update_status()
+
+    # Only containers from mystack are included, not "other"
+    names = {s["name"] for s in stacks}
+    assert names == {"app1", "app2"}
+
+    # Config persisted docker_containers, dropped docker_stacks
+    updated = yaml.safe_load(config_file.read_text())
+    host = updated["hosts"][0]
+    assert host["docker_mode"] == "selected"
+    assert set(host["docker_containers"]) == {"app1", "app2"}
+    assert "docker_stacks" not in host
+
+
+@pytest.mark.asyncio
+async def test_selected_mode_empty_docker_containers_monitors_nothing(config_file, data_dir):
+    """selected mode with docker_containers=[] includes nothing."""
+    import yaml
+
+    raw = yaml.safe_load(config_file.read_text())
+    raw["hosts"][0]["docker_mode"] = "selected"
+    raw["hosts"][0]["docker_containers"] = []
+    config_file.write_text(yaml.dump(raw))
+
+    docker_ps_output = json.dumps(
+        {"Names": "/app1", "Image": "app1:latest", "Labels": ""}
+    )
+    conn = _make_multi_conn(
+        [MagicMock(stdout=docker_ps_output, returncode=0)]
+    )
+
+    with patch("app.backends.ssh_docker_backend._connect", new=AsyncMock(return_value=conn)):
+        backend = SSHDockerBackend()
+        stacks = await backend.get_stacks_with_update_status()
+
+    assert stacks == []
+
+
+# ---------------------------------------------------------------------------
+# SSHDockerBackend — mode transitions (all four modes × SSH backend)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_mode_all_includes_every_container(config_file, data_dir):
+    import yaml
+
+    raw = yaml.safe_load(config_file.read_text())
+    raw["hosts"][0]["docker_mode"] = "all"
+    config_file.write_text(yaml.dump(raw))
+
+    ps = "\n".join([
+        json.dumps({"Names": "/a", "Image": "a:1", "Labels": ""}),
+        json.dumps({"Names": "/b", "Image": "b:1", "Labels": "com.docker.compose.project=proj"}),
+    ])
+    conn = _make_multi_conn([
+        MagicMock(stdout=ps, returncode=0),
+        MagicMock(stdout='[]', returncode=0),
+        MagicMock(stdout='[]', returncode=0),
+    ])
+    with (
+        patch("app.backends.ssh_docker_backend._connect", new=AsyncMock(return_value=conn)),
+        patch("app.backends.ssh_docker_backend.check_image_update",
+              new=AsyncMock(return_value="up_to_date")),
+    ):
+        result = await SSHDockerBackend().get_stacks_with_update_status()
+    assert {s["name"] for s in result} == {"a", "b"}
+
+
+@pytest.mark.asyncio
+async def test_mode_all_and_new_includes_every_container(config_file, data_dir):
+    import yaml
+
+    raw = yaml.safe_load(config_file.read_text())
+    raw["hosts"][0]["docker_mode"] = "all_and_new"
+    config_file.write_text(yaml.dump(raw))
+
+    ps = json.dumps({"Names": "/c", "Image": "c:1", "Labels": ""})
+    conn = _make_multi_conn([
+        MagicMock(stdout=ps, returncode=0),
+        MagicMock(stdout='[]', returncode=0),
+    ])
+    with (
+        patch("app.backends.ssh_docker_backend._connect", new=AsyncMock(return_value=conn)),
+        patch("app.backends.ssh_docker_backend.check_image_update",
+              new=AsyncMock(return_value="up_to_date")),
+    ):
+        result = await SSHDockerBackend().get_stacks_with_update_status()
+    assert len(result) == 1
+    assert result[0]["name"] == "c"
+
+
+@pytest.mark.asyncio
+async def test_mode_selected_with_docker_containers_filters(config_file, data_dir):
+    import yaml
+
+    raw = yaml.safe_load(config_file.read_text())
+    raw["hosts"][0]["docker_mode"] = "selected"
+    raw["hosts"][0]["docker_containers"] = ["wanted"]
+    config_file.write_text(yaml.dump(raw))
+
+    ps = "\n".join([
+        json.dumps({"Names": "/wanted", "Image": "wanted:1", "Labels": ""}),
+        json.dumps({"Names": "/unwanted", "Image": "unwanted:1", "Labels": ""}),
+    ])
+    conn = _make_multi_conn([
+        MagicMock(stdout=ps, returncode=0),
+        MagicMock(stdout='[]', returncode=0),
+    ])
+    with (
+        patch("app.backends.ssh_docker_backend._connect", new=AsyncMock(return_value=conn)),
+        patch("app.backends.ssh_docker_backend.check_image_update",
+              new=AsyncMock(return_value="up_to_date")),
+    ):
+        result = await SSHDockerBackend().get_stacks_with_update_status()
+    assert len(result) == 1
+    assert result[0]["name"] == "wanted"
+
+
+@pytest.mark.asyncio
+async def test_mode_none_host_not_monitored(config_file, data_dir):
+    """A host with no docker_mode set is not included in monitoring."""
+    import yaml
+
+    raw = yaml.safe_load(config_file.read_text())
+    # Ensure no docker_mode
+    raw["hosts"][0].pop("docker_mode", None)
+    config_file.write_text(yaml.dump(raw))
+
+    backend = SSHDockerBackend()
+    result = await backend.get_stacks_with_update_status()
+    assert result == []
+
+
+# ---------------------------------------------------------------------------
+# SSHDockerBackend — Proxmox backend mode transitions
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_proxmox_lxc_all_mode(config_file, data_dir):
+    """Proxmox LXC host in all mode routes through pct exec and returns containers."""
+    import yaml
+    from app.config_manager import save_proxmox_config
+    from app.credentials import save_integration_credentials
+
+    save_proxmox_config(url="https://pve.example:8006", verify_ssl=False)
+    save_integration_credentials("proxmox", ssh_user="root", ssh_key="id_proxmox")
+
+    raw = yaml.safe_load(config_file.read_text())
+    raw["hosts"][0]["docker_mode"] = "all"
+    raw["hosts"][0]["proxmox_node"] = "pve"
+    raw["hosts"][0]["proxmox_vmid"] = 100
+    config_file.write_text(yaml.dump(raw))
+
+    ps = json.dumps({"Names": "/lxc-app", "Image": "lxc-app:1", "Labels": ""})
+    conn = _make_multi_conn([
+        MagicMock(stdout=ps, returncode=0),
+        MagicMock(stdout='[]', returncode=0),
+    ])
+    with (
+        patch("app.backends.ssh_docker_backend._connect", new=AsyncMock(return_value=conn)),
+        patch("app.backends.ssh_docker_backend.check_image_update",
+              new=AsyncMock(return_value="up_to_date")),
+    ):
+        result = await SSHDockerBackend().get_stacks_with_update_status()
+
+    assert len(result) == 1
+    assert result[0]["name"] == "lxc-app"
+    cmd = conn.run.call_args_list[0].args[0]
+    assert cmd.startswith("pct exec 100 -- sh -c ")
+
+
+@pytest.mark.asyncio
+async def test_proxmox_lxc_selected_mode(config_file, data_dir):
+    """Proxmox LXC host in selected mode filters by docker_containers."""
+    import yaml
+    from app.config_manager import save_proxmox_config
+    from app.credentials import save_integration_credentials
+
+    save_proxmox_config(url="https://pve.example:8006", verify_ssl=False)
+    save_integration_credentials("proxmox", ssh_user="root", ssh_key="id_proxmox")
+
+    raw = yaml.safe_load(config_file.read_text())
+    raw["hosts"][0]["docker_mode"] = "selected"
+    raw["hosts"][0]["docker_containers"] = ["lxc-app"]
+    raw["hosts"][0]["proxmox_node"] = "pve"
+    raw["hosts"][0]["proxmox_vmid"] = 100
+    config_file.write_text(yaml.dump(raw))
+
+    ps = "\n".join([
+        json.dumps({"Names": "/lxc-app", "Image": "lxc-app:1", "Labels": ""}),
+        json.dumps({"Names": "/other", "Image": "other:1", "Labels": ""}),
+    ])
+    conn = _make_multi_conn([
+        MagicMock(stdout=ps, returncode=0),
+        MagicMock(stdout='[]', returncode=0),
+    ])
+    with (
+        patch("app.backends.ssh_docker_backend._connect", new=AsyncMock(return_value=conn)),
+        patch("app.backends.ssh_docker_backend.check_image_update",
+              new=AsyncMock(return_value="up_to_date")),
+    ):
+        result = await SSHDockerBackend().get_stacks_with_update_status()
+
+    assert len(result) == 1
+    assert result[0]["name"] == "lxc-app"
+
+
+# ---------------------------------------------------------------------------
 # SSHDockerBackend — update_stack
 # ---------------------------------------------------------------------------
 
@@ -394,9 +743,9 @@ async def test_update_stack_runs_pull_and_up(config_file, data_dir, monkeypatch)
 # ---------------------------------------------------------------------------
 
 
-def test_docker_discover_no_stacks_returns_empty(client):
+def test_docker_discover_no_containers_returns_empty(client):
     with patch(
-        "app.backends.ssh_docker_backend.SSHDockerBackend.discover_stacks",
+        "app.backends.ssh_docker_backend.SSHDockerBackend.discover_containers",
         new=AsyncMock(return_value=[]),
     ):
         response = client.get("/admin/hosts/test-host/docker-discover")
@@ -404,14 +753,16 @@ def test_docker_discover_no_stacks_returns_empty(client):
     assert response.text.strip() == ""
 
 
-def test_docker_discover_returns_prompt_when_stacks_found(client):
-    stacks = [
-        {"name": "sonarr", "config_file": "/opt/stacks/sonarr/docker-compose.yml"},
-        {"name": "radarr", "config_file": "/opt/stacks/radarr/docker-compose.yml"},
+def test_docker_discover_returns_prompt_when_containers_found(client):
+    containers = [
+        {"name": "sonarr", "image": "sonarr:latest", "status": "Up", "running": True,
+         "compose_project": "arr-stack", "css_id": "sonarr"},
+        {"name": "radarr", "image": "radarr:latest", "status": "Up", "running": True,
+         "compose_project": "arr-stack", "css_id": "radarr"},
     ]
     with patch(
-        "app.backends.ssh_docker_backend.SSHDockerBackend.discover_stacks",
-        new=AsyncMock(return_value=stacks),
+        "app.backends.ssh_docker_backend.SSHDockerBackend.discover_containers",
+        new=AsyncMock(return_value=containers),
     ):
         response = client.get("/admin/hosts/test-host/docker-discover")
     assert response.status_code == 200
@@ -420,10 +771,61 @@ def test_docker_discover_returns_prompt_when_stacks_found(client):
     assert "monitor" in response.text.lower()
 
 
+def test_docker_discover_exception_returns_empty(client):
+    with patch(
+        "app.backends.ssh_docker_backend.SSHDockerBackend.discover_containers",
+        new=AsyncMock(side_effect=Exception("SSH timeout")),
+    ):
+        response = client.get("/admin/hosts/test-host/docker-discover")
+    assert response.status_code == 200
+    assert response.text.strip() == ""
+
+
 def test_docker_discover_unknown_host_returns_empty(client):
     response = client.get("/admin/hosts/does-not-exist/docker-discover")
     assert response.status_code == 200
     assert response.text.strip() == ""
+
+
+def test_docker_manage_returns_panel(client):
+    containers = [
+        {"name": "plex", "image": "plex:latest", "status": "Up", "running": True,
+         "compose_project": None, "css_id": "plex"},
+    ]
+    with patch(
+        "app.backends.ssh_docker_backend.SSHDockerBackend.discover_containers",
+        new=AsyncMock(return_value=containers),
+    ):
+        response = client.get("/admin/hosts/test-host/docker-manage")
+    assert response.status_code == 200
+    assert "plex" in response.text
+    assert "monitor" in response.text.lower()
+
+
+def test_docker_manage_unknown_host_returns_empty(client):
+    response = client.get("/admin/hosts/does-not-exist/docker-manage")
+    assert response.status_code == 200
+    assert response.text.strip() == ""
+
+
+def test_docker_manage_shows_error_on_connection_failure(client):
+    with patch(
+        "app.backends.ssh_docker_backend.SSHDockerBackend.discover_containers",
+        new=AsyncMock(side_effect=Exception("Connection refused")),
+    ):
+        response = client.get("/admin/hosts/test-host/docker-manage")
+    assert response.status_code == 200
+    assert "Connection refused" in response.text
+
+
+def test_docker_manage_empty_state(client):
+    with patch(
+        "app.backends.ssh_docker_backend.SSHDockerBackend.discover_containers",
+        new=AsyncMock(return_value=[]),
+    ):
+        response = client.get("/admin/hosts/test-host/docker-manage")
+    assert response.status_code == 200
+    assert "No containers found" in response.text
 
 
 def test_docker_monitoring_save_all(client, config_file):
@@ -438,18 +840,32 @@ def test_docker_monitoring_save_all(client, config_file):
     assert host["docker_mode"] == "all"
 
 
+def test_docker_monitoring_save_all_and_new(client, config_file):
+    import yaml
+
+    response = client.post(
+        "/admin/hosts/test-host/docker-monitoring", data={"docker_mode": "all_and_new"}
+    )
+    assert response.status_code == 200
+    raw = yaml.safe_load(config_file.read_text())
+    host = next(h for h in raw["hosts"] if h["name"] == "Test Host")
+    assert host["docker_mode"] == "all_and_new"
+    assert "docker_containers" not in host
+
+
 def test_docker_monitoring_save_selected(client, config_file):
     import yaml
 
     response = client.post(
         "/admin/hosts/test-host/docker-monitoring",
-        data={"docker_mode": "selected", "docker_stacks": ["sonarr", "radarr"]},
+        data={"docker_mode": "selected", "docker_containers": ["sonarr", "radarr"]},
     )
     assert response.status_code == 200
     raw = yaml.safe_load(config_file.read_text())
     host = next(h for h in raw["hosts"] if h["name"] == "Test Host")
     assert host["docker_mode"] == "selected"
-    assert set(host["docker_stacks"]) == {"sonarr", "radarr"}
+    assert set(host["docker_containers"]) == {"sonarr", "radarr"}
+    assert "docker_stacks" not in host
 
 
 def test_docker_monitoring_save_none_clears(client, config_file):
@@ -465,6 +881,15 @@ def test_docker_monitoring_save_none_clears(client, config_file):
     raw = yaml.safe_load(config_file.read_text())
     host = next(h for h in raw["hosts"] if h["name"] == "Test Host")
     assert "docker_mode" not in host
+    assert "docker_containers" not in host
+
+
+def test_docker_monitoring_save_shows_success_flash(client):
+    response = client.post(
+        "/admin/hosts/test-host/docker-monitoring", data={"docker_mode": "all"}
+    )
+    assert response.status_code == 200
+    assert "saved" in response.text.lower()
 
 
 def test_docker_prompt_dismiss(client):
@@ -533,10 +958,10 @@ async def test_get_stacks_filters_by_selected_mode(config_file, data_dir):
 
     raw = yaml.safe_load(config_file.read_text())
     raw["hosts"][0]["docker_mode"] = "selected"
-    raw["hosts"][0]["docker_stacks"] = ["radarr"]
+    raw["hosts"][0]["docker_containers"] = ["radarr"]
     config_file.write_text(yaml.dump(raw))
 
-    # docker ps -a returns both containers; only radarr passes the project filter
+    # docker ps -a returns both containers; only radarr passes the container name filter
     docker_ps_output = "\n".join([
         json.dumps({"Names": "/sonarr", "Image": "sonarr:latest",
                     "Labels": "com.docker.compose.project=sonarr"}),
@@ -824,13 +1249,13 @@ async def test_standalone_containers_appear_in_all_mode(config_file, data_dir):
 
 
 @pytest.mark.asyncio
-async def test_selected_mode_excludes_standalone_containers(config_file, data_dir):
-    """In selected mode, containers without a matching compose project are excluded."""
+async def test_selected_mode_filters_by_container_name(config_file, data_dir):
+    """In selected mode, only containers whose names are in docker_containers are included."""
     import yaml
 
     raw = yaml.safe_load(config_file.read_text())
     raw["hosts"][0]["docker_mode"] = "selected"
-    raw["hosts"][0]["docker_stacks"] = ["allowed-stack"]
+    raw["hosts"][0]["docker_containers"] = ["in-stack"]
     config_file.write_text(yaml.dump(raw))
 
     docker_ps_output = "\n".join([

--- a/tests/test_setup_containers.py
+++ b/tests/test_setup_containers.py
@@ -136,8 +136,8 @@ def test_setup_containers_save_stores_selection(config_file, data_dir, monkeypat
     raw = yaml.safe_load(config_file.read_text())
     test_host = next(h for h in raw["hosts"] if h["name"] == "Test Host")
     assert test_host.get("docker_mode") == "selected"
-    assert "nginx" in test_host.get("docker_stacks", [])
-    assert "plex" in test_host.get("docker_stacks", [])
+    assert "nginx" in test_host.get("docker_containers", [])
+    assert "plex" in test_host.get("docker_containers", [])
 
 
 def test_setup_containers_save_empty_selection(config_file, data_dir, monkeypatch):
@@ -165,7 +165,8 @@ def test_save_wizard_container_selection_sets_docker_mode(config_file, data_dir)
     raw = yaml.safe_load(config_file.read_text())
     host = next(h for h in raw["hosts"] if h["name"] == "Test Host")
     assert host["docker_mode"] == "selected"
-    assert set(host["docker_stacks"]) == {"plex", "sonarr"}
+    assert set(host["docker_containers"]) == {"plex", "sonarr"}
+    assert "docker_stacks" not in host
 
 
 def test_save_wizard_container_selection_ignores_malformed(config_file, data_dir):

--- a/tests/test_setup_hosts.py
+++ b/tests/test_setup_hosts.py
@@ -109,7 +109,7 @@ def test_setup_add_host_connection_succeeds_no_docker_adds_host(
         patch(
             "app.auth_router.verify_connection", new=AsyncMock(return_value=mock_result)
         ),
-        patch("app.auth_router.detect_docker_stacks", new=AsyncMock(return_value=0)),
+        patch("app.auth_router.discover_containers", new=AsyncMock(return_value=[])),
     ):
         response = setup_client.post(
             "/setup/hosts/add",
@@ -137,7 +137,14 @@ def test_setup_add_host_docker_detected_shows_prompt(
         patch(
             "app.auth_router.verify_connection", new=AsyncMock(return_value=mock_result)
         ),
-        patch("app.auth_router.detect_docker_stacks", new=AsyncMock(return_value=3)),
+        patch("app.auth_router.discover_containers", new=AsyncMock(return_value=[
+            {"name": "c1", "image": "img1:1", "status": "Up", "running": True,
+             "compose_project": None, "css_id": "c1"},
+            {"name": "c2", "image": "img2:1", "status": "Up", "running": True,
+             "compose_project": None, "css_id": "c2"},
+            {"name": "c3", "image": "img3:1", "status": "Up", "running": True,
+             "compose_project": None, "css_id": "c3"},
+        ])),
     ):
         response = setup_client.post(
             "/setup/hosts/add",
@@ -151,7 +158,7 @@ def test_setup_add_host_docker_detected_shows_prompt(
         )
     assert response.status_code == 200
     assert (
-        "docker detected" in response.text.lower() or "3 stack" in response.text.lower()
+        "docker detected" in response.text.lower() or "3 container" in response.text.lower()
     )
     assert "monitor" in response.text.lower()
 
@@ -165,7 +172,10 @@ def _add_host_via_session(
         patch(
             "app.auth_router.verify_connection", new=AsyncMock(return_value=mock_result)
         ),
-        patch("app.auth_router.detect_docker_stacks", new=AsyncMock(return_value=3)),
+        patch("app.auth_router.discover_containers", new=AsyncMock(return_value=[
+            {"name": "c1", "image": "img:1", "status": "Up", "running": True,
+             "compose_project": None, "css_id": "c1"},
+        ])),
     ):
         setup_client.post(
             "/setup/hosts/add",
@@ -235,7 +245,7 @@ def test_setup_add_host_auto_update_saved(setup_client, data_dir, config_file):
         patch(
             "app.auth_router.verify_connection", new=AsyncMock(return_value=mock_result)
         ),
-        patch("app.auth_router.detect_docker_stacks", new=AsyncMock(return_value=0)),
+        patch("app.auth_router.discover_containers", new=AsyncMock(return_value=[])),
     ):
         response = setup_client.post(
             "/setup/hosts/add",


### PR DESCRIPTION
OP#109

## Summary
- Adds inline container monitoring management panel (clickable Docker pill + "Containers" button per host row) with four modes: Select containers, Monitor all, Monitor all + new, Stop monitoring
- Renames `docker_stacks` → `docker_containers` config field; one-shot migration auto-runs on next monitoring cycle for hosts with old config
- New `GET /admin/hosts/{slug}/docker-manage` endpoint discovers live containers grouped by Compose project (with a Standalone group) and returns the management panel

## Test plan
- [ ] Click the Docker pill on a host with monitoring enabled — management panel opens inline
- [ ] Click "Containers" button on a host with no Docker configured — panel opens showing empty/error state
- [ ] Switch mode from "All" to "Select containers" — container list appears grouped by Compose project
- [ ] Uncheck some containers, save — only checked containers appear in monitoring cycle
- [ ] Save "Stop monitoring" — `docker_mode` removed from config, pill shows "—"
- [ ] Host with old `docker_stacks` config — verify migration expands to `docker_containers` on next check cycle
- [ ] Verify 918 tests pass (`python -m pytest -q`), coverage ≥95%

🤖 Generated with [Claude Code](https://claude.com/claude-code)