### PR TITLE
[#110] Fix portainer/agent containers dropped when Portainer integration not configured

### DIFF
--- a/app/backends/ssh_docker_backend.py
+++ b/app/backends/ssh_docker_backend.py
@@ -20,7 +20,7 @@ from urllib.parse import quote, unquote, urlparse
 from ..ssh_client import _connect
 from ..registry_client import check_image_update, extract_local_digest
 from ..credentials import get_credentials, get_integration_credentials
-from ..config_manager import get_hosts, get_ssh_config, get_proxmox_config, set_docker_monitoring
+from ..config_manager import get_hosts, get_ssh_config, get_proxmox_config, get_portainer_config, set_docker_monitoring
 from ..self_identity import get_self_container_id
 
 log = logging.getLogger(__name__)
@@ -229,9 +229,16 @@ class SSHDockerBackend:
             )
             containers = _parse_json_output(ps_result.stdout)
             portainer_projects = _portainer_managed_projects(containers)
-            if portainer_projects:
+            portainer_active = _portainer_integration_active()
+            if portainer_projects and portainer_active:
                 log.info(
                     "Docker SSH: %s — skipping %d Portainer-managed project(s): %s",
+                    h, len(portainer_projects), sorted(portainer_projects),
+                )
+            elif portainer_projects and not portainer_active:
+                log.info(
+                    "Docker SSH: %s — Portainer agent detected but no Portainer integration"
+                    " configured; including %d project(s) via SSH: %s",
                     h, len(portainer_projects), sorted(portainer_projects),
                 )
 
@@ -272,8 +279,10 @@ class SSHDockerBackend:
                 if project and project in self_projects:
                     continue
 
-                # Skip compose projects managed by a Portainer agent on this host
-                if project and project in portainer_projects:
+                # Skip compose projects managed by a Portainer agent — but only
+                # when the Portainer integration is active; otherwise those
+                # containers would vanish from the dashboard entirely.
+                if project and project in portainer_projects and portainer_active:
                     continue
 
                 raw_all.append((container_name, image, project))
@@ -547,6 +556,13 @@ def _compose_projects_from_ps(containers: list[dict]) -> list[dict]:
         if name not in by_project or (cf and not by_project[name]):
             by_project[name] = cf
     return [{"name": n, "config_file": f} for n, f in by_project.items()]
+
+
+def _portainer_integration_active() -> bool:
+    """Return True if both a Portainer URL and API key are configured."""
+    cfg = get_portainer_config()
+    creds = get_integration_credentials("portainer")
+    return bool(cfg.get("url") and creds.get("api_key"))
 
 
 def _portainer_managed_projects(containers: list[dict]) -> set[str]:

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -11,6 +11,7 @@ from app.backends.ssh_docker_backend import (
     _compose_projects_from_ps,
     _parse_docker_ps_labels,
     _parse_json_output,
+    _portainer_integration_active,
     _portainer_managed_projects,
     _rollup_status,
 )
@@ -2582,3 +2583,141 @@ def test_portainer_managed_projects_standalone_unaffected():
     ]
     result = _portainer_managed_projects(containers)
     assert result == set()
+
+
+# ---------------------------------------------------------------------------
+# _portainer_integration_active
+# ---------------------------------------------------------------------------
+
+
+def test_portainer_integration_active_false_when_unconfigured():
+    """Returns False when no Portainer URL or API key is set."""
+    with (
+        patch("app.backends.ssh_docker_backend.get_portainer_config", return_value={}),
+        patch("app.backends.ssh_docker_backend.get_integration_credentials", return_value={}),
+    ):
+        assert _portainer_integration_active() is False
+
+
+def test_portainer_integration_active_false_when_url_missing():
+    """Returns False when API key is set but URL is absent."""
+    with (
+        patch("app.backends.ssh_docker_backend.get_portainer_config", return_value={}),
+        patch("app.backends.ssh_docker_backend.get_integration_credentials",
+              return_value={"api_key": "tok"}),
+    ):
+        assert _portainer_integration_active() is False
+
+
+def test_portainer_integration_active_false_when_key_missing():
+    """Returns False when URL is set but API key is absent."""
+    with (
+        patch("app.backends.ssh_docker_backend.get_portainer_config",
+              return_value={"url": "https://portainer.test:9443"}),
+        patch("app.backends.ssh_docker_backend.get_integration_credentials", return_value={}),
+    ):
+        assert _portainer_integration_active() is False
+
+
+def test_portainer_integration_active_true_when_both_set():
+    """Returns True when both URL and API key are present."""
+    with (
+        patch("app.backends.ssh_docker_backend.get_portainer_config",
+              return_value={"url": "https://portainer.test:9443"}),
+        patch("app.backends.ssh_docker_backend.get_integration_credentials",
+              return_value={"api_key": "tok"}),
+    ):
+        assert _portainer_integration_active() is True
+
+
+# ---------------------------------------------------------------------------
+# _containers_for_host — Portainer agent present, integration not configured
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_portainer_agent_containers_included_without_integration(config_file, data_dir):
+    """When portainer/agent runs but no Portainer integration is configured,
+    SSH backend must include the /data/compose/ containers instead of dropping them."""
+    import yaml
+
+    raw = yaml.safe_load(config_file.read_text())
+    raw["hosts"][0]["docker_mode"] = "all"
+    config_file.write_text(yaml.dump(raw))
+
+    portainer_agent = json.dumps({
+        "Names": "/portainer_agent_1",
+        "Image": "portainer/agent:latest",
+        "Labels": "",
+    })
+    managed_container = json.dumps({
+        "Names": "/actualbudget_1",
+        "Image": "actualbudget/actual:latest",
+        "Labels": (
+            "com.docker.compose.project=actualbudget,"
+            "com.docker.compose.project.config_files=/data/compose/58/docker-compose.yml"
+        ),
+    })
+    inspect_output = '["actualbudget/actual@sha256:abc"]'
+
+    conn = _make_multi_conn([
+        MagicMock(stdout="\n".join([portainer_agent, managed_container]), returncode=0),
+        MagicMock(stdout=inspect_output, returncode=0),
+    ])
+
+    with (
+        patch("app.backends.ssh_docker_backend._connect", new=AsyncMock(return_value=conn)),
+        patch("app.backends.ssh_docker_backend.check_image_update",
+              new=AsyncMock(return_value="up_to_date")),
+        patch("app.backends.ssh_docker_backend.get_portainer_config", return_value={}),
+        patch("app.backends.ssh_docker_backend.get_integration_credentials", return_value={}),
+    ):
+        backend = SSHDockerBackend()
+        stacks = await backend.get_stacks_with_update_status()
+
+    names = [s["name"] for s in stacks]
+    assert "actualbudget_1" in names
+
+
+@pytest.mark.asyncio
+async def test_portainer_agent_containers_skipped_with_integration(config_file, data_dir):
+    """When portainer/agent runs AND Portainer integration is configured,
+    SSH backend must skip /data/compose/ containers (Portainer backend owns them)."""
+    import yaml
+
+    raw = yaml.safe_load(config_file.read_text())
+    raw["hosts"][0]["docker_mode"] = "all"
+    config_file.write_text(yaml.dump(raw))
+
+    portainer_agent = json.dumps({
+        "Names": "/portainer_agent_1",
+        "Image": "portainer/agent:latest",
+        "Labels": "",
+    })
+    managed_container = json.dumps({
+        "Names": "/actualbudget_1",
+        "Image": "actualbudget/actual:latest",
+        "Labels": (
+            "com.docker.compose.project=actualbudget,"
+            "com.docker.compose.project.config_files=/data/compose/58/docker-compose.yml"
+        ),
+    })
+
+    conn = _make_multi_conn([
+        MagicMock(stdout="\n".join([portainer_agent, managed_container]), returncode=0),
+    ])
+
+    with (
+        patch("app.backends.ssh_docker_backend._connect", new=AsyncMock(return_value=conn)),
+        patch("app.backends.ssh_docker_backend.check_image_update",
+              new=AsyncMock(return_value="up_to_date")),
+        patch("app.backends.ssh_docker_backend.get_portainer_config",
+              return_value={"url": "https://portainer.test:9443"}),
+        patch("app.backends.ssh_docker_backend.get_integration_credentials",
+              return_value={"api_key": "tok"}),
+    ):
+        backend = SSHDockerBackend()
+        stacks = await backend.get_stacks_with_update_status()
+
+    names = [s["name"] for s in stacks]
+    assert "actualbudget_1" not in names


### PR DESCRIPTION
OP#110

## Summary
- SSH backend was unconditionally skipping all containers whose `config_files` path starts with `/data/compose/` whenever a `portainer/agent` container was detected on the host
- This caused those containers to vanish from the dashboard when no Portainer URL/API key was configured (nobody would report them)
- Fix: added `_portainer_integration_active()` helper that checks the Portainer config + credentials; the skip now only fires when the Portainer integration is actually configured

## Test plan
- [ ] `test_portainer_integration_active_false_when_unconfigured` — helper returns False with no config
- [ ] `test_portainer_integration_active_false_when_url_missing` — False when only API key set
- [ ] `test_portainer_integration_active_false_when_key_missing` — False when only URL set
- [ ] `test_portainer_integration_active_true_when_both_set` — True when both present
- [ ] `test_portainer_agent_containers_included_without_integration` — `/data/compose/` containers appear in SSH backend when no Portainer integration configured
- [ ] `test_portainer_agent_containers_skipped_with_integration` — `/data/compose/` containers are still skipped when Portainer integration is active

🤖 Generated with [Claude Code](https://claude.com/claude-code)