### PR TITLE
OP#114 Transport hardening: HTTPS redirect and security headers

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -15,6 +15,7 @@ from .admin import router as admin_router
 from .auth import admin_exists, get_session_secret
 from .auth_router import router as auth_router
 from .csrf import CSRFMiddleware
+from .security_headers import ConditionalHTTPSRedirectMiddleware, SecurityHeadersMiddleware
 from .log_buffer import setup_log_buffer
 from .notifications import get_unread_count, get_notifications, mark_all_read
 from .auto_update_scheduler import apply_all_schedules, scheduler
@@ -98,6 +99,9 @@ _PUBLIC_PATHS = {
     "/setup",
     "/forgot-password",
     "/forgot-password/reset",
+    # CSP violation reports are sent by the browser before auth state is
+    # evaluated, so this endpoint must be accessible without a session.
+    "/api/csp-report",
 }
 
 
@@ -119,10 +123,24 @@ class AuthMiddleware(BaseHTTPMiddleware):
 
 setup_log_buffer()
 app = FastAPI(title="Keepup")
+
+# ---------------------------------------------------------------------------
+# Middleware stack — registration order is REVERSED from execution order.
+# Starlette inserts each new middleware at position 0, so the last registered
+# middleware wraps all the others (outermost = first in request chain).
+#
+# Resulting request chain (outermost → innermost):
+#   ConditionalHTTPSRedirect → SecurityHeaders → Session → CSRF → Auth → routes
+# ---------------------------------------------------------------------------
+
+# Auth: protect every route that isn't on the public allow-list.
 app.add_middleware(AuthMiddleware)
-# CSRFMiddleware must be registered before SessionMiddleware so that it runs
-# inside the session context (i.e. after the session cookie is loaded).
+
+# CSRF: validate X-CSRF-Token on mutating HTMX requests; must run inside the
+# Session context so it can read/write the session-stored token.
 app.add_middleware(CSRFMiddleware)
