### PR TITLE
[#117] Audit logging for sensitive operations

### DIFF
--- a/app/admin.py
+++ b/app/admin.py
@@ -7,6 +7,7 @@ import pyotp
 from fastapi import APIRouter, Form, Request
 from fastapi.responses import HTMLResponse
 
+from .audit import audit
 from .auth import (
     _MIN_PASSWORD_LEN,
     change_password,
@@ -227,6 +228,7 @@ async def admin_integrations_save_portainer(
     save_portainer_config(url=url, verify_ssl=verify_ssl)
     if key:
         save_integration_credentials("portainer", api_key=key)
+        audit(request, "credential.save", target="portainer")
 
     await reload_backends()
 
@@ -537,6 +539,7 @@ async def admin_delete_host(request: Request, slug: str) -> HTMLResponse:
             "partials/admin_hosts.html",
             {"request": request, "hosts": _hosts_with_status(), "error": str(exc)},
         )
+    audit(request, "host.delete", target=slug)
     return templates.TemplateResponse(
         "partials/admin_hosts.html",
         {"request": request, "hosts": _hosts_with_status()},
@@ -591,6 +594,7 @@ async def admin_save_credentials(
                 "error": str(exc),
             },
         )
+    audit(request, "credential.save", target=slug, details={"auth_method": auth_method})
     # Return hosts list and trigger Docker auto-discovery for this host
     return templates.TemplateResponse(
         "partials/admin_hosts.html",
@@ -1107,6 +1111,7 @@ async def admin_change_password(
             {"request": request, **_account_context(), "pw_errors": errors},
         )
     change_password(new_password)
+    audit(request, "account.password.change")
     # New password meets policy — clear the home-page upgrade notice if present.
     request.session.pop("show_password_notice", None)
     return templates.TemplateResponse(
@@ -1150,6 +1155,7 @@ async def admin_mfa_setup_submit(
             },
         )
     enroll_mfa(secret)
+    audit(request, "account.mfa.enroll")
     request.session.pop("mfa_setup_secret", None)
     return templates.TemplateResponse(
         "partials/admin_account.html",
@@ -1173,6 +1179,7 @@ async def admin_mfa_remove(
             },
         )
     remove_mfa()
+    audit(request, "account.mfa.remove")
     return templates.TemplateResponse(
         "partials/admin_account.html",
         {"request": request, **_account_context(), "mfa_removed": True},
@@ -1194,6 +1201,7 @@ async def admin_regenerate_backup_key(
             },
         )
     new_key = regenerate_backup_key()
+    audit(request, "account.backup_key.regen")
     return templates.TemplateResponse(
         "partials/admin_account.html",
         {"request": request, **_account_context(), "new_backup_key": new_key},
@@ -1224,6 +1232,7 @@ async def admin_factory_reset(
                 "reset_error": 'Type "RESET" in the confirmation field.',
             },
         )
+    audit(request, "account.factory_reset")
     wipe_credential_store()
     reset_config()
     request.session.clear()

--- a/app/audit.py
+++ b/app/audit.py
@@ -1,0 +1,68 @@
+"""Append-only JSON audit log for sensitive operations (OP#117)."""
+
+import json
+import logging
+import logging.handlers
+import os
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from fastapi import Request
+
+_DATA_DIR = Path(os.getenv("DATA_PATH", "/app/data"))
+
+_audit_log = logging.getLogger("app.audit")
+_audit_log.setLevel(logging.INFO)
+_audit_log.propagate = False
+
+
+def setup_audit_log(data_dir: Path | None = None) -> None:
+    """Configure the rotating file handler. Call once at startup (or in tests)."""
+    target_dir = data_dir if data_dir is not None else _DATA_DIR
+    target_dir.mkdir(parents=True, exist_ok=True)
+    for h in list(_audit_log.handlers):
+        _audit_log.removeHandler(h)
+        h.close()
+    handler = logging.handlers.RotatingFileHandler(
+        target_dir / "audit.log",
+        maxBytes=10 * 1024 * 1024,
+        backupCount=5,
+        encoding="utf-8",
+    )
+    handler.setFormatter(logging.Formatter("%(message)s"))
+    _audit_log.addHandler(handler)
+
+
+def _client_ip(request: Request) -> str:
+    forwarded = request.headers.get("X-Forwarded-For")
+    if forwarded:
+        return forwarded.split(",")[0].strip()
+    return request.client.host if request.client else "unknown"
+
+
+def audit(
+    request: Request,
+    action: str,
+    target: str = "",
+    result: str = "ok",
+    details: dict[str, Any] | None = None,
+    actor: str | None = None,
+) -> None:
+    """Append one JSON-per-line audit entry. Secrets must never appear in details."""
+    if actor is None:
+        from .auth import get_admin_username
+        actor = get_admin_username() or "unknown"
+    request_id = getattr(request.state, "request_id", None) or str(uuid.uuid4())
+    entry = {
+        "ts": datetime.now(timezone.utc).isoformat(),
+        "request_id": request_id,
+        "actor": actor,
+        "source_ip": _client_ip(request),
+        "action": action,
+        "target": target,
+        "result": result,
+        "details": details or {},
+    }
+    _audit_log.info(json.dumps(entry, default=str))

--- a/app/auth_router.py
+++ b/app/auth_router.py
@@ -62,6 +62,7 @@ from .credentials import (
     save_credentials,
     save_integration_credentials,
 )
+from .audit import audit
 from .proxmox_client import ProxmoxClient
 from .ssh_client import discover_containers, verify_connection
 from .backend_loader import reload_backends
@@ -1092,6 +1093,7 @@ async def login_submit(
             error = f"Incorrect credentials. {attempts_left} attempt{'s' if attempts_left != 1 else ''} remaining before lockout."
         else:
             error = "Incorrect username, password, or authenticator code."
+        audit(request, "auth.login.failure", result="denied", actor=username.strip() or "unknown")
         return templates.TemplateResponse(
             "login.html",
             {
@@ -1103,6 +1105,7 @@ async def login_submit(
         )
 
     _clear_attempts(ip)
+    audit(request, "auth.login.success", actor=username.strip() or "unknown")
     request.session["authenticated"] = True
     if remember_me == "on":
         request.session["remember_me"] = True

--- a/app/main.py
+++ b/app/main.py
@@ -13,6 +13,7 @@ from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.middleware.sessions import SessionMiddleware
 
 from .admin import router as admin_router
+from .audit import audit, setup_audit_log
 from .auth import admin_exists, get_session_secret
 from .auth_router import router as auth_router
 from .csrf import CSRFMiddleware
@@ -118,11 +119,20 @@ class AuthMiddleware(BaseHTTPMiddleware):
         return await call_next(request)
 
 
+class RequestIDMiddleware(BaseHTTPMiddleware):
+    """Attach a unique request_id to every request for log correlation."""
+
+    async def dispatch(self, request: Request, call_next):
+        request.state.request_id = str(uuid.uuid4())
+        return await call_next(request)
+
+
 # ---------------------------------------------------------------------------
 # App setup
 # ---------------------------------------------------------------------------
 
 setup_log_buffer()
+setup_audit_log()
 app = FastAPI(title="Keepup")
 
 # ---------------------------------------------------------------------------
@@ -131,8 +141,12 @@ app = FastAPI(title="Keepup")
 # middleware wraps all the others (outermost = first in request chain).
 #
 # Resulting request chain (outermost → innermost):
-#   ConditionalHTTPSRedirect → SecurityHeaders → Session → CSRF → Auth → routes
+#   ConditionalHTTPSRedirect → SecurityHeaders → Session → CSRF → Auth → RequestID → routes
 # ---------------------------------------------------------------------------
+
+# RequestID: stamp every request with a unique ID for log correlation.
+# Registered first so it runs innermost — just before the route handler.
+app.add_middleware(RequestIDMiddleware)
 
 # Auth: protect every route that isn't on the public allow-list.
 app.add_middleware(AuthMiddleware)
@@ -695,6 +709,7 @@ async def host_update(
                 "sub": proxmox_node,
             }
             background_tasks.add_task(_job_run_proxmox_node_upgrade, job_id, slug)
+            audit(request, "host.upgrade.trigger", target=slug, details={"host": host_name, "job_id": job_id})
             return templates.TemplateResponse(
                 "partials/job_poll.html",
                 {"request": request, "job_id": job_id, "job": _jobs[job_id]},
@@ -717,6 +732,7 @@ async def host_update(
             background_tasks.add_task(
                 _job_run_lxc_upgrade, job_id, proxmox_node, proxmox_vmid, ssh_host
             )
+            audit(request, "host.upgrade.trigger", target=slug, details={"host": host_name, "job_id": job_id})
             return templates.TemplateResponse(
                 "partials/job_poll.html",
                 {"request": request, "job_id": job_id, "job": _jobs[job_id]},
@@ -746,6 +762,7 @@ async def host_update(
             "sub": host.get("host", ""),
         }
         background_tasks.add_task(_job_run_host_update, job_id, host, creds)
+        audit(request, "host.upgrade.trigger", target=slug, details={"host": host_name, "job_id": job_id})
         return templates.TemplateResponse(
             "partials/job_poll.html",
             {"request": request, "job_id": job_id, "job": _jobs[job_id]},
@@ -829,6 +846,7 @@ async def host_restart(
                 _job_run_proxmox_node_restart,
                 job_id, slug, proxmox_node,
             )
+            audit(request, "host.reboot.trigger", target=slug, details={"host": host_name, "job_id": job_id})
             return templates.TemplateResponse(
                 "partials/job_poll.html",
                 {"request": request, "job_id": job_id, "job": _jobs[job_id]},
@@ -858,6 +876,7 @@ async def host_restart(
             "sub": host.get("host", ""),
         }
         background_tasks.add_task(_job_run_host_restart, job_id, host, creds)
+        audit(request, "host.reboot.trigger", target=slug, details={"host": host["name"], "job_id": job_id})
         return templates.TemplateResponse(
             "partials/job_poll.html",
             {"request": request, "job_id": job_id, "job": _jobs[job_id]},
@@ -949,6 +968,7 @@ async def stack_update(
         "sub": backend_key,
     }
     background_tasks.add_task(_job_run_stack_update, job_id, backend_key, ref)
+    audit(request, "docker.stack.update", target=f"{backend_key}/{ref}", details={"stack": stack_name, "job_id": job_id})
     return templates.TemplateResponse(
         "partials/job_poll.html",
         {"request": request, "job_id": job_id, "job": _jobs[job_id]},

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -64,7 +64,17 @@ def data_dir(tmp_path, monkeypatch):
     monkeypatch.setattr(aul, "_DATA_DIR", d)
     monkeypatch.setattr(aul, "_LOG_PATH", d / "auto_update_log.json")
 
-    return d
+    # Redirect audit log to temp dir so tests can read and verify entries.
+    import app.audit as audit_mod
+
+    monkeypatch.setattr(audit_mod, "_DATA_DIR", d)
+    audit_mod.setup_audit_log(d)
+
+    yield d
+
+    for h in list(audit_mod._audit_log.handlers):
+        audit_mod._audit_log.removeHandler(h)
+        h.close()
 
 
 @pytest.fixture

--- a/tests/test_security_117.py
+++ b/tests/test_security_117.py
@@ -1,0 +1,291 @@
+"""
+Tests for OP#117 — Audit logging for sensitive operations.
+
+Covers:
+  - Audit log file is created at data_dir/audit.log
+  - Each entry has the required shape: ts, request_id, actor, source_ip,
+    action, target, result, details
+  - All covered sensitive actions emit an entry with the expected action string
+  - Credentials are never written to the audit log (redaction test)
+  - Log rotation handler is configured (RotatingFileHandler)
+"""
+
+import json
+import logging.handlers
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+import app.audit as audit_mod
+from app.audit import audit, setup_audit_log
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _read_entries(data_dir: Path) -> list[dict]:
+    log_path = data_dir / "audit.log"
+    if not log_path.exists():
+        return []
+    return [json.loads(line) for line in log_path.read_text().splitlines() if line.strip()]
+
+
+def _last_entry(data_dir: Path) -> dict:
+    entries = _read_entries(data_dir)
+    assert entries, "audit.log is empty"
+    return entries[-1]
+
+
+def _entries_with_action(data_dir: Path, action: str) -> list[dict]:
+    return [e for e in _read_entries(data_dir) if e.get("action") == action]
+
+
+def _assert_valid_shape(entry: dict) -> None:
+    required = {"ts", "request_id", "actor", "source_ip", "action", "target", "result", "details"}
+    missing = required - entry.keys()
+    assert not missing, f"audit entry missing fields: {missing}"
+    assert entry["ts"]
+    assert entry["request_id"]
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — audit module
+# ---------------------------------------------------------------------------
+
+
+def test_setup_creates_rotating_handler(tmp_path):
+    """setup_audit_log configures a RotatingFileHandler."""
+    setup_audit_log(tmp_path)
+    assert any(isinstance(h, logging.handlers.RotatingFileHandler) for h in audit_mod._audit_log.handlers)
+    for h in list(audit_mod._audit_log.handlers):
+        audit_mod._audit_log.removeHandler(h)
+        h.close()
+
+
+def test_audit_entry_shape(data_dir):
+    """audit() writes a valid JSON entry with all required keys."""
+    req = MagicMock()
+    req.state.request_id = "test-req-id"
+    req.headers.get.return_value = None
+    req.client.host = "10.0.0.1"
+
+    with patch("app.auth.get_admin_username", return_value="testadmin"):
+        audit(req, "test.action", target="test-target", result="ok", details={"k": "v"})
+
+    entry = _last_entry(data_dir)
+    assert entry["ts"]
+    assert entry["request_id"] == "test-req-id"
+    assert entry["actor"] == "testadmin"
+    assert entry["source_ip"] == "10.0.0.1"
+    assert entry["action"] == "test.action"
+    assert entry["target"] == "test-target"
+    assert entry["result"] == "ok"
+    assert entry["details"] == {"k": "v"}
+
+
+def test_audit_x_forwarded_for(data_dir):
+    """source_ip reads the first address from X-Forwarded-For."""
+    req = MagicMock()
+    req.state.request_id = "req-fwd"
+    req.headers.get.return_value = "203.0.113.5, 10.0.0.1"
+    req.client.host = "172.16.0.1"
+
+    with patch("app.auth.get_admin_username", return_value="testadmin"):
+        audit(req, "test.ip", actor="testadmin")
+
+    assert _last_entry(data_dir)["source_ip"] == "203.0.113.5"
+
+
+def test_audit_generates_request_id_when_missing(data_dir):
+    """If request.state has no request_id, a UUID is generated."""
+    req = MagicMock(spec=[])  # spec=[] → no attributes → getattr returns MagicMock but not AttributeError
+    req.headers = MagicMock()
+    req.headers.get.return_value = None
+    req.client = MagicMock()
+    req.client.host = "10.0.0.2"
+    # state has no request_id attribute
+    req.state = MagicMock(spec=[])
+
+    with patch("app.auth.get_admin_username", return_value="testadmin"):
+        audit(req, "test.no_id", actor="testadmin")
+
+    entry = _last_entry(data_dir)
+    # UUID4 has 36 characters (with hyphens)
+    assert len(entry["request_id"]) == 36
+
+
+# ---------------------------------------------------------------------------
+# Integration tests — sensitive actions via HTTP
+# ---------------------------------------------------------------------------
+
+
+def test_login_success_audit(anon_client, data_dir):
+    """Successful login emits auth.login.success."""
+    anon_client.post(
+        "/login",
+        data={"username": "testadmin", "password": "testpassword123"},
+        follow_redirects=False,
+    )
+    entries = _entries_with_action(data_dir, "auth.login.success")
+    assert entries, "expected auth.login.success entry"
+    e = entries[-1]
+    assert e["result"] == "ok"
+    assert e["actor"] == "testadmin"
+    _assert_valid_shape(e)
+
+
+def test_login_failure_audit(anon_client, data_dir):
+    """Failed login emits auth.login.failure."""
+    anon_client.post(
+        "/login",
+        data={"username": "testadmin", "password": "wrongpassword"},
+        follow_redirects=False,
+    )
+    entries = _entries_with_action(data_dir, "auth.login.failure")
+    assert entries, "expected auth.login.failure entry"
+    e = entries[-1]
+    assert e["result"] == "denied"
+    assert e["actor"] == "testadmin"
+    _assert_valid_shape(e)
+
+
+def test_password_change_audit(client, data_dir):
+    """Password change emits account.password.change."""
+    client.post(
+        "/admin/account/password",
+        data={
+            "current_password": "testpassword123",
+            "new_password": "newsecurepassword123",
+            "new_password_confirm": "newsecurepassword123",
+        },
+    )
+    entries = _entries_with_action(data_dir, "account.password.change")
+    assert entries, "expected account.password.change entry"
+    _assert_valid_shape(entries[-1])
+
+
+def test_backup_key_regen_audit(client, data_dir):
+    """Backup key regeneration emits account.backup_key.regen."""
+    client.post(
+        "/admin/account/backup-key",
+        data={"current_password": "testpassword123"},
+    )
+    entries = _entries_with_action(data_dir, "account.backup_key.regen")
+    assert entries, "expected account.backup_key.regen entry"
+    _assert_valid_shape(entries[-1])
+
+
+def test_mfa_enroll_audit(client, data_dir):
+    """MFA enrollment emits account.mfa.enroll."""
+    # GET stores the TOTP secret in session; POST verifies and enrolls
+    client.get("/admin/account/mfa/setup")
+    with patch("app.admin.pyotp") as mock_pyotp:
+        mock_totp = MagicMock()
+        mock_totp.verify.return_value = True
+        mock_pyotp.TOTP.return_value = mock_totp
+        client.post(
+            "/admin/account/mfa/setup",
+            data={"totp_code": "123456"},
+        )
+    entries = _entries_with_action(data_dir, "account.mfa.enroll")
+    assert entries, "expected account.mfa.enroll entry"
+    _assert_valid_shape(entries[-1])
+
+
+def test_mfa_remove_audit(client, data_dir):
+    """MFA removal emits account.mfa.remove."""
+    with patch("app.admin.verify_password", return_value=True):
+        with patch("app.admin.verify_totp", return_value=True):
+            client.post(
+                "/admin/account/mfa/remove",
+                data={"current_password": "testpassword123", "totp_code": "123456"},
+            )
+    entries = _entries_with_action(data_dir, "account.mfa.remove")
+    assert entries, "expected account.mfa.remove entry"
+    _assert_valid_shape(entries[-1])
+
+
+def test_factory_reset_audit(client, data_dir):
+    """Factory reset emits account.factory_reset (logged before the wipe)."""
+    client.post(
+        "/admin/account/factory-reset",
+        data={"current_password": "testpassword123", "confirm_text": "RESET"},
+    )
+    entries = _entries_with_action(data_dir, "account.factory_reset")
+    assert entries, "expected account.factory_reset entry"
+    e = entries[-1]
+    assert e["result"] == "ok"
+    _assert_valid_shape(e)
+
+
+def test_credential_save_audit(client, data_dir):
+    """Saving SSH credentials emits credential.save for the correct host slug."""
+    client.post(
+        "/admin/hosts/test-host/credentials",
+        data={
+            "auth_method": "password",
+            "ssh_password": "supersecretpassword",
+            "ssh_key": "",
+            "sudo_password": "",
+        },
+    )
+    entries = _entries_with_action(data_dir, "credential.save")
+    assert entries, "expected credential.save entry"
+    e = entries[-1]
+    assert e["target"] == "test-host"
+    assert e["result"] == "ok"
+    assert e["details"]["auth_method"] == "password"
+    _assert_valid_shape(e)
+
+
+def test_credential_save_no_secret_in_log(client, data_dir):
+    """The SSH password must NOT appear anywhere in the audit log."""
+    secret_value = "topsecretpassword_XYZ987"
+    client.post(
+        "/admin/hosts/test-host/credentials",
+        data={
+            "auth_method": "password",
+            "ssh_password": secret_value,
+            "ssh_key": "",
+            "sudo_password": "",
+        },
+    )
+    log_text = (data_dir / "audit.log").read_text()
+    assert secret_value not in log_text, "credential value must not appear in audit log"
+
+
+def test_host_upgrade_trigger_audit(client, data_dir):
+    """Triggering a host upgrade emits host.upgrade.trigger."""
+    with patch("app.main.run_host_update_buffered", new=AsyncMock(return_value=[])):
+        client.post("/api/host/test-host/update", data={})
+    entries = _entries_with_action(data_dir, "host.upgrade.trigger")
+    assert entries, "expected host.upgrade.trigger entry"
+    e = entries[-1]
+    assert e["target"] == "test-host"
+    assert e["result"] == "ok"
+    assert "job_id" in e["details"]
+    _assert_valid_shape(e)
+
+
+def test_host_reboot_trigger_audit(client, data_dir):
+    """Triggering a host reboot emits host.reboot.trigger."""
+    with patch("app.main.reboot_host", new=AsyncMock(return_value=None)):
+        client.post("/api/host/test-host/restart", data={"confirmed": "yes"})
+    entries = _entries_with_action(data_dir, "host.reboot.trigger")
+    assert entries, "expected host.reboot.trigger entry"
+    e = entries[-1]
+    assert e["target"] == "test-host"
+    _assert_valid_shape(e)
+
+
+def test_host_delete_audit(client, data_dir):
+    """Deleting a host emits host.delete."""
+    client.delete("/admin/hosts/test-host")
+    entries = _entries_with_action(data_dir, "host.delete")
+    assert entries, "expected host.delete entry"
+    e = entries[-1]
+    assert e["target"] == "test-host"
+    _assert_valid_shape(e)

--- a/tests/test_security_117.py
+++ b/tests/test_security_117.py
@@ -15,8 +15,6 @@ import logging.handlers
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
-import pytest
-
 import app.audit as audit_mod
 from app.audit import audit, setup_audit_log
 


### PR DESCRIPTION
OP#117

## Summary
- Adds `app/audit.py`: append-only JSON-per-line audit log at `/app/data/audit.log` with `RotatingFileHandler` (10 MB, 5 backups)
- Adds `RequestIDMiddleware` to stamp every request with a UUID, available as `request.state.request_id` in all handlers
- Instruments all required sensitive actions: login success/failure, host upgrade/reboot trigger, Docker stack update, password change, MFA enroll/remove, backup key regen, factory reset, SSH credential save, host delete
- Secrets are never written to the audit log — verified by a dedicated redaction test
- 16 new tests in `tests/test_security_117.py`; overall coverage 97%, `audit.py` at 100%

## Test plan
- [ ] `pytest tests/test_security_117.py` — all 16 pass
- [ ] `pytest` — all 1011 tests pass
- [ ] Coverage ≥ 95% maintained (actual: 97%)
- [ ] `audit.log` appears in `/app/data/` after first sensitive action
- [ ] Log entries contain all required fields: `ts`, `request_id`, `actor`, `source_ip`, `action`, `target`, `result`, `details`
- [ ] No credential values appear in log entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)