### PR TITLE
[#121] Fix: Keepup container excluded from its own update list

### DIFF
--- a/app/admin.py
+++ b/app/admin.py
@@ -8,7 +8,6 @@ from fastapi import APIRouter, Form, Request
 from fastapi.responses import HTMLResponse
 
 from .audit import audit
-from .rate_limiter import limiter
 from .auth import (
     _MIN_PASSWORD_LEN,
     change_password,

--- a/app/portainer_client.py
+++ b/app/portainer_client.py
@@ -14,7 +14,7 @@ import logging
 import httpx
 
 from .registry_client import extract_local_digest, check_image_update
-from .self_identity import get_self_container_id
+from .self_identity import get_self_container_id, get_self_container_name
 
 log = logging.getLogger(__name__)
 
@@ -72,7 +72,8 @@ class PortainerClient:
         """Pull latest images and redeploy the stack."""
         # Safety net: refuse to redeploy a stack that contains the self-container.
         self_id = get_self_container_id()
-        if self_id:
+        self_name = get_self_container_name()
+        if self_id or self_name:
             try:
                 containers = await self._get_containers(endpoint_id)
                 stack_meta = await self.get(f"/api/stacks/{stack_id}")
@@ -82,7 +83,14 @@ class PortainerClient:
                     if c.get("Labels", {}).get("com.docker.compose.project", "").lower()
                     == stack_name_lower
                 ]
-                if any((c.get("Id", "") or "")[:12] == self_id for c in stack_containers):
+                id_match = self_id and any(
+                    (c.get("Id", "") or "")[:12] == self_id for c in stack_containers
+                )
+                name_match = self_name and any(
+                    self_name in [n.lstrip("/") for n in c.get("Names", [])]
+                    for c in stack_containers
+                )
+                if id_match or name_match:
                     raise ValueError(
                         f"Self-update refused: Keepup is in Portainer stack {stack_id}"
                     )
@@ -155,6 +163,7 @@ class PortainerClient:
                 endpoint_containers[ep["Id"]] = []
 
         self_id = get_self_container_id()
+        self_name = get_self_container_name()
 
         results = []
         for stack in stacks:
@@ -175,9 +184,15 @@ class PortainerClient:
             ]
 
             # Skip the stack that contains the running Keepup container.
-            if self_id and any(
+            # Check by container ID first; fall back to name when HOSTNAME is overridden.
+            id_match = self_id and any(
                 (c.get("Id", "") or "")[:12] == self_id for c in stack_containers
-            ):
+            )
+            name_match = self_name and any(
+                self_name in [n.lstrip("/") for n in c.get("Names", [])]
+                for c in stack_containers
+            )
+            if id_match or name_match:
                 endpoint_name = endpoint_map.get(endpoint_id, f"env-{endpoint_id}")
                 log.info(
                     "Portainer: excluding self-stack %s on %s from discovery",

--- a/app/self_identity.py
+++ b/app/self_identity.py
@@ -2,18 +2,48 @@ import os
 import re
 
 _CONTAINER_ID_RE = re.compile(r"^[0-9a-f]{12}$")
+_CGROUP_LONG_ID_RE = re.compile(r"[0-9a-f]{64}")
+
+
+def _container_id_from_cgroup() -> str | None:
+    """Read the container ID from /proc/self/cgroup (works when HOSTNAME is overridden).
+
+    Covers both cgroups v1 (/docker/<64-char-id>) and v2 (docker-<64-char-id>.scope).
+    Returns None outside Docker or when the file is unavailable.
+    """
+    try:
+        with open("/proc/self/cgroup") as f:
+            for line in f:
+                m = _CGROUP_LONG_ID_RE.search(line)
+                if m:
+                    return m.group(0)[:12]
+    except OSError:
+        pass
+    return None
 
 
 def get_self_container_id() -> str | None:
     """Return the short container ID when Keepup runs inside Docker, else None.
 
-    Docker sets HOSTNAME to the 12-char hex short ID by default. Returns None
-    on bare-metal or in test environments where HOSTNAME looks like a real hostname.
+    Tries HOSTNAME first (Docker default). Falls back to /proc/self/cgroup so
+    the ID is found even when the user sets a custom hostname: in docker-compose.
+    Returns None on bare-metal or in environments where neither source is available.
     """
     hostname = os.environ.get("HOSTNAME", "")
     if _CONTAINER_ID_RE.match(hostname):
         return hostname
-    return None
+    return _container_id_from_cgroup()
+
+
+def get_self_container_name() -> str | None:
+    """Return the container name from KEEPUP_CONTAINER_NAME env var, else None.
+
+    Used as a name-based fallback for self-exclusion when the container ID cannot
+    be determined (e.g. some container runtimes that don't expose cgroup paths).
+    Set KEEPUP_CONTAINER_NAME=keepup in docker-compose.yml to enable this.
+    """
+    name = os.environ.get("KEEPUP_CONTAINER_NAME", "").strip()
+    return name or None
 
 
 def is_self_on_proxmox_node(node_slug: str) -> bool:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,8 @@ services:
     container_name: keepup
     ports:
       - "8765:8765"
+    environment:
+      - KEEPUP_CONTAINER_NAME=keepup
     volumes:
       - ./config:/app/config    # config.yml — host list and SSH defaults
       - ./data:/app/data        # encrypted credentials and session secret

--- a/tests/test_portainer_client.py
+++ b/tests/test_portainer_client.py
@@ -448,3 +448,76 @@ async def test_portainer_update_proceeds_when_check_fails(client, monkeypatch):
 
     assert result == {"Id": 20}
     put_mock.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Name-based self-exclusion (OP#121) — fallback when HOSTNAME is overridden
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_self_stack_excluded_by_container_name(client, monkeypatch):
+    """Stack is excluded when KEEPUP_CONTAINER_NAME matches a container name, even if HOSTNAME
+    is not a hex ID (e.g. user set hostname: keepup in docker-compose)."""
+    monkeypatch.setenv("HOSTNAME", "keepup")  # not a hex ID
+    monkeypatch.setenv("KEEPUP_CONTAINER_NAME", "keepup")
+
+    self_container = {
+        "Id": "aabbccddeeff112233445566",
+        "Image": "ghcr.io/d4vastu/keepup:latest",
+        "ImageID": "sha256:keepup",
+        "Names": ["/keepup"],
+        "Labels": {"com.docker.compose.project": "keepup"},
+    }
+    other_container = {
+        "Id": "112233445566aabbccddeeff",
+        "Image": "linuxserver/sonarr:latest",
+        "ImageID": "sha256:sonarr",
+        "Names": ["/sonarr"],
+        "Labels": {"com.docker.compose.project": "sonarr"},
+    }
+    stacks = [
+        {"Id": 20, "Name": "keepup", "EndpointId": 1, "Env": []},
+        {"Id": 21, "Name": "sonarr", "EndpointId": 1, "Env": []},
+    ]
+
+    with (
+        patch("app.self_identity._container_id_from_cgroup", return_value=None),
+        patch.object(client, "get_endpoints", new=AsyncMock(return_value=ENDPOINTS[:1])),
+        patch.object(client, "get_stacks", new=AsyncMock(return_value=stacks)),
+        patch.object(
+            client, "_get_containers",
+            new=AsyncMock(return_value=[self_container, other_container]),
+        ),
+        patch.object(client, "_get_image_info", new=AsyncMock(return_value=IMAGE_INFO)),
+        patch("app.portainer_client.check_image_update", new=AsyncMock(return_value="up_to_date")),
+        patch("app.portainer_client.extract_local_digest", return_value="sha256:x"),
+    ):
+        results = await client.get_stacks_with_update_status()
+
+    names = {r["name"] for r in results}
+    assert "keepup" not in names
+    assert "sonarr" in names
+
+
+@pytest.mark.asyncio
+async def test_update_stack_refused_by_container_name(client, monkeypatch):
+    """update_stack raises ValueError when KEEPUP_CONTAINER_NAME matches, even without a hex HOSTNAME."""
+    monkeypatch.setenv("HOSTNAME", "keepup")
+    monkeypatch.setenv("KEEPUP_CONTAINER_NAME", "keepup")
+
+    self_container = {
+        "Id": "aabbccddeeff112233445566",
+        "Image": "ghcr.io/d4vastu/keepup:latest",
+        "Names": ["/keepup"],
+        "Labels": {"com.docker.compose.project": "keepup"},
+    }
+    stack_meta = {"Id": 20, "Name": "keepup", "Env": []}
+
+    with (
+        patch("app.self_identity._container_id_from_cgroup", return_value=None),
+        patch.object(client, "_get_containers", new=AsyncMock(return_value=[self_container])),
+        patch.object(client, "get", new=AsyncMock(return_value=stack_meta)),
+    ):
+        with pytest.raises(ValueError, match="Self-update refused"):
+            await client.update_stack(20, 1)

--- a/tests/test_security_118.py
+++ b/tests/test_security_118.py
@@ -8,9 +8,7 @@ Covers:
   M6 – session_version invalidates sessions on MFA/password changes
 """
 
-import time
 from pathlib import Path
-from unittest.mock import patch
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_self_identity.py
+++ b/tests/test_self_identity.py
@@ -1,27 +1,45 @@
 """Tests for app.self_identity."""
 
-from app.self_identity import get_self_container_id, is_self_on_proxmox_node
+from io import StringIO
+from unittest.mock import patch
+
+from app.self_identity import (
+    _container_id_from_cgroup,
+    get_self_container_id,
+    get_self_container_name,
+    is_self_on_proxmox_node,
+)
+
+_PATCH_CGROUP = patch("app.self_identity._container_id_from_cgroup", return_value=None)
+
+# ---------------------------------------------------------------------------
+# get_self_container_id — HOSTNAME path
+# ---------------------------------------------------------------------------
 
 
 def test_returns_none_when_hostname_absent(monkeypatch):
     monkeypatch.delenv("HOSTNAME", raising=False)
-    assert get_self_container_id() is None
+    with _PATCH_CGROUP:
+        assert get_self_container_id() is None
 
 
 def test_returns_none_for_regular_hostname(monkeypatch):
     monkeypatch.setenv("HOSTNAME", "myserver")
-    assert get_self_container_id() is None
+    with _PATCH_CGROUP:
+        assert get_self_container_id() is None
 
 
 def test_returns_none_for_partial_hex(monkeypatch):
     monkeypatch.setenv("HOSTNAME", "abc123")
-    assert get_self_container_id() is None
+    with _PATCH_CGROUP:
+        assert get_self_container_id() is None
 
 
 def test_returns_none_for_uppercase_hex(monkeypatch):
     # Docker short IDs are always lowercase; uppercase is not a container ID.
     monkeypatch.setenv("HOSTNAME", "ABC123DEF456")
-    assert get_self_container_id() is None
+    with _PATCH_CGROUP:
+        assert get_self_container_id() is None
 
 
 def test_returns_short_id_for_docker_hostname(monkeypatch):
@@ -31,12 +49,100 @@ def test_returns_short_id_for_docker_hostname(monkeypatch):
 
 def test_returns_none_for_13_char_hex(monkeypatch):
     monkeypatch.setenv("HOSTNAME", "a1b2c3d4e5f60")
-    assert get_self_container_id() is None
+    with _PATCH_CGROUP:
+        assert get_self_container_id() is None
 
 
 def test_returns_none_for_11_char_hex(monkeypatch):
     monkeypatch.setenv("HOSTNAME", "a1b2c3d4e5f")
-    assert get_self_container_id() is None
+    with _PATCH_CGROUP:
+        assert get_self_container_id() is None
+
+
+# ---------------------------------------------------------------------------
+# _container_id_from_cgroup
+# ---------------------------------------------------------------------------
+
+# 64-char lowercase hex container ID, short form = "abc123def456"
+_CONTAINER_LONG_ID = "abc123def4567890abcdef12345678901234567890abcdef1234567890abcdef"
+
+_CGROUP_V1 = (
+    f"12:cpuset:/docker/{_CONTAINER_LONG_ID}\n"
+    f"11:memory:/docker/{_CONTAINER_LONG_ID}\n"
+)
+
+_CGROUP_V2 = f"0::/system.slice/docker-{_CONTAINER_LONG_ID}.scope\n"
+
+
+def test_cgroup_v1_returns_short_id():
+    with patch("builtins.open", return_value=StringIO(_CGROUP_V1)):
+        result = _container_id_from_cgroup()
+    assert result == "abc123def456"
+
+
+def test_cgroup_v2_returns_short_id():
+    with patch("builtins.open", return_value=StringIO(_CGROUP_V2)):
+        result = _container_id_from_cgroup()
+    assert result == "abc123def456"
+
+
+def test_cgroup_no_id_returns_none():
+    with patch("builtins.open", return_value=StringIO("0::/\n")):
+        result = _container_id_from_cgroup()
+    assert result is None
+
+
+def test_cgroup_oserror_returns_none():
+    with patch("builtins.open", side_effect=OSError("no such file")):
+        result = _container_id_from_cgroup()
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# get_self_container_id — cgroup fallback path
+# ---------------------------------------------------------------------------
+
+
+def test_cgroup_fallback_used_when_hostname_is_plain(monkeypatch):
+    """When HOSTNAME is not a hex ID, the cgroup fallback should provide the ID."""
+    monkeypatch.setenv("HOSTNAME", "keepup")
+    with patch(
+        "app.self_identity._container_id_from_cgroup",
+        return_value="aabbccddeeff",
+    ):
+        assert get_self_container_id() == "aabbccddeeff"
+
+
+def test_cgroup_fallback_returns_none_outside_docker(monkeypatch):
+    """Bare-metal: both HOSTNAME and cgroup return nothing → None."""
+    monkeypatch.setenv("HOSTNAME", "homelab")
+    with patch("app.self_identity._container_id_from_cgroup", return_value=None):
+        assert get_self_container_id() is None
+
+
+# ---------------------------------------------------------------------------
+# get_self_container_name
+# ---------------------------------------------------------------------------
+
+
+def test_container_name_from_env(monkeypatch):
+    monkeypatch.setenv("KEEPUP_CONTAINER_NAME", "keepup")
+    assert get_self_container_name() == "keepup"
+
+
+def test_container_name_strips_whitespace(monkeypatch):
+    monkeypatch.setenv("KEEPUP_CONTAINER_NAME", "  keepup  ")
+    assert get_self_container_name() == "keepup"
+
+
+def test_container_name_returns_none_when_unset(monkeypatch):
+    monkeypatch.delenv("KEEPUP_CONTAINER_NAME", raising=False)
+    assert get_self_container_name() is None
+
+
+def test_container_name_returns_none_for_empty_string(monkeypatch):
+    monkeypatch.setenv("KEEPUP_CONTAINER_NAME", "")
+    assert get_self_container_name() is None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
OP#121

## Summary
- `get_self_container_id()` now falls back to `/proc/self/cgroup` when `HOSTNAME` is not a Docker short ID (e.g. user sets `hostname: keepup` in docker-compose)
- `get_self_container_name()` added — reads `KEEPUP_CONTAINER_NAME` env var for a name-based last-resort fallback when cgroup is also unavailable
- `docker-compose.yml` ships `KEEPUP_CONTAINER_NAME=keepup` so name-based exclusion works out of the box
- Both `get_stacks_with_update_status` and `update_stack` in `PortainerClient` now check ID **or** name, whichever resolves

## Test plan
- [ ] `test_cgroup_v1_returns_short_id` / `test_cgroup_v2_returns_short_id` — cgroup parsing for both cgroup versions
- [ ] `test_cgroup_fallback_used_when_hostname_is_plain` — HOSTNAME override triggers cgroup path
- [ ] `test_container_name_from_env` / `test_container_name_strips_whitespace` / etc. — `KEEPUP_CONTAINER_NAME` env var
- [ ] `test_self_stack_excluded_by_container_name` — name-based stack exclusion in discovery
- [ ] `test_update_stack_refused_by_container_name` — name-based guard in `update_stack`
- [ ] Full suite: 1041 passed, 97% coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)