### PR TITLE
[#107] Fix container monitoring prompt skipped for sudo users (Portainer/OMV)

### DIFF
--- a/app/auth_router.py
+++ b/app/auth_router.py
@@ -1240,7 +1240,10 @@ async def setup_add_host(
 
     creds: dict = {}
     if auth_method == "password" and ssh_password.strip():
-        creds = {"ssh_password": ssh_password.strip()}
+        creds = {
+            "ssh_password": ssh_password.strip(),
+            "sudo_password": ssh_password.strip(),
+        }
 
     result = await verify_connection(host_entry, get_ssh_config(), creds)
     if not result["ok"]:

--- a/app/ssh_client.py
+++ b/app/ssh_client.py
@@ -93,11 +93,16 @@ async def discover_containers(
 ) -> list[dict]:
     """Return list of running containers as [{"id": name, "name": name, "image": image}, ...].
     Returns empty list on error or if Docker not available."""
+    creds = creds or {}
+    needs_sudo = _needs_sudo(host, ssh_cfg)
+    sudo_password = creds.get("sudo_password")
     try:
         async with await _connect(host, ssh_cfg, creds) as conn:
-            result = await conn.run(
+            result = await _run(
+                conn,
                 'docker ps --format \'{"name":"{{.Names}}","image":"{{.Image}}"}\'',
-                check=False,
+                sudo_password=sudo_password,
+                needs_sudo=needs_sudo,
             )
         containers = []
         for line in result.stdout.strip().splitlines():
@@ -124,11 +129,16 @@ async def detect_docker_stacks(
     host: dict, ssh_cfg: dict, creds: dict | None = None
 ) -> int:
     """Return the number of Docker Compose stacks found on the host, or -1 on error."""
+    creds = creds or {}
+    needs_sudo = _needs_sudo(host, ssh_cfg)
+    sudo_password = creds.get("sudo_password")
     try:
         async with await _connect(host, ssh_cfg, creds) as conn:
-            result = await conn.run(
+            result = await _run(
+                conn,
                 "docker compose ls --all --format json 2>/dev/null || echo '[]'",
-                check=False,
+                sudo_password=sudo_password,
+                needs_sudo=needs_sudo,
             )
         import json
 

--- a/tests/test_setup_hosts.py
+++ b/tests/test_setup_hosts.py
@@ -163,6 +163,33 @@ def test_setup_add_host_docker_detected_shows_prompt(
     assert "monitor" in response.text.lower()
 
 
+def test_setup_add_host_passes_sudo_password_to_discovery(
+    setup_client, data_dir, config_file
+):
+    """Wizard must forward ssh_password as sudo_password so non-root users can run docker ps."""
+    _create_admin()
+    mock_result = {"ok": True, "message": "Connected"}
+    discover_mock = AsyncMock(return_value=[])
+    with (
+        patch(
+            "app.auth_router.verify_connection", new=AsyncMock(return_value=mock_result)
+        ),
+        patch("app.auth_router.discover_containers", new=discover_mock),
+    ):
+        setup_client.post(
+            "/setup/hosts/add",
+            data={
+                "name": "OMV Host",
+                "host": "192.168.5.228",
+                "user": "admin",
+                "auth_method": "password",
+                "ssh_password": "secret",
+            },
+        )
+    creds_passed = discover_mock.call_args[0][2]
+    assert creds_passed.get("sudo_password") == "secret"
+
+
 def _add_host_via_session(
     setup_client, name, host, ssh_password="pass", enable_auto_update=False
 ):

--- a/tests/test_ssh_client.py
+++ b/tests/test_ssh_client.py
@@ -7,6 +7,8 @@ import pytest
 from app.package_managers import AptPackageManager
 from app.ssh_client import (
     check_host_updates,
+    detect_docker_stacks,
+    discover_containers,
     reboot_host,
     run_host_update_buffered,
     verify_connection,
@@ -266,3 +268,118 @@ async def test_run_host_update_respects_timeout():
     ):
         with pytest.raises(asyncio.TimeoutError):
             await run_host_update_buffered(HOST_KEY, {"command_timeout": 1})
+
+
+# ---------------------------------------------------------------------------
+# discover_containers
+# ---------------------------------------------------------------------------
+
+_CONTAINER_JSON = (
+    '{"name":"nginx","image":"nginx:latest"}\n'
+    '{"name":"redis","image":"redis:7"}\n'
+)
+
+HOST_NON_ROOT = {"name": "Test", "host": "10.0.0.1", "user": "admin"}
+HOST_ROOT = {"name": "Test", "host": "10.0.0.1", "user": "root"}
+SSH_CFG_NON_ROOT = {**SSH_CFG, "default_user": "admin"}
+CREDS_SUDO = {"sudo_password": "sudopass"}
+
+
+@pytest.mark.asyncio
+async def test_discover_containers_parses_containers():
+    conn = _make_conn(stdout=_CONTAINER_JSON)
+    with patch("app.ssh_client.asyncssh.connect", new=AsyncMock(return_value=conn)):
+        result = await discover_containers(HOST_ROOT, SSH_CFG)
+    assert len(result) == 2
+    assert result[0] == {"id": "nginx", "name": "nginx", "image": "nginx:latest"}
+    assert result[1] == {"id": "redis", "name": "redis", "image": "redis:7"}
+
+
+@pytest.mark.asyncio
+async def test_discover_containers_returns_empty_on_error():
+    with patch(
+        "app.ssh_client.asyncssh.connect", side_effect=Exception("refused")
+    ):
+        result = await discover_containers(HOST_ROOT, SSH_CFG)
+    assert result == []
+
+
+@pytest.mark.asyncio
+async def test_discover_containers_uses_sudo_for_non_root():
+    conn = _make_conn(stdout=_CONTAINER_JSON)
+    with patch("app.ssh_client.asyncssh.connect", new=AsyncMock(return_value=conn)):
+        await discover_containers(HOST_NON_ROOT, SSH_CFG_NON_ROOT, creds=CREDS_SUDO)
+    sent_cmd = conn.run.call_args[0][0]
+    assert sent_cmd.startswith("sudo -S")
+    assert "docker ps" in sent_cmd
+
+
+@pytest.mark.asyncio
+async def test_discover_containers_no_sudo_for_root():
+    conn = _make_conn(stdout=_CONTAINER_JSON)
+    with patch("app.ssh_client.asyncssh.connect", new=AsyncMock(return_value=conn)):
+        await discover_containers(HOST_ROOT, SSH_CFG)
+    sent_cmd = conn.run.call_args[0][0]
+    assert not sent_cmd.startswith("sudo")
+    assert "docker ps" in sent_cmd
+
+
+@pytest.mark.asyncio
+async def test_discover_containers_standalone_containers():
+    """docker ps lists standalone (non-compose, non-swarm) containers."""
+    stdout = '{"name":"standalone","image":"alpine:3"}\n'
+    conn = _make_conn(stdout=stdout)
+    with patch("app.ssh_client.asyncssh.connect", new=AsyncMock(return_value=conn)):
+        result = await discover_containers(HOST_ROOT, SSH_CFG)
+    assert len(result) == 1
+    assert result[0]["name"] == "standalone"
+
+
+# ---------------------------------------------------------------------------
+# detect_docker_stacks
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_detect_docker_stacks_compose_only():
+    stacks_json = '[{"Name":"web","Status":"running","ConfigFiles":"..."}]'
+    conn = _make_conn(stdout=stacks_json)
+    with patch("app.ssh_client.asyncssh.connect", new=AsyncMock(return_value=conn)):
+        count = await detect_docker_stacks(HOST_ROOT, SSH_CFG)
+    assert count == 1
+
+
+@pytest.mark.asyncio
+async def test_detect_docker_stacks_empty_returns_zero():
+    conn = _make_conn(stdout="[]")
+    with patch("app.ssh_client.asyncssh.connect", new=AsyncMock(return_value=conn)):
+        count = await detect_docker_stacks(HOST_ROOT, SSH_CFG)
+    assert count == 0
+
+
+@pytest.mark.asyncio
+async def test_detect_docker_stacks_error_returns_minus_one():
+    with patch(
+        "app.ssh_client.asyncssh.connect", side_effect=Exception("refused")
+    ):
+        count = await detect_docker_stacks(HOST_ROOT, SSH_CFG)
+    assert count == -1
+
+
+@pytest.mark.asyncio
+async def test_detect_docker_stacks_uses_sudo_for_non_root():
+    conn = _make_conn(stdout="[]")
+    with patch("app.ssh_client.asyncssh.connect", new=AsyncMock(return_value=conn)):
+        await detect_docker_stacks(HOST_NON_ROOT, SSH_CFG_NON_ROOT, creds=CREDS_SUDO)
+    sent_cmd = conn.run.call_args[0][0]
+    assert sent_cmd.startswith("sudo -S")
+    assert "docker compose ls" in sent_cmd
+
+
+@pytest.mark.asyncio
+async def test_detect_docker_stacks_no_sudo_for_root():
+    conn = _make_conn(stdout="[]")
+    with patch("app.ssh_client.asyncssh.connect", new=AsyncMock(return_value=conn)):
+        await detect_docker_stacks(HOST_ROOT, SSH_CFG)
+    sent_cmd = conn.run.call_args[0][0]
+    assert not sent_cmd.startswith("sudo")


### PR DESCRIPTION
OP#107

## Summary
- `discover_containers` and `detect_docker_stacks` now use the `_needs_sudo`/`_run` helpers so non-root SSH users with sudo (e.g. OMV `admin`) no longer get an empty container list
- Fixes the add-host flow skipping the "Enable container monitoring?" prompt for hosts where `docker` requires sudo

## Test plan
- [ ] `test_discover_containers_uses_sudo_for_non_root` — verifies `sudo -S docker ps` is sent for non-root user
- [ ] `test_discover_containers_no_sudo_for_root` — verifies plain `docker ps` for root
- [ ] `test_discover_containers_standalone_containers` — standalone containers (not compose/swarm) are detected
- [ ] `test_detect_docker_stacks_uses_sudo_for_non_root` — same for `detect_docker_stacks`
- [ ] `test_detect_docker_stacks_no_sudo_for_root` — same for root
- [ ] Full suite: 928 passed, 96% coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)