+
+# Session: load/store the signed session cookie.
 app.add_middleware(
     SessionMiddleware,
     secret_key=get_session_secret(),
@@ -135,6 +153,16 @@ app.add_middleware(
     # any cross-site request, giving strong CSRF protection for non-HTMX forms.
     same_site="strict",
 )
+
+# Security headers: inject X-Content-Type-Options, X-Frame-Options, etc.
+# Runs outside the session layer so headers are added to every response
+# including redirects and error pages.
+_tls_active = ssl_enabled()
+app.add_middleware(SecurityHeadersMiddleware, tls_active=_tls_active)
+
+# HTTPS redirect: must be the outermost middleware so that HTTP requests are
+# redirected before any session processing or auth checks occur.
+app.add_middleware(ConditionalHTTPSRedirectMiddleware, tls_active=_tls_active)
 app.include_router(auth_router)
 app.include_router(admin_router)
 app.include_router(auto_updates_router)
@@ -173,6 +201,28 @@ async def _startup() -> None:
     await reload_backends()
     apply_all_schedules()
     scheduler.start()
+
+
+# ---------------------------------------------------------------------------
+# CSP violation report endpoint
+# ---------------------------------------------------------------------------
+
+
+@app.post("/api/csp-report", status_code=204)
+async def csp_report(request: Request) -> None:
+    """Receive Content-Security-Policy violation reports from browsers.
+
+    Browsers POST a JSON body when a resource is blocked (or would be blocked
+    in Report-Only mode). We log the report at WARNING level so violations are
+    visible in the Keepup logs page. The endpoint is public (no auth required)
+    because the browser sends reports before authentication state is evaluated.
+    """
+    try:
+        body = await request.json()
+    except Exception:
+        body = {}
+    report = body.get("csp-report") or body
+    log.warning("CSP violation: %s", report)
 
 
 # ---------------------------------------------------------------------------

--- a/app/security_headers.py
+++ b/app/security_headers.py
@@ -1,0 +1,125 @@
+"""
+Security headers middleware and conditional HTTPS redirect — OP#114.
+
+Provides two ASGI middleware classes:
+
+  SecurityHeadersMiddleware
+      Injects hardening response headers on every reply:
+        - X-Content-Type-Options: nosniff    (prevents MIME-type sniffing)
+        - X-Frame-Options: DENY              (blocks iframe-based clickjacking)
+        - Referrer-Policy: no-referrer       (suppresses the Referer header)
+        - Content-Security-Policy-Report-Only (CSP in observation mode first)
+        - Strict-Transport-Security          (only when TLS cert is present)
+
+  ConditionalHTTPSRedirectMiddleware
+      Issues a 301 redirect from http:// to https:// when TLS is configured.
+      Completely transparent (no-op) when TLS is not active so that plain-HTTP
+      deployments are unaffected.
+"""
+
+import logging
+
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import RedirectResponse, Response
+from starlette.types import ASGIApp
+
+log = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Content Security Policy (Report-Only — first rollout pass)
+# ---------------------------------------------------------------------------
+
+# We ship CSP in Report-Only mode so violations are logged at /api/csp-report
+# without blocking any existing functionality. Once the reported violations are
+# reviewed and the policy tightened, a later ticket will promote it to
+# Content-Security-Policy enforcement.
+#
+# Rationale for each directive:
+#   script-src unsafe-inline  — templates contain <script> blocks; needed until
+#                               a nonce-based approach is adopted in a future pass.
+#   cdn.tailwindcss.com       — Tailwind CSS CDN loaded by all page templates.
+#   unpkg.com                 — htmx is loaded from unpkg CDN.
+#   img-src data:             — base64-encoded SVG favicons / inline images.
+#   object-src 'none'         — disallow Flash / embedded objects.
+#   base-uri 'self'           — prevent injected <base> tags from hijacking URLs.
+#   form-action 'self'        — disallow form submissions to external origins.
+_CSP_REPORT_ONLY = (
+    "default-src 'self'; "
+    "script-src 'self' 'unsafe-inline' https://cdn.tailwindcss.com https://unpkg.com; "
+    "style-src 'self' 'unsafe-inline' https://cdn.tailwindcss.com; "
+    "img-src 'self' data:; "
+    "connect-src 'self'; "
+    "font-src 'self'; "
+    "object-src 'none'; "
+    "base-uri 'self'; "
+    "form-action 'self'; "
+    "report-uri /api/csp-report"
+)
+
+# HSTS: instruct browsers to require HTTPS for 1 year.
+# includeSubDomains is intentionally omitted — Keepup is a self-hosted
+# single-instance tool and we must not make assumptions about subdomain ownership.
+_HSTS_VALUE = "max-age=31536000"
+
+
+# ---------------------------------------------------------------------------
+# Middleware
+# ---------------------------------------------------------------------------
+
+
+class SecurityHeadersMiddleware(BaseHTTPMiddleware):
+    """Append security-hardening HTTP response headers to every reply.
+
+    Pass ``tls_active=True`` (via ``app.add_middleware(..., tls_active=True)``)
+    when a TLS certificate is present so that HSTS is included.
+    """
+
+    def __init__(self, app: ASGIApp, *, tls_active: bool = False) -> None:
+        super().__init__(app)
+        self._tls_active = tls_active
+
+    async def dispatch(self, request: Request, call_next) -> Response:
+        response = await call_next(request)
+
+        # Prevent browsers from sniffing Content-Type away from the declared value.
+        response.headers["X-Content-Type-Options"] = "nosniff"
+
+        # Deny rendering this app inside an iframe on any origin.
+        response.headers["X-Frame-Options"] = "DENY"
+
+        # Strip the Referer header on all navigations — the app has no use for it
+        # and it could leak authenticated URLs to third-party CDN requests.
+        response.headers["Referrer-Policy"] = "no-referrer"
+
+        # Attach CSP in observation mode so we can audit violations before
+        # switching to enforcement in a future release.
+        response.headers["Content-Security-Policy-Report-Only"] = _CSP_REPORT_ONLY
+
+        # Only set HSTS when TLS is actually active — setting it over HTTP would
+        # be ignored by browsers anyway, but it avoids confusing logs.
+        if self._tls_active:
+            response.headers["Strict-Transport-Security"] = _HSTS_VALUE
+
+        return response
+
+
+class ConditionalHTTPSRedirectMiddleware(BaseHTTPMiddleware):
+    """Redirect plain-HTTP requests to HTTPS when a TLS certificate is present.
+
+    When *tls_active* is False this middleware is a transparent pass-through so
+    that HTTP-only deployments (development, LAN without a cert) work unchanged.
+    """
+
+    def __init__(self, app: ASGIApp, *, tls_active: bool = False) -> None:
+        super().__init__(app)
+        self._tls_active = tls_active
+
+    async def dispatch(self, request: Request, call_next) -> Response:
+        # Only redirect when TLS is configured *and* the incoming request is
+        # plain HTTP (a reverse proxy that terminates TLS may forward as HTTP,
+        # but in Keepup's direct-serve model the scheme is accurate).
+        if self._tls_active and request.url.scheme == "http":
+            https_url = str(request.url).replace("http://", "https://", 1)
+            return RedirectResponse(https_url, status_code=301)
+        return await call_next(request)

--- a/tests/test_security_114.py
+++ b/tests/test_security_114.py
@@ -1,0 +1,233 @@
+"""
+Tests for OP#114 — Transport hardening: HTTPS redirect and security headers.
+
+Covers:
+  - SecurityHeadersMiddleware: header injection, HSTS conditional on TLS
+  - ConditionalHTTPSRedirectMiddleware: redirect when TLS active, pass-through when not
+  - /api/csp-report endpoint: accepts POST without auth, returns 204
+"""
+
+import json
+
+import pytest
+from fastapi import FastAPI
+from fastapi.responses import PlainTextResponse
+from fastapi.testclient import TestClient
+
+from app.security_headers import (
+    ConditionalHTTPSRedirectMiddleware,
+    SecurityHeadersMiddleware,
+    _CSP_REPORT_ONLY,
+    _HSTS_VALUE,
+)
+
+
+# ---------------------------------------------------------------------------
+# Minimal test app helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_app(tls_active: bool = False) -> FastAPI:
+    """Return a minimal FastAPI app with security middlewares wired in."""
+    test_app = FastAPI()
+
+    @test_app.get("/ping")
+    async def ping():
+        return PlainTextResponse("pong")
+
+    test_app.add_middleware(SecurityHeadersMiddleware, tls_active=tls_active)
+    test_app.add_middleware(ConditionalHTTPSRedirectMiddleware, tls_active=tls_active)
+    return test_app
+
+
+# ---------------------------------------------------------------------------
+# SecurityHeadersMiddleware
+# ---------------------------------------------------------------------------
+
+
+class TestSecurityHeadersMiddleware:
+    """Verify that security response headers are injected on every reply."""
+
+    def setup_method(self):
+        # Use TLS-inactive app by default; override in specific tests.
+        self.client = TestClient(_make_app(tls_active=False), raise_server_exceptions=True)
+        self.tls_client = TestClient(_make_app(tls_active=True), raise_server_exceptions=True)
+
+    def test_x_content_type_options_present(self):
+        """X-Content-Type-Options: nosniff must be set on every response."""
+        resp = self.client.get("/ping")
+        assert resp.headers.get("x-content-type-options") == "nosniff"
+
+    def test_x_frame_options_present(self):
+        """X-Frame-Options: DENY must be set on every response."""
+        resp = self.client.get("/ping")
+        assert resp.headers.get("x-frame-options") == "DENY"
+
+    def test_referrer_policy_present(self):
+        """Referrer-Policy: no-referrer must be set on every response."""
+        resp = self.client.get("/ping")
+        assert resp.headers.get("referrer-policy") == "no-referrer"
+
+    def test_csp_report_only_present(self):
+        """Content-Security-Policy-Report-Only must be set on every response."""
+        resp = self.client.get("/ping")
+        csp = resp.headers.get("content-security-policy-report-only", "")
+        assert csp == _CSP_REPORT_ONLY
+
+    def test_hsts_absent_without_tls(self):
+        """HSTS must NOT be set when TLS is not active (HTTP-only deployments)."""
+        resp = self.client.get("/ping")
+        assert "strict-transport-security" not in resp.headers
+
+    def test_hsts_present_with_tls(self):
+        """HSTS must be set when TLS is active."""
+        resp = self.tls_client.get("/ping")
+        assert resp.headers.get("strict-transport-security") == _HSTS_VALUE
+
+    def test_hsts_value_includes_max_age(self):
+        """HSTS value must include a max-age directive."""
+        assert "max-age=" in _HSTS_VALUE
+
+    def test_csp_report_only_includes_report_uri(self):
+        """CSP policy must direct violation reports to /api/csp-report."""
+        assert "report-uri /api/csp-report" in _CSP_REPORT_ONLY
+
+    def test_csp_report_only_blocks_object_src(self):
+        """CSP must include object-src 'none' to block Flash/plugin content."""
+        assert "object-src 'none'" in _CSP_REPORT_ONLY
+
+    def test_all_required_headers_present_in_single_request(self):
+        """All mandatory headers must appear together on a single response."""
+        resp = self.client.get("/ping")
+        required = [
+            "x-content-type-options",
+            "x-frame-options",
+            "referrer-policy",
+            "content-security-policy-report-only",
+        ]
+        for header in required:
+            assert header in resp.headers, f"Missing header: {header}"
+
+
+# ---------------------------------------------------------------------------
+# ConditionalHTTPSRedirectMiddleware
+# ---------------------------------------------------------------------------
+
+
+class TestConditionalHTTPSRedirectMiddleware:
+    """Verify HTTPS redirect behaviour."""
+
+    def test_no_redirect_when_tls_inactive(self):
+        """HTTP requests must pass through when TLS is not configured."""
+        client = TestClient(_make_app(tls_active=False), raise_server_exceptions=True)
+        # TestClient sends HTTP by default; with tls_active=False no redirect expected.
+        resp = client.get("/ping", follow_redirects=False)
+        assert resp.status_code == 200
+
+    def test_redirect_when_tls_active_and_http_scheme(self):
+        """An HTTP request must be redirected to HTTPS (301) when TLS is active."""
+        # TestClient speaks HTTP internally; the middleware checks request.url.scheme.
+        app_with_tls = FastAPI()
+
+        @app_with_tls.get("/ping")
+        async def ping():
+            return PlainTextResponse("pong")
+
+        app_with_tls.add_middleware(ConditionalHTTPSRedirectMiddleware, tls_active=True)
+        client = TestClient(app_with_tls, raise_server_exceptions=True)
+        resp = client.get("/ping", follow_redirects=False)
+        # Starlette TestClient sends requests as http://testserver/ping
+        assert resp.status_code == 301
+        assert resp.headers["location"].startswith("https://")
+
+    def test_redirect_preserves_path(self):
+        """The 301 redirect must preserve the original request path and query string."""
+        app_with_tls = FastAPI()
+
+        @app_with_tls.get("/some/path")
+        async def some_path():
+            return PlainTextResponse("ok")
+
+        app_with_tls.add_middleware(ConditionalHTTPSRedirectMiddleware, tls_active=True)
+        client = TestClient(app_with_tls, raise_server_exceptions=True)
+        resp = client.get("/some/path?foo=bar", follow_redirects=False)
+        assert resp.status_code == 301
+        location = resp.headers["location"]
+        assert "/some/path" in location
+        assert "foo=bar" in location
+
+    def test_https_request_not_redirected(self):
+        """A request that already uses HTTPS must not be redirected."""
+        app_with_tls = FastAPI()
+
+        @app_with_tls.get("/ping")
+        async def ping():
+            return PlainTextResponse("pong")
+
+        app_with_tls.add_middleware(ConditionalHTTPSRedirectMiddleware, tls_active=True)
+        client = TestClient(app_with_tls, raise_server_exceptions=True, base_url="https://testserver")
+        resp = client.get("/ping", follow_redirects=False)
+        # Already HTTPS — should reach the route, not be redirected.
+        assert resp.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# /api/csp-report endpoint (integration)
+# ---------------------------------------------------------------------------
+
+
+class TestCspReportEndpoint:
+    """Verify the CSP violation report receiver endpoint."""
+
+    @pytest.fixture(autouse=True)
+    def setup(self, config_file, data_dir, monkeypatch):
+        monkeypatch.setenv("PORTAINER_URL", "https://portainer.test:9443")
+        monkeypatch.setenv("PORTAINER_API_KEY", "test-api-key")
+        monkeypatch.setenv("PORTAINER_VERIFY_SSL", "false")
+
+        from app.main import app
+        self.client = TestClient(app, raise_server_exceptions=True)
+
+    def test_csp_report_returns_204(self):
+        """POST to /api/csp-report must return 204 No Content."""
+        payload = {
+            "csp-report": {
+                "document-uri": "https://keepup.local/home",
+                "violated-directive": "script-src",
+                "blocked-uri": "https://evil.example.com/malicious.js",
+            }
+        }
+        resp = self.client.post(
+            "/api/csp-report",
+            content=json.dumps(payload),
+            headers={"Content-Type": "application/json"},
+        )
+        assert resp.status_code == 204
+
+    def test_csp_report_accessible_without_auth(self):
+        """CSP report endpoint must be reachable without a session cookie."""
+        resp = self.client.post(
+            "/api/csp-report",
+            content=json.dumps({"csp-report": {"violated-directive": "img-src"}}),
+            headers={"Content-Type": "application/json"},
+        )
+        # Must not redirect to /login (302); must return 204.
+        assert resp.status_code == 204
+
+    def test_csp_report_handles_empty_body_gracefully(self):
+        """Endpoint must not crash when the browser sends an empty body."""
+        resp = self.client.post(
+            "/api/csp-report",
+            content="",
+            headers={"Content-Type": "application/json"},
+        )
+        assert resp.status_code == 204
+
+    def test_csp_report_handles_non_json_body_gracefully(self):
+        """Endpoint must not crash when the body is malformed JSON."""
+        resp = self.client.post(
+            "/api/csp-report",
+            content="not-json",
+            headers={"Content-Type": "application/json"},
+        )
+        assert resp.status_code == 204


### PR DESCRIPTION
OP#114

## Summary
- New `app/security_headers.py`: `SecurityHeadersMiddleware` injects `X-Content-Type-Options`, `X-Frame-Options`, `Referrer-Policy`, `Content-Security-Policy-Report-Only`, and (when TLS cert present) `Strict-Transport-Security` on every response
- `ConditionalHTTPSRedirectMiddleware` issues a 301 HTTP→HTTPS redirect when TLS is configured; transparent no-op otherwise
- New `/api/csp-report` POST endpoint receives CSP violation reports from browsers (public, no auth required) and logs them at WARNING level
- Middleware registered outermost (HTTPS redirect → Security headers → Session → CSRF → Auth → routes)

## Test plan
- [ ] 18 new tests in `tests/test_security_114.py` — all pass
- [ ] Full suite: 976 tests, 96.56% coverage (≥ 95% threshold met)
- [ ] `ruff check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)