### PR TITLE
[#122] Fix: password length warning false positive for pre-flag accounts

### DIFF
--- a/app/auth_router.py
+++ b/app/auth_router.py
@@ -1116,12 +1116,14 @@ async def login_submit(
     if remember_me == "on":
         request.session["remember_me"] = True
 
-    # Show a soft notice on the home page if the stored password was set before
-    # the current minimum-length policy was adopted.  We cannot determine whether
-    # the plaintext password meets the policy from the hash alone, so we rely on
-    # the `password_meets_policy` flag that is written whenever a password is saved.
+    # At login time we have the plaintext password, so we can heal a missing
+    # password_meets_policy flag for accounts created before the flag was introduced,
+    # preventing false-positive upgrade notices for passwords that already meet policy.
     if not get_integration_credentials("admin").get("password_meets_policy"):
-        request.session["show_password_notice"] = True
+        if len(password) >= _MIN_PASSWORD_LEN:
+            save_integration_credentials("admin", password_meets_policy=True)
+        else:
+            request.session["show_password_notice"] = True
 
     # Sanitise the redirect target to prevent open-redirect attacks.
     next_url = _safe_next_url(request.query_params.get("next", "/home"))

--- a/tests/test_security_116.py
+++ b/tests/test_security_116.py
@@ -380,9 +380,77 @@ class TestLoginPasswordNotice:
 
     def test_home_hides_notice_when_policy_flag_set(self):
         """Home page must NOT show the notice when password already meets policy."""
-        # Change password to something ≥ 12 chars to set the flag
         from app.auth import change_password
         change_password("LongPassword123")
+
+        self.client.post(
+            "/login",
+            data={"username": "testadmin", "password": "LongPassword123"},
+            follow_redirects=False,
+        )
+        resp = self.client.get("/home")
+        assert resp.status_code == 200
+        assert "may not meet the current minimum" not in resp.text
+
+
+# ---------------------------------------------------------------------------
+# Login heals missing password_meets_policy flag (OP#122)
+# ---------------------------------------------------------------------------
+
+
+class TestLoginPolicyFlagHealing:
+    """Login must heal a missing password_meets_policy flag using the plaintext password."""
+
+    @pytest.fixture(autouse=True)
+    def setup(self, config_file, data_dir, monkeypatch):
+        monkeypatch.setenv("PORTAINER_URL", "https://portainer.test:9443")
+        monkeypatch.setenv("PORTAINER_API_KEY", "test-api-key")
+        monkeypatch.setenv("PORTAINER_VERIFY_SSL", "false")
+
+        from app.main import app
+        from app.auth import create_admin
+
+        create_admin(username="testadmin", password="LongPassword123", totp_secret=None)
+        self.client = TestClient(app, raise_server_exceptions=True)
+
+    def _strip_policy_flag(self):
+        """Remove password_meets_policy from the store to simulate a pre-flag account."""
+        from app.credentials import save_integration_credentials
+        save_integration_credentials("admin", password_meets_policy="")
+
+    def test_no_notice_for_long_password_missing_flag(self):
+        """Login with a ≥12-char password must suppress the notice even when flag is absent."""
+        self._strip_policy_flag()
+        self.client.post(
+            "/login",
+            data={"username": "testadmin", "password": "LongPassword123"},
+            follow_redirects=False,
+        )
+        resp = self.client.get("/home")
+        assert resp.status_code == 200
+        assert "may not meet the current minimum" not in resp.text
+
+    def test_flag_healed_to_true_on_long_password_login(self):
+        """Login with a ≥12-char password must write password_meets_policy=True."""
+        from app.credentials import get_integration_credentials
+        self._strip_policy_flag()
+        assert get_integration_credentials("admin").get("password_meets_policy") is None
+
+        self.client.post(
+            "/login",
+            data={"username": "testadmin", "password": "LongPassword123"},
+            follow_redirects=False,
+        )
+        assert get_integration_credentials("admin").get("password_meets_policy") is True
+
+    def test_notice_shown_for_short_password_missing_flag(self):
+        """Login with a <12-char password must still show the notice when flag is absent."""
+        from app.auth import create_admin
+        from app.credentials import save_integration_credentials
+
+        # Re-create admin with a short password (bypassing UI validation) and strip flag.
+        create_admin(username="testadmin", password="short1234", totp_secret=None)
+        save_integration_credentials("admin", password_meets_policy="")
 
         self.client.post(
             "/login",
@@ -391,5 +459,4 @@ class TestLoginPasswordNotice:
         )
         resp = self.client.get("/home")
         assert resp.status_code == 200
-        # Notice banner should not be present — check for the specific notice text
-        assert "may not meet the current minimum" not in resp.text
+        assert "may not meet the current minimum" in resp.text


### PR DESCRIPTION
OP#122

## Summary
- At login the server now has the plaintext password, so we use it to heal a missing `password_meets_policy` flag for accounts created before the flag was introduced
- If the submitted password is ≥ 12 chars the flag is written to `True` and the notice is suppressed; otherwise the notice is shown as intended
- Fixes the false-positive upgrade banner shown for any account whose long password pre-dates the `password_meets_policy` field

## Test plan
- [ ] `tests/test_security_116.py::TestLoginPolicyFlagHealing::test_no_notice_for_long_password_missing_flag` — no banner for ≥12-char password when flag is absent
- [ ] `tests/test_security_116.py::TestLoginPolicyFlagHealing::test_flag_healed_to_true_on_long_password_login` — flag written to `True` on login
- [ ] `tests/test_security_116.py::TestLoginPolicyFlagHealing::test_notice_shown_for_short_password_missing_flag` — banner still shown for <12-char password
- [ ] Full suite: `python -m pytest` → 1059 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)