### PR TITLE
Integration TLS trust model (TOFU certificate pinning)

### DIFF
--- a/app/__version__.py
+++ b/app/__version__.py
@@ -1,1 +1,1 @@
-APP_VERSION = "0.30.1"
+APP_VERSION = "0.31.0"

--- a/app/admin.py
+++ b/app/admin.py
@@ -47,6 +47,7 @@ from .config_manager import (
     set_docker_monitoring,
     update_host,
 )
+from .cert_utils import build_pinned_ssl_ctx, cert_info, fetch_server_cert, fingerprint
 from .proxmox_client import ProxmoxClient
 from .credentials import (
     credential_status,
@@ -65,6 +66,37 @@ from .templates_env import make_templates
 
 router = APIRouter(prefix="/admin")
 templates = make_templates()
+
+
+def _is_ssl_cert_error(exc: Exception) -> bool:
+    msg = str(exc)
+    if "CERTIFICATE_VERIFY_FAILED" in msg or "certificate verify failed" in msg.lower():
+        return True
+    cause = getattr(exc, "__cause__", None) or getattr(exc, "__context__", None)
+    if cause and cause is not exc:
+        return _is_ssl_cert_error(cause)
+    return False
+
+
+def _cert_trust_response(
+    request: Request,
+    info: dict,
+    test_url: str,
+    include_ids: str,
+    target_id: str,
+    changed: bool = False,
+):
+    return templates.TemplateResponse(
+        "partials/cert_trust_prompt.html",
+        {
+            "request": request,
+            "info": info,
+            "test_url": test_url,
+            "include_ids": include_ids,
+            "target_id": target_id,
+            "changed": changed,
+        },
+    )
 
 
 def _connection_status() -> dict:
@@ -112,7 +144,8 @@ def _integration_status() -> dict:
         "proxmox_token_id": px_creds.get("token_id", ""),
         "proxmox_secret_set": bool(px_creds.get("secret") or px_creds.get("api_token")),
         "proxmox_configured": bool(px_cfg.get("url") and (px_creds.get("secret") or px_creds.get("api_token"))),
-        "proxmox_verify_ssl": px_cfg.get("verify_ssl", False),
+        "proxmox_pinned": bool(px_cfg.get("pinned_fingerprint")),
+        "proxmox_cert_fingerprint": px_cfg.get("pinned_fingerprint", ""),
         "proxmox_ssh_user": px_creds.get("ssh_user", ""),
         "proxmox_ssh_key": px_creds.get("ssh_key", ""),
         "proxmox_ssh_password_set": bool(px_creds.get("ssh_password")),
@@ -121,18 +154,22 @@ def _integration_status() -> dict:
         "pbs_token_id": pbs_creds.get("token_id", ""),
         "pbs_secret_set": bool(pbs_creds.get("secret") or pbs_creds.get("api_token")),
         "pbs_configured": bool(pbs_cfg.get("url") and (pbs_creds.get("secret") or pbs_creds.get("api_token"))),
-        "pbs_verify_ssl": pbs_cfg.get("verify_ssl", False),
+        "pbs_pinned": bool(pbs_cfg.get("pinned_fingerprint")),
+        "pbs_cert_fingerprint": pbs_cfg.get("pinned_fingerprint", ""),
         "opnsense_url": opn_cfg.get("url", ""),
         "opnsense_configured": bool(opn_cfg.get("url") and opn_creds.get("api_key")),
-        "opnsense_verify_ssl": opn_cfg.get("verify_ssl", False),
+        "opnsense_pinned": bool(opn_cfg.get("pinned_fingerprint")),
+        "opnsense_cert_fingerprint": opn_cfg.get("pinned_fingerprint", ""),
         "pfsense_url": pf_cfg.get("url", ""),
         "pfsense_configured": bool(pf_cfg.get("url") and pf_creds.get("api_key")),
-        "pfsense_verify_ssl": pf_cfg.get("verify_ssl", False),
+        "pfsense_pinned": bool(pf_cfg.get("pinned_fingerprint")),
+        "pfsense_cert_fingerprint": pf_cfg.get("pinned_fingerprint", ""),
         "ha_url": ha_cfg.get("url", ""),
         "ha_configured": bool(ha_cfg.get("url") and ha_creds.get("token")),
         "portainer_url": port_cfg.get("url", ""),
         "portainer_key_set": bool(port_creds.get("api_key")),
-        "portainer_verify_ssl": port_cfg.get("verify_ssl", False),
+        "portainer_pinned": bool(port_cfg.get("pinned_fingerprint")),
+        "portainer_cert_fingerprint": port_cfg.get("pinned_fingerprint", ""),
         "portainer_configured": bool(port_cfg.get("url") and port_creds.get("api_key")),
         "dockerhub_user": dh_cfg.get("username", ""),
         "dockerhub_token_set": bool(dh_creds.get("token")),
@@ -179,35 +216,68 @@ async def admin_integrations_test_portainer(
     request: Request,
     portainer_url: str = Form(""),
     portainer_api_key: str = Form(""),
-    portainer_verify_ssl: str = Form(""),
+    trust_accepted: str = Form(""),
 ) -> HTMLResponse:
     """Test Portainer connection — same logic as connections test, returns inline HTML."""
     url = portainer_url.strip().rstrip("/")
     key = portainer_api_key.strip()
-    verify_ssl = portainer_verify_ssl == "on"
     if not url or not key:
         return HTMLResponse(
             '<span class="text-amber-400 text-sm">Enter a URL and API token first.</span>'
         )
+
+    if trust_accepted == "1":
+        pem = request.session.get("pending_cert_portainer", "")
+        if not pem:
+            return HTMLResponse(
+                '<span class="text-red-400 text-sm">&#10007; Session expired — re-test to try again.</span>'
+            )
+    else:
+        pem = get_portainer_config().get("pinned_cert_pem", "")
+
     try:
         from .portainer_client import PortainerClient
 
-        client = PortainerClient(url=url, api_key=key, verify_ssl=verify_ssl)
+        client = PortainerClient(url=url, api_key=key, pinned_cert_pem=pem)
         endpoints = await client.get_endpoints()
         count = len(endpoints)
+        if trust_accepted == "1":
+            fp = fingerprint(pem)
+            request.session["confirmed_cert_portainer"] = {"pem": pem, "fingerprint": fp}
+            request.session.pop("pending_cert_portainer", None)
+            return HTMLResponse(
+                f'<span class="text-green-400 text-sm">&#10003; Connected — '
+                f'{count} environment{"s" if count != 1 else ""} found. '
+                f'Certificate pinned. Click Save to apply.</span>'
+            )
         return HTMLResponse(
             f'<span class="text-green-400 text-sm">&#10003; Connected — '
             f'{count} environment{"s" if count != 1 else ""} found. '
             f'Click Save to apply.</span>'
         )
     except Exception as exc:
+        if _is_ssl_cert_error(exc):
+            changed = bool(pem)
+            try:
+                new_pem = fetch_server_cert(url)
+                info = cert_info(new_pem)
+                request.session["pending_cert_portainer"] = new_pem
+            except Exception:
+                return HTMLResponse(
+                    '<span class="text-red-400 text-sm">&#10007; SSL certificate error — could not fetch certificate details.</span>'
+                )
+            return _cert_trust_response(
+                request, info,
+                test_url="/admin/integrations/portainer/test",
+                include_ids="#port-url,#port-key",
+                target_id="#portainer-test-result",
+                changed=changed,
+            )
         msg = str(exc)
         if "401" in msg or "403" in msg:
             hint = "Invalid API token — check you copied it correctly."
         elif "Name or service not known" in msg or "connect" in msg.lower():
             hint = "Can't reach that address — check the URL and that Portainer is running."
-        elif "SSL" in msg or "certificate" in msg.lower():
-            hint = "SSL error — try disabling SSL verification."
         else:
             hint = msg
         return HTMLResponse(f'<span class="text-red-400 text-sm">&#10007; {hint}</span>')
@@ -218,13 +288,15 @@ async def admin_integrations_save_portainer(
     request: Request,
     portainer_url: str = Form(""),
     portainer_api_key: str = Form(""),
-    portainer_verify_ssl: str = Form(""),
 ) -> HTMLResponse:
     url = portainer_url.strip().rstrip("/")
     key = portainer_api_key.strip()
-    verify_ssl = portainer_verify_ssl == "on"
-
-    save_portainer_config(url=url, verify_ssl=verify_ssl)
+    confirmed = request.session.pop("confirmed_cert_portainer", {})
+    save_portainer_config(
+        url=url,
+        pinned_cert_pem=confirmed.get("pem", ""),
+        pinned_fingerprint=confirmed.get("fingerprint", ""),
+    )
     if key:
         save_integration_credentials("portainer", api_key=key)
         audit(request, "credential.save", target="portainer")
@@ -272,13 +344,13 @@ async def admin_proxmox_discover(request: Request) -> HTMLResponse:
         token = f"{api_user}!{api_token}" if api_user else api_token
     else:
         token = f"{token_id}={secret}"
-    verify_ssl = cfg.get("verify_ssl", False)
+    pinned_pem = cfg.get("pinned_cert_pem", "")
     if not url or not token:
         return HTMLResponse(
             '<span style="font-size:12px;color:#f85149">Proxmox not configured.</span>'
         )
     try:
-        client = ProxmoxClient(url=url, api_token=token, verify_ssl=verify_ssl)
+        client = ProxmoxClient(url=url, api_token=token, pinned_cert_pem=pinned_pem)
         resources = await client.discover_resources()
         return templates.TemplateResponse(
             "partials/admin_proxmox_discover.html",
@@ -375,7 +447,7 @@ async def admin_proxmox_add_node_host(request: Request) -> HTMLResponse:
         token = f"{api_user}!{api_token}" if api_user else api_token
     else:
         token = f"{token_id}={secret}"
-    verify_ssl = cfg.get("verify_ssl", False)
+    pinned_pem = cfg.get("pinned_cert_pem", "")
     if not url or not token:
         return HTMLResponse(
             '<span style="font-size:12px;color:#f85149">Proxmox not configured.</span>'
@@ -385,7 +457,7 @@ async def admin_proxmox_add_node_host(request: Request) -> HTMLResponse:
     px_host = urllib.parse.urlparse(url).hostname or ""
 
     try:
-        client = ProxmoxClient(url=url, api_token=token, verify_ssl=verify_ssl)
+        client = ProxmoxClient(url=url, api_token=token, pinned_cert_pem=pinned_pem)
         nodes = await client.get_nodes()
     except Exception as exc:
         return HTMLResponse(
@@ -744,29 +816,64 @@ async def admin_test_portainer(
     request: Request,
     portainer_url: str = Form(""),
     portainer_api_key: str = Form(""),
-    portainer_verify_ssl: str = Form(""),
+    trust_accepted: str = Form(""),
 ) -> HTMLResponse:
     """Test Portainer connection with provided (unsaved) values."""
     url = portainer_url.strip().rstrip("/")
     key = portainer_api_key.strip()
-    verify_ssl = portainer_verify_ssl == "on"
 
     if not url or not key:
         return HTMLResponse(
             '<span class="text-amber-400 text-sm">Enter a URL and API token first.</span>'
         )
+
+    if trust_accepted == "1":
+        pem = request.session.get("pending_cert_portainer", "")
+        if not pem:
+            return HTMLResponse(
+                '<span class="text-red-400 text-sm">&#10007; Session expired — re-test to try again.</span>'
+            )
+    else:
+        pem = get_portainer_config().get("pinned_cert_pem", "")
+
     try:
         from .portainer_client import PortainerClient
 
-        client = PortainerClient(url=url, api_key=key, verify_ssl=verify_ssl)
+        client = PortainerClient(url=url, api_key=key, pinned_cert_pem=pem)
         endpoints = await client.get_endpoints()
         count = len(endpoints)
+        if trust_accepted == "1":
+            fp = fingerprint(pem)
+            request.session["confirmed_cert_portainer"] = {"pem": pem, "fingerprint": fp}
+            request.session.pop("pending_cert_portainer", None)
+            return HTMLResponse(
+                f'<span class="text-green-400 text-sm">&#10003; Connected — '
+                f'{count} environment{"s" if count != 1 else ""} found. '
+                f'Certificate pinned. Click Save to apply.</span>'
+            )
         return HTMLResponse(
             f'<span class="text-green-400 text-sm">&#10003; Connected — '
             f'{count} environment{"s" if count != 1 else ""} found. '
             f'Click Save to apply.</span>'
         )
     except Exception as exc:
+        if _is_ssl_cert_error(exc):
+            changed = bool(pem)
+            try:
+                new_pem = fetch_server_cert(url)
+                info = cert_info(new_pem)
+                request.session["pending_cert_portainer"] = new_pem
+            except Exception:
+                return HTMLResponse(
+                    '<span class="text-red-400 text-sm">&#10007; SSL certificate error — could not fetch certificate details.</span>'
+                )
+            return _cert_trust_response(
+                request, info,
+                test_url="/admin/connections/portainer/test",
+                include_ids="#port-url,#port-key",
+                target_id="#portainer-test-result",
+                changed=changed,
+            )
         msg = str(exc)
         if "401" in msg or "403" in msg:
             hint = "Invalid API token — check you copied it correctly."
@@ -776,8 +883,6 @@ async def admin_test_portainer(
             or "connect" in msg.lower()
         ):
             hint = "Can't reach that address — check the URL and that Portainer is running."
-        elif "SSL" in msg or "certificate" in msg.lower():
-            hint = "SSL error — try enabling &ldquo;Ignore SSL warnings&rdquo; below."
         else:
             hint = msg
         return HTMLResponse(
@@ -790,13 +895,15 @@ async def admin_save_portainer(
     request: Request,
     portainer_url: str = Form(""),
     portainer_api_key: str = Form(""),
-    portainer_verify_ssl: str = Form(""),
 ) -> HTMLResponse:
     url = portainer_url.strip().rstrip("/")
     key = portainer_api_key.strip()
-    verify_ssl = portainer_verify_ssl == "on"
-
-    save_portainer_config(url=url, verify_ssl=verify_ssl)
+    confirmed = request.session.pop("confirmed_cert_portainer", {})
+    save_portainer_config(
+        url=url,
+        pinned_cert_pem=confirmed.get("pem", ""),
+        pinned_fingerprint=confirmed.get("fingerprint", ""),
+    )
     if key:
         save_integration_credentials("portainer", api_key=key)
 

--- a/app/auth_router.py
+++ b/app/auth_router.py
@@ -65,11 +65,45 @@ from .audit import audit
 from .proxmox_client import ProxmoxClient
 from .ssh_client import discover_containers, verify_connection
 from .backend_loader import reload_backends
+from .cert_utils import build_pinned_ssl_ctx, cert_info, fetch_server_cert, fingerprint
 from .httpx_client import make_client
 from .templates_env import make_templates
 
 router = APIRouter()
 templates = make_templates()
+
+
+def _is_ssl_cert_error(exc: Exception) -> bool:
+    """Return True if exc is (or wraps) an SSL certificate verification failure."""
+    msg = str(exc)
+    if "CERTIFICATE_VERIFY_FAILED" in msg or "certificate verify failed" in msg.lower():
+        return True
+    cause = getattr(exc, "__cause__", None) or getattr(exc, "__context__", None)
+    if cause and cause is not exc:
+        return _is_ssl_cert_error(cause)
+    return False
+
+
+def _cert_trust_response(
+    request: Request,
+    info: dict,
+    test_url: str,
+    include_ids: str,
+    target_id: str,
+    changed: bool = False,
+):
+    """Render the cert-trust prompt partial."""
+    return templates.TemplateResponse(
+        "partials/cert_trust_prompt.html",
+        {
+            "request": request,
+            "info": info,
+            "test_url": test_url,
+            "include_ids": include_ids,
+            "target_id": target_id,
+            "changed": changed,
+        },
+    )
 
 
 def _ssh_section_ctx(request: Request, **extra) -> dict:
@@ -391,8 +425,8 @@ async def setup_connect(request: Request) -> HTMLResponse:
 # --- Proxmox ---
 
 
-def _setup_proxmox_client_parts() -> tuple[str, str, bool]:
-    """Return (url, token, verify_ssl) from saved Proxmox config."""
+def _setup_proxmox_client_parts() -> tuple[str, str, str]:
+    """Return (url, token, pinned_cert_pem) from saved Proxmox config."""
     cfg = get_proxmox_config()
     creds = get_integration_credentials("proxmox")
     url = cfg.get("url", "")
@@ -404,7 +438,7 @@ def _setup_proxmox_client_parts() -> tuple[str, str, bool]:
         token = f"{api_user}!{api_token}" if api_user else api_token
     else:
         token = f"{token_id}={secret}"
-    return url, token, cfg.get("verify_ssl", False)
+    return url, token, cfg.get("pinned_cert_pem", "")
 
 
 def _proxmox_lxc_step(request: Request, resources: list[dict]) -> HTMLResponse:
@@ -447,32 +481,63 @@ async def setup_test_proxmox(
     proxmox_url: str = Form(""),
     proxmox_token_id: str = Form(""),
     proxmox_secret: str = Form(""),
-    proxmox_verify_ssl: str = Form(""),
+    trust_accepted: str = Form(""),
 ) -> HTMLResponse:
     url = proxmox_url.strip().rstrip("/")
     token_id = proxmox_token_id.strip()
     secret = proxmox_secret.strip()
-    verify_ssl = proxmox_verify_ssl == "on"
     if not url or not token_id or not secret:
         return HTMLResponse(
             '<span class="text-amber-400 text-sm">Enter a URL, Token ID, and Secret first.</span>'
         )
     token = f"{token_id}={secret}"
+
+    if trust_accepted == "1":
+        pem = request.session.get("pending_cert_proxmox", "")
+        if not pem:
+            return HTMLResponse(
+                '<span class="text-red-400 text-sm">&#10007; Session expired — re-test to try again.</span>'
+            )
+    else:
+        pem = get_proxmox_config().get("pinned_cert_pem", "")
+
     try:
-        client = ProxmoxClient(url=url, api_token=token, verify_ssl=verify_ssl)
+        client = ProxmoxClient(url=url, api_token=token, pinned_cert_pem=pem)
         version = await client.get_version()
         ver = version.get("version", "")
+        if trust_accepted == "1":
+            fp = fingerprint(pem)
+            request.session["confirmed_cert_proxmox"] = {"pem": pem, "fingerprint": fp}
+            request.session.pop("pending_cert_proxmox", None)
+            return HTMLResponse(
+                f'<span class="text-green-400 text-sm">&#10003; Connected — Proxmox VE {ver}. Certificate pinned. Click Save to continue.</span>'
+            )
         return HTMLResponse(
             f'<span class="text-green-400 text-sm">&#10003; Connected — Proxmox VE {ver}. Click Save to continue.</span>'
         )
     except Exception as exc:
+        if _is_ssl_cert_error(exc):
+            changed = bool(pem)
+            try:
+                new_pem = fetch_server_cert(url)
+                info = cert_info(new_pem)
+                request.session["pending_cert_proxmox"] = new_pem
+            except Exception:
+                return HTMLResponse(
+                    '<span class="text-red-400 text-sm">&#10007; SSL certificate error — could not fetch certificate details.</span>'
+                )
+            return _cert_trust_response(
+                request, info,
+                test_url="/setup/connect/proxmox/test",
+                include_ids="#proxmox-url,#proxmox-api-user,#proxmox-token-id,#proxmox-secret",
+                target_id="#proxmox-test-result",
+                changed=changed,
+            )
         msg = str(exc)
         if "401" in msg or "403" in msg:
             hint = "Invalid API token."
         elif "connect" in msg.lower() or "Name or service" in msg:
             hint = "Can&#39;t reach that address — check the URL."
-        elif "SSL" in msg or "certificate" in msg.lower():
-            hint = "SSL error — try disabling SSL verification."
         else:
             hint = msg[:120]
         return HTMLResponse(f'<span class="text-red-400 text-sm">&#10007; {hint}</span>')
@@ -484,13 +549,16 @@ async def setup_save_proxmox(
     proxmox_url: str = Form(""),
     proxmox_token_id: str = Form(""),
     proxmox_secret: str = Form(""),
-    proxmox_verify_ssl: str = Form(""),
 ) -> HTMLResponse:
     url = proxmox_url.strip().rstrip("/")
     token_id = proxmox_token_id.strip()
     secret = proxmox_secret.strip()
-    verify_ssl = proxmox_verify_ssl == "on"
-    save_proxmox_config(url=url, verify_ssl=verify_ssl)
+    confirmed = request.session.pop("confirmed_cert_proxmox", {})
+    save_proxmox_config(
+        url=url,
+        pinned_cert_pem=confirmed.get("pem", ""),
+        pinned_fingerprint=confirmed.get("fingerprint", ""),
+    )
     cred_kwargs: dict = {}
     if token_id:
         cred_kwargs["token_id"] = token_id
@@ -506,7 +574,8 @@ async def setup_save_proxmox(
         try:
             import urllib.parse
             token = f"{token_id}={secret}"
-            client = ProxmoxClient(url=url, api_token=token, verify_ssl=verify_ssl)
+            pinned_pem = get_proxmox_config().get("pinned_cert_pem", "")
+            client = ProxmoxClient(url=url, api_token=token, pinned_cert_pem=pinned_pem)
             nodes = await client.get_nodes()
             resources = await client.discover_resources()
             request.session["setup_proxmox_resources"] = resources
@@ -536,11 +605,11 @@ async def setup_save_proxmox(
 async def setup_proxmox_discover(request: Request) -> HTMLResponse:
     """For already-connected Proxmox: discover resources and enter the guided flow."""
     import urllib.parse
-    url, token, verify_ssl = _setup_proxmox_client_parts()
+    url, token, pinned_pem = _setup_proxmox_client_parts()
     if not url or not token:
         return HTMLResponse('<p class="text-sm text-red-400">Proxmox not configured.</p>')
     try:
-        client = ProxmoxClient(url=url, api_token=token, verify_ssl=verify_ssl)
+        client = ProxmoxClient(url=url, api_token=token, pinned_cert_pem=pinned_pem)
         nodes = await client.get_nodes()
         resources = await client.discover_resources()
         request.session["setup_proxmox_resources"] = resources
@@ -803,34 +872,68 @@ async def setup_test_pbs(
     pbs_api_user: str = Form(""),
     pbs_token_id: str = Form(""),
     pbs_secret: str = Form(""),
-    pbs_verify_ssl: str = Form(""),
+    trust_accepted: str = Form(""),
 ) -> HTMLResponse:
     url = pbs_url.strip().rstrip("/")
     token_id = pbs_token_id.strip()
     secret = pbs_secret.strip()
-    verify_ssl = pbs_verify_ssl == "on"
     if not url or not token_id or not secret:
         return HTMLResponse(
             '<span class="text-amber-400 text-sm">Enter a URL, Token ID, and Secret first.</span>'
         )
     # PBS auth: PBSAPIToken=<tokenid>:<secret>  (colon separator, not equals)
+    import logging
+    _log = logging.getLogger(__name__)
+
+    if trust_accepted == "1":
+        pem = request.session.get("pending_cert_pbs", "")
+        if not pem:
+            return HTMLResponse(
+                '<span class="text-red-400 text-sm">&#10007; Session expired — re-test to try again.</span>'
+            )
+    else:
+        pem = get_pbs_config().get("pinned_cert_pem", "")
+
+    ssl_ctx = build_pinned_ssl_ctx(pem) if pem else None
     try:
-        async with make_client(verify=verify_ssl) as c:
+        async with make_client(ssl_context=ssl_ctx) as c:
             resp = await c.get(
                 f"{url}/api2/json/version",
                 headers={"Authorization": f"PBSAPIToken={token_id}:{secret}"},
             )
             resp.raise_for_status()
             ver = resp.json().get("data", {}).get("version", "")
-        import logging
-        logging.getLogger(__name__).info("PBS connected: version %s", ver)
+        _log.info("PBS connected: version %s", ver)
+        if trust_accepted == "1":
+            fp = fingerprint(pem)
+            request.session["confirmed_cert_pbs"] = {"pem": pem, "fingerprint": fp}
+            request.session.pop("pending_cert_pbs", None)
+            return HTMLResponse(
+                f'<span class="text-green-400 text-sm">&#10003; Connected — Proxmox Backup Server {ver}. Certificate pinned. Click Save to continue.</span>'
+            )
         return HTMLResponse(
             f'<span class="text-green-400 text-sm">&#10003; Connected — Proxmox Backup Server {ver}. Click Save to continue.</span>'
         )
     except Exception as exc:
+        if _is_ssl_cert_error(exc):
+            changed = bool(pem)
+            try:
+                new_pem = fetch_server_cert(url)
+                info = cert_info(new_pem)
+                request.session["pending_cert_pbs"] = new_pem
+            except Exception:
+                return HTMLResponse(
+                    '<span class="text-red-400 text-sm">&#10007; SSL certificate error — could not fetch certificate details.</span>'
+                )
+            return _cert_trust_response(
+                request, info,
+                test_url="/setup/connect/pbs/test",
+                include_ids="#pbs-url,#pbs-user,#pbs-token-id,#pbs-secret",
+                target_id="#pbs-test-result",
+                changed=changed,
+            )
         msg = str(exc)
-        import logging
-        logging.getLogger(__name__).warning("PBS connection failed: %s", msg)
+        _log.warning("PBS connection failed: %s", msg)
         hint = "Invalid Token ID or Secret." if ("401" in msg or "403" in msg) else msg[:120]
         return HTMLResponse(
             f'<span class="text-red-400 text-sm">&#10007; {hint}</span>'
@@ -844,14 +947,17 @@ async def setup_save_pbs(
     pbs_api_user: str = Form(""),
     pbs_token_id: str = Form(""),
     pbs_secret: str = Form(""),
-    pbs_verify_ssl: str = Form(""),
 ) -> HTMLResponse:
     url = pbs_url.strip().rstrip("/")
     api_user = pbs_api_user.strip()
     token_id = pbs_token_id.strip()
     secret = pbs_secret.strip()
-    verify_ssl = pbs_verify_ssl == "on"
-    save_pbs_config(url=url, verify_ssl=verify_ssl)
+    confirmed = request.session.pop("confirmed_cert_pbs", {})
+    save_pbs_config(
+        url=url,
+        pinned_cert_pem=confirmed.get("pem", ""),
+        pinned_fingerprint=confirmed.get("fingerprint", ""),
+    )
     if api_user or token_id or secret:
         save_integration_credentials(
             "proxmox_backup",
@@ -874,27 +980,61 @@ async def setup_test_opnsense(
     opnsense_url: str = Form(""),
     opnsense_api_key: str = Form(""),
     opnsense_api_secret: str = Form(""),
-    opnsense_verify_ssl: str = Form(""),
+    trust_accepted: str = Form(""),
 ) -> HTMLResponse:
     url = opnsense_url.strip().rstrip("/")
     key = opnsense_api_key.strip()
     secret = opnsense_api_secret.strip()
-    verify_ssl = opnsense_verify_ssl == "on"
     if not url or not key or not secret:
         return HTMLResponse(
             '<span class="text-amber-400 text-sm">Enter URL, API key, and API secret first.</span>'
         )
+
+    if trust_accepted == "1":
+        pem = request.session.get("pending_cert_opnsense", "")
+        if not pem:
+            return HTMLResponse(
+                '<span class="text-red-400 text-sm">&#10007; Session expired — re-test to try again.</span>'
+            )
+    else:
+        pem = get_opnsense_config().get("pinned_cert_pem", "")
+
+    ssl_ctx = build_pinned_ssl_ctx(pem) if pem else None
     try:
-        async with make_client(verify=verify_ssl) as c:
+        async with make_client(ssl_context=ssl_ctx) as c:
             resp = await c.get(
                 f"{url}/api/core/firmware/info",
                 auth=(key, secret),
             )
             resp.raise_for_status()
+        if trust_accepted == "1":
+            fp = fingerprint(pem)
+            request.session["confirmed_cert_opnsense"] = {"pem": pem, "fingerprint": fp}
+            request.session.pop("pending_cert_opnsense", None)
+            return HTMLResponse(
+                '<span class="text-green-400 text-sm">&#10003; Connected. Certificate pinned. Click Save to continue.</span>'
+            )
         return HTMLResponse(
             '<span class="text-green-400 text-sm">&#10003; Connected. Click Save to continue.</span>'
         )
     except Exception as exc:
+        if _is_ssl_cert_error(exc):
+            changed = bool(pem)
+            try:
+                new_pem = fetch_server_cert(url)
+                info = cert_info(new_pem)
+                request.session["pending_cert_opnsense"] = new_pem
+            except Exception:
+                return HTMLResponse(
+                    '<span class="text-red-400 text-sm">&#10007; SSL certificate error — could not fetch certificate details.</span>'
+                )
+            return _cert_trust_response(
+                request, info,
+                test_url="/setup/connect/opnsense/test",
+                include_ids="#opn-url,#opn-key,#opn-secret",
+                target_id="#opnsense-test-result",
+                changed=changed,
+            )
         msg = str(exc)
         hint = (
             "Invalid API key or secret."
@@ -912,13 +1052,16 @@ async def setup_save_opnsense(
     opnsense_url: str = Form(""),
     opnsense_api_key: str = Form(""),
     opnsense_api_secret: str = Form(""),
-    opnsense_verify_ssl: str = Form(""),
 ) -> HTMLResponse:
     url = opnsense_url.strip().rstrip("/")
     key = opnsense_api_key.strip()
     secret = opnsense_api_secret.strip()
-    verify_ssl = opnsense_verify_ssl == "on"
-    save_opnsense_config(url=url, verify_ssl=verify_ssl)
+    confirmed = request.session.pop("confirmed_cert_opnsense", {})
+    save_opnsense_config(
+        url=url,
+        pinned_cert_pem=confirmed.get("pem", ""),
+        pinned_fingerprint=confirmed.get("fingerprint", ""),
+    )
     if key and secret:
         save_integration_credentials("opnsense", api_key=key, api_secret=secret)
     _queue_integration_host(request, "opnsense", "OPNsense", url)
@@ -935,26 +1078,60 @@ async def setup_test_pfsense(
     request: Request,
     pfsense_url: str = Form(""),
     pfsense_api_key: str = Form(""),
-    pfsense_verify_ssl: str = Form(""),
+    trust_accepted: str = Form(""),
 ) -> HTMLResponse:
     url = pfsense_url.strip().rstrip("/")
     key = pfsense_api_key.strip()
-    verify_ssl = pfsense_verify_ssl == "on"
     if not url or not key:
         return HTMLResponse(
             '<span class="text-amber-400 text-sm">Enter a URL and API key first.</span>'
         )
+
+    if trust_accepted == "1":
+        pem = request.session.get("pending_cert_pfsense", "")
+        if not pem:
+            return HTMLResponse(
+                '<span class="text-red-400 text-sm">&#10007; Session expired — re-test to try again.</span>'
+            )
+    else:
+        pem = get_pfsense_config().get("pinned_cert_pem", "")
+
+    ssl_ctx = build_pinned_ssl_ctx(pem) if pem else None
     try:
-        async with make_client(verify=verify_ssl) as c:
+        async with make_client(ssl_context=ssl_ctx) as c:
             resp = await c.get(
                 f"{url}/api/v1/system/version",
                 headers={"Authorization": key},
             )
             resp.raise_for_status()
+        if trust_accepted == "1":
+            fp = fingerprint(pem)
+            request.session["confirmed_cert_pfsense"] = {"pem": pem, "fingerprint": fp}
+            request.session.pop("pending_cert_pfsense", None)
+            return HTMLResponse(
+                '<span class="text-green-400 text-sm">&#10003; Connected. Certificate pinned. Click Save to continue.</span>'
+            )
         return HTMLResponse(
             '<span class="text-green-400 text-sm">&#10003; Connected. Click Save to continue.</span>'
         )
     except Exception as exc:
+        if _is_ssl_cert_error(exc):
+            changed = bool(pem)
+            try:
+                new_pem = fetch_server_cert(url)
+                info = cert_info(new_pem)
+                request.session["pending_cert_pfsense"] = new_pem
+            except Exception:
+                return HTMLResponse(
+                    '<span class="text-red-400 text-sm">&#10007; SSL certificate error — could not fetch certificate details.</span>'
+                )
+            return _cert_trust_response(
+                request, info,
+                test_url="/setup/connect/pfsense/test",
+                include_ids="#pf-url,#pf-key",
+                target_id="#pfsense-test-result",
+                changed=changed,
+            )
         msg = str(exc)
         hint = "Invalid API key." if ("401" in msg or "403" in msg) else msg[:120]
         return HTMLResponse(
@@ -967,12 +1144,15 @@ async def setup_save_pfsense(
     request: Request,
     pfsense_url: str = Form(""),
     pfsense_api_key: str = Form(""),
-    pfsense_verify_ssl: str = Form(""),
 ) -> HTMLResponse:
     url = pfsense_url.strip().rstrip("/")
     key = pfsense_api_key.strip()
-    verify_ssl = pfsense_verify_ssl == "on"
-    save_pfsense_config(url=url, verify_ssl=verify_ssl)
+    confirmed = request.session.pop("confirmed_cert_pfsense", {})
+    save_pfsense_config(
+        url=url,
+        pinned_cert_pem=confirmed.get("pem", ""),
+        pinned_fingerprint=confirmed.get("fingerprint", ""),
+    )
     if key:
         save_integration_credentials("pfsense", api_key=key)
     _queue_integration_host(request, "pfsense", "pfSense", url)
@@ -1546,32 +1726,63 @@ async def setup_test_portainer(
     request: Request,
     portainer_url: str = Form(""),
     portainer_api_key: str = Form(""),
-    portainer_verify_ssl: str = Form(""),
+    trust_accepted: str = Form(""),
 ) -> HTMLResponse:
     url = portainer_url.strip().rstrip("/")
     key = portainer_api_key.strip()
-    verify_ssl = portainer_verify_ssl == "on"
     if not url or not key:
         return HTMLResponse(
             '<span class="text-amber-400 text-sm">Enter a URL and API token first.</span>'
         )
+
+    if trust_accepted == "1":
+        pem = request.session.get("pending_cert_portainer", "")
+        if not pem:
+            return HTMLResponse(
+                '<span class="text-red-400 text-sm">&#10007; Session expired — re-test to try again.</span>'
+            )
+    else:
+        pem = get_portainer_config().get("pinned_cert_pem", "")
+
     try:
         from .portainer_client import PortainerClient
 
-        client = PortainerClient(url=url, api_key=key, verify_ssl=verify_ssl)
+        client = PortainerClient(url=url, api_key=key, pinned_cert_pem=pem)
         endpoints = await client.get_endpoints()
         count = len(endpoints)
+        if trust_accepted == "1":
+            fp = fingerprint(pem)
+            request.session["confirmed_cert_portainer"] = {"pem": pem, "fingerprint": fp}
+            request.session.pop("pending_cert_portainer", None)
+            return HTMLResponse(
+                f'<span class="text-green-400 text-sm">&#10003; Connected — {count} environment{"s" if count != 1 else ""} found. Certificate pinned. Click Save to apply.</span>'
+            )
         return HTMLResponse(
             f'<span class="text-green-400 text-sm">&#10003; Connected — {count} environment{"s" if count != 1 else ""} found. Click Save to apply.</span>'
         )
     except Exception as exc:
+        if _is_ssl_cert_error(exc):
+            changed = bool(pem)
+            try:
+                new_pem = fetch_server_cert(url)
+                info = cert_info(new_pem)
+                request.session["pending_cert_portainer"] = new_pem
+            except Exception:
+                return HTMLResponse(
+                    '<span class="text-red-400 text-sm">&#10007; SSL certificate error — could not fetch certificate details.</span>'
+                )
+            return _cert_trust_response(
+                request, info,
+                test_url="/setup/portainer/test",
+                include_ids="[name='portainer_url'],[name='portainer_api_key']",
+                target_id="#portainer-test-result",
+                changed=changed,
+            )
         msg = str(exc)
         if "401" in msg or "403" in msg:
             hint = "Invalid API token."
         elif "connect" in msg.lower() or "Name or service" in msg:
             hint = "Can&#39;t reach that address — check the URL."
-        elif "SSL" in msg or "certificate" in msg.lower():
-            hint = "SSL error — try disabling SSL verification."
         else:
             hint = msg[:120]
         return HTMLResponse(
@@ -1584,12 +1795,15 @@ async def setup_save_portainer(
     request: Request,
     portainer_url: str = Form(""),
     portainer_api_key: str = Form(""),
-    portainer_verify_ssl: str = Form(""),
 ) -> HTMLResponse:
     url = portainer_url.strip().rstrip("/")
     key = portainer_api_key.strip()
-    verify_ssl = portainer_verify_ssl == "on"
-    save_portainer_config(url=url, verify_ssl=verify_ssl)
+    confirmed = request.session.pop("confirmed_cert_portainer", {})
+    save_portainer_config(
+        url=url,
+        pinned_cert_pem=confirmed.get("pem", ""),
+        pinned_fingerprint=confirmed.get("fingerprint", ""),
+    )
     if key:
         save_integration_credentials("portainer", api_key=key)
     await reload_backends()

--- a/app/backend_loader.py
+++ b/app/backend_loader.py
@@ -36,7 +36,7 @@ async def reload_backends() -> list:
     port_creds = get_integration_credentials("portainer")
     url = port_cfg.get("url", "")
     key = port_creds.get("api_key", "")
-    verify_ssl = port_cfg.get("verify_ssl", False)
+    pinned_pem = port_cfg.get("pinned_cert_pem", "")
 
     if url and key:
         from .portainer_client import PortainerClient
@@ -44,7 +44,7 @@ async def reload_backends() -> list:
 
         backends.append(
             PortainerBackend(
-                PortainerClient(url=url, api_key=key, verify_ssl=verify_ssl)
+                PortainerClient(url=url, api_key=key, pinned_cert_pem=pinned_pem)
             )
         )
 

--- a/app/cert_utils.py
+++ b/app/cert_utils.py
@@ -1,0 +1,74 @@
+"""
+TOFU (Trust On First Use) certificate pinning utilities.
+
+Handles cert fetching, fingerprint extraction, and building custom SSL contexts
+so integrations can pin self-signed certificates without disabling TLS entirely.
+"""
+import hashlib
+import socket
+import ssl
+from urllib.parse import urlparse
+
+from cryptography import x509
+from cryptography.hazmat.primitives.serialization import Encoding
+
+
+def fetch_server_cert(url: str) -> str:
+    """Fetch the leaf TLS certificate from a server without verifying it.
+
+    Returns the certificate as a PEM-encoded string.
+    Raises on connection failure.
+    """
+    parsed = urlparse(url)
+    host = parsed.hostname or ""
+    port = parsed.port or 443
+
+    ctx = ssl.create_default_context()
+    ctx.check_hostname = False
+    ctx.verify_mode = ssl.CERT_NONE
+
+    with socket.create_connection((host, port), timeout=10) as sock:
+        with ctx.wrap_socket(sock, server_hostname=host) as ssock:
+            der = ssock.getpeercert(binary_form=True)
+
+    cert = x509.load_der_x509_certificate(der)
+    return cert.public_bytes(Encoding.PEM).decode("ascii")
+
+
+def fingerprint(pem: str) -> str:
+    """Return the SHA-256 fingerprint of a PEM certificate as colon-separated hex."""
+    cert = x509.load_pem_x509_certificate(pem.encode())
+    der = cert.public_bytes(Encoding.DER)
+    digest = hashlib.sha256(der).hexdigest().upper()
+    return ":".join(digest[i : i + 2] for i in range(0, len(digest), 2))
+
+
+def cert_info(pem: str) -> dict:
+    """Parse a PEM certificate and return display fields for the TOFU UI."""
+    cert = x509.load_pem_x509_certificate(pem.encode())
+
+    def _cn(name: x509.Name) -> str:
+        attrs = name.get_attributes_for_oid(x509.NameOID.COMMON_NAME)
+        return attrs[0].value if attrs else str(name)
+
+    fp = fingerprint(pem)
+    return {
+        "fingerprint": fp,
+        "subject_cn": _cn(cert.subject),
+        "issuer_cn": _cn(cert.issuer),
+        "not_before": cert.not_valid_before_utc.strftime("%Y-%m-%d %H:%M UTC"),
+        "not_after": cert.not_valid_after_utc.strftime("%Y-%m-%d %H:%M UTC"),
+    }
+
+
+def build_pinned_ssl_ctx(pem: str) -> ssl.SSLContext:
+    """Return an SSLContext that trusts only the pinned certificate.
+
+    check_hostname is disabled because self-signed certs often use an IP
+    address that doesn't match the cert's CN/SAN.
+    """
+    ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+    ctx.check_hostname = False
+    ctx.verify_mode = ssl.CERT_REQUIRED
+    ctx.load_verify_locations(cadata=pem)
+    return ctx

--- a/app/config_manager.py
+++ b/app/config_manager.py
@@ -228,10 +228,21 @@ def get_portainer_config() -> dict:
     return load_config().get("portainer", {})
 
 
-def save_portainer_config(url: str, verify_ssl: bool) -> None:
+def save_portainer_config(
+    url: str,
+    pinned_cert_pem: str = "",
+    pinned_fingerprint: str = "",
+) -> None:
     config = load_config()
     if url:
-        config["portainer"] = {"url": url.rstrip("/"), "verify_ssl": verify_ssl}
+        existing = config.get("portainer", {})
+        pem = pinned_cert_pem or existing.get("pinned_cert_pem", "")
+        fp = pinned_fingerprint or existing.get("pinned_fingerprint", "")
+        entry: dict = {"url": url.rstrip("/")}
+        if pem:
+            entry["pinned_cert_pem"] = pem
+            entry["pinned_fingerprint"] = fp
+        config["portainer"] = entry
     else:
         config.pop("portainer", None)
     save_config(config)
@@ -325,10 +336,21 @@ def get_proxmox_config() -> dict:
     return load_config().get("proxmox", {})
 
 
-def save_proxmox_config(url: str, verify_ssl: bool) -> None:
+def save_proxmox_config(
+    url: str,
+    pinned_cert_pem: str = "",
+    pinned_fingerprint: str = "",
+) -> None:
     config = load_config()
     if url:
-        config["proxmox"] = {"url": url.rstrip("/"), "verify_ssl": verify_ssl}
+        existing = config.get("proxmox", {})
+        pem = pinned_cert_pem or existing.get("pinned_cert_pem", "")
+        fp = pinned_fingerprint or existing.get("pinned_fingerprint", "")
+        entry: dict = {"url": url.rstrip("/")}
+        if pem:
+            entry["pinned_cert_pem"] = pem
+            entry["pinned_fingerprint"] = fp
+        config["proxmox"] = entry
     else:
         config.pop("proxmox", None)
     save_config(config)
@@ -338,10 +360,21 @@ def get_pbs_config() -> dict:
     return load_config().get("proxmox_backup", {})
 
 
-def save_pbs_config(url: str, verify_ssl: bool) -> None:
+def save_pbs_config(
+    url: str,
+    pinned_cert_pem: str = "",
+    pinned_fingerprint: str = "",
+) -> None:
     config = load_config()
     if url:
-        config["proxmox_backup"] = {"url": url.rstrip("/"), "verify_ssl": verify_ssl}
+        existing = config.get("proxmox_backup", {})
+        pem = pinned_cert_pem or existing.get("pinned_cert_pem", "")
+        fp = pinned_fingerprint or existing.get("pinned_fingerprint", "")
+        entry: dict = {"url": url.rstrip("/")}
+        if pem:
+            entry["pinned_cert_pem"] = pem
+            entry["pinned_fingerprint"] = fp
+        config["proxmox_backup"] = entry
     else:
         config.pop("proxmox_backup", None)
     save_config(config)
@@ -351,10 +384,21 @@ def get_opnsense_config() -> dict:
     return load_config().get("opnsense", {})
 
 
-def save_opnsense_config(url: str, verify_ssl: bool) -> None:
+def save_opnsense_config(
+    url: str,
+    pinned_cert_pem: str = "",
+    pinned_fingerprint: str = "",
+) -> None:
     config = load_config()
     if url:
-        config["opnsense"] = {"url": url.rstrip("/"), "verify_ssl": verify_ssl}
+        existing = config.get("opnsense", {})
+        pem = pinned_cert_pem or existing.get("pinned_cert_pem", "")
+        fp = pinned_fingerprint or existing.get("pinned_fingerprint", "")
+        entry: dict = {"url": url.rstrip("/")}
+        if pem:
+            entry["pinned_cert_pem"] = pem
+            entry["pinned_fingerprint"] = fp
+        config["opnsense"] = entry
     else:
         config.pop("opnsense", None)
     save_config(config)
@@ -364,12 +408,34 @@ def get_pfsense_config() -> dict:
     return load_config().get("pfsense", {})
 
 
-def save_pfsense_config(url: str, verify_ssl: bool) -> None:
+def save_pfsense_config(
+    url: str,
+    pinned_cert_pem: str = "",
+    pinned_fingerprint: str = "",
+) -> None:
     config = load_config()
     if url:
-        config["pfsense"] = {"url": url.rstrip("/"), "verify_ssl": verify_ssl}
+        existing = config.get("pfsense", {})
+        pem = pinned_cert_pem or existing.get("pinned_cert_pem", "")
+        fp = pinned_fingerprint or existing.get("pinned_fingerprint", "")
+        entry: dict = {"url": url.rstrip("/")}
+        if pem:
+            entry["pinned_cert_pem"] = pem
+            entry["pinned_fingerprint"] = fp
+        config["pfsense"] = entry
     else:
         config.pop("pfsense", None)
+    save_config(config)
+
+
+def get_tofu_migrated() -> bool:
+    """Return True if the one-shot verify_ssl→TOFU migration has already run."""
+    return load_config().get("tofu_migrated", False)
+
+
+def mark_tofu_migrated() -> None:
+    config = load_config()
+    config["tofu_migrated"] = True
     save_config(config)
 
 

--- a/app/httpx_client.py
+++ b/app/httpx_client.py
@@ -1,5 +1,6 @@
 """Central httpx client factory with standardised timeouts and per-host circuit breakers."""
 
+import ssl
 from contextlib import asynccontextmanager
 from datetime import timedelta
 from urllib.parse import urlparse
@@ -25,6 +26,7 @@ def get_breaker(host: str) -> aiobreaker.CircuitBreaker:
 def make_client(
     *,
     verify: bool | str = True,
+    ssl_context: ssl.SSLContext | None = None,
     base_url: str = "",
     headers: dict | None = None,
     timeout: httpx.Timeout | None = None,
@@ -33,7 +35,7 @@ def make_client(
     return httpx.AsyncClient(
         base_url=base_url,
         headers=headers or {},
-        verify=verify,
+        verify=ssl_context if ssl_context is not None else verify,
         timeout=timeout or _DEFAULT_TIMEOUT,
         follow_redirects=follow_redirects,
     )
@@ -67,6 +69,7 @@ async def make_breaker_client(
     *,
     base_url: str,
     verify: bool | str = True,
+    ssl_context: ssl.SSLContext | None = None,
     headers: dict | None = None,
     timeout: httpx.Timeout | None = None,
 ):
@@ -75,7 +78,11 @@ async def make_breaker_client(
     host = _host_from_url(base_url)
     breaker = get_breaker(host)
     async with make_client(
-        base_url=base_url, verify=verify, headers=headers, timeout=timeout
+        base_url=base_url,
+        verify=verify,
+        ssl_context=ssl_context,
+        headers=headers,
+        timeout=timeout,
     ) as client:
         yield _BreakerClient(client, breaker)
 

--- a/app/main.py
+++ b/app/main.py
@@ -27,7 +27,22 @@ from .notifications import get_unread_count, get_notifications, mark_all_read
 from .auto_update_scheduler import apply_all_schedules, scheduler
 from .auto_updates_router import router as auto_updates_router
 from .backend_loader import get_backends, get_dockerhub_creds, reload_backends
-from .config_manager import get_hosts, get_pbs_config, get_proxmox_config, migrate_ssh_config
+from .config_manager import (
+    get_hosts,
+    get_opnsense_config,
+    get_pbs_config,
+    get_pfsense_config,
+    get_portainer_config,
+    get_proxmox_config,
+    get_tofu_migrated,
+    mark_tofu_migrated,
+    migrate_ssh_config,
+    save_opnsense_config,
+    save_pbs_config,
+    save_pfsense_config,
+    save_portainer_config,
+    save_proxmox_config,
+)
 from .credentials import get_credentials, get_integration_credentials, save_sudo_password
 from .ssh_client import (
     _needs_sudo,
@@ -335,6 +350,54 @@ def _check_version_notification() -> None:
         pass
 
 
+async def _migrate_tofu_certs() -> None:
+    """One-shot migration: for integrations previously using verify_ssl=False, auto-pin the cert."""
+    if get_tofu_migrated():
+        return
+
+    from .cert_utils import cert_info, fetch_server_cert, fingerprint as fp_of
+    from .notifications import notify
+
+    # Map integration key → (get_cfg_fn, save_cfg_fn, url_from_cfg)
+    integrations = [
+        ("proxmox", get_proxmox_config, save_proxmox_config),
+        ("proxmox_backup", get_pbs_config, save_pbs_config),
+        ("opnsense", get_opnsense_config, save_opnsense_config),
+        ("pfsense", get_pfsense_config, save_pfsense_config),
+        ("portainer", get_portainer_config, save_portainer_config),
+    ]
+
+    pinned: list[str] = []
+    for name, get_cfg, save_cfg in integrations:
+        cfg = get_cfg()
+        if not cfg.get("verify_ssl") or cfg.get("pinned_cert_pem"):
+            continue
+        url = cfg.get("url", "")
+        if not url:
+            continue
+        try:
+            pem = fetch_server_cert(url)
+            info = cert_info(pem)
+            save_cfg(url=url, pinned_cert_pem=pem, pinned_fingerprint=info["fingerprint"])
+            pinned.append(name)
+            log.info("TOFU migration: auto-pinned cert for %s (fp: %s)", name, info["fingerprint"])
+        except Exception as exc:
+            log.warning("TOFU migration: could not pin cert for %s — %s", name, exc)
+
+    mark_tofu_migrated()
+    if pinned:
+        names = ", ".join(pinned)
+        notify(
+            title="TLS certificates auto-pinned",
+            message=(
+                f"Keepup upgraded to certificate pinning (TOFU). "
+                f"Certificates were automatically captured for: {names}. "
+                f"Re-test each integration if connections fail."
+            ),
+            level="info",
+        )
+
+
 @app.on_event("startup")
 async def _startup() -> None:
     _check_version_notification()
@@ -343,6 +406,7 @@ async def _startup() -> None:
         log.warning(
             "%d host(s) have no SSH user configured — set it via Admin › Hosts.", missing
         )
+    await _migrate_tofu_certs()
     await reload_backends()
     apply_all_schedules()
     scheduler.start()
@@ -619,7 +683,7 @@ async def pbs_status(request: Request) -> HTMLResponse:
     cfg = get_pbs_config()
     creds = get_integration_credentials("proxmox_backup")
     url = cfg.get("url", "")
-    verify_ssl = cfg.get("verify_ssl", False)
+    pinned_pem = cfg.get("pinned_cert_pem", "")
     token_id = creds.get("token_id", "")
     secret = creds.get("secret", "")
     # Legacy fallback
@@ -633,8 +697,10 @@ async def pbs_status(request: Request) -> HTMLResponse:
     if not url or not (token_id or creds.get("api_token")):
         return HTMLResponse("")
 
+    from .cert_utils import build_pinned_ssl_ctx
+    ssl_ctx = build_pinned_ssl_ctx(pinned_pem) if pinned_pem else None
     try:
-        async with make_client(verify=verify_ssl) as c:
+        async with make_client(ssl_context=ssl_ctx) as c:
             resp = await c.get(f"{url}/api2/json/version", headers={"Authorization": auth})
             resp.raise_for_status()
             ver = resp.json().get("data", {}).get("version", "unknown")
@@ -670,10 +736,10 @@ async def _proxmox_client_from_config():
         token = f"{api_user}!{api_token}" if api_user else api_token
     else:
         token = f"{token_id}={secret}"
-    verify_ssl = cfg.get("verify_ssl", False)
+    pinned_pem = cfg.get("pinned_cert_pem", "")
     if not url or not token:
         raise RuntimeError("Proxmox integration not configured.")
-    return ProxmoxClient(url=url, api_token=token, verify_ssl=verify_ssl)
+    return ProxmoxClient(url=url, api_token=token, pinned_cert_pem=pinned_pem)
 
 
 @app.get("/api/host/{slug}/check", response_class=HTMLResponse)

--- a/app/main.py
+++ b/app/main.py
@@ -370,7 +370,7 @@ async def _migrate_tofu_certs() -> None:
     pinned: list[str] = []
     for name, get_cfg, save_cfg in integrations:
         cfg = get_cfg()
-        if not cfg.get("verify_ssl") or cfg.get("pinned_cert_pem"):
+        if cfg.get("verify_ssl") is not False or cfg.get("pinned_cert_pem"):
             continue
         url = cfg.get("url", "")
         if not url:

--- a/app/portainer_client.py
+++ b/app/portainer_client.py
@@ -20,13 +20,23 @@ log = logging.getLogger(__name__)
 
 
 class PortainerClient:
-    def __init__(self, url: str, api_key: str, verify_ssl: bool = False):
+    def __init__(self, url: str, api_key: str, pinned_cert_pem: str = ""):
         self.base = url.rstrip("/")
         self.headers = {"X-API-Key": api_key}
-        self.verify_ssl = verify_ssl
+        self._pinned_cert_pem = pinned_cert_pem
+
+    def _ssl_ctx(self):
+        if self._pinned_cert_pem:
+            from .cert_utils import build_pinned_ssl_ctx
+            return build_pinned_ssl_ctx(self._pinned_cert_pem)
+        return None
 
     def _client(self):
-        return make_breaker_client(base_url=self.base, headers=self.headers, verify=self.verify_ssl)
+        return make_breaker_client(
+            base_url=self.base,
+            headers=self.headers,
+            ssl_context=self._ssl_ctx(),
+        )
 
     async def get(self, path: str) -> dict | list:
         async with self._client() as c:

--- a/app/proxmox_client.py
+++ b/app/proxmox_client.py
@@ -15,13 +15,23 @@ log = logging.getLogger(__name__)
 
 
 class ProxmoxClient:
-    def __init__(self, url: str, api_token: str, verify_ssl: bool = False):
+    def __init__(self, url: str, api_token: str, pinned_cert_pem: str = ""):
         self.base = url.rstrip("/")
         self.headers = {"Authorization": f"PVEAPIToken={api_token}"}
-        self.verify_ssl = verify_ssl
+        self._pinned_cert_pem = pinned_cert_pem
+
+    def _ssl_ctx(self):
+        if self._pinned_cert_pem:
+            from .cert_utils import build_pinned_ssl_ctx
+            return build_pinned_ssl_ctx(self._pinned_cert_pem)
+        return None
 
     def _client(self):
-        return make_breaker_client(base_url=self.base, headers=self.headers, verify=self.verify_ssl)
+        return make_breaker_client(
+            base_url=self.base,
+            headers=self.headers,
+            ssl_context=self._ssl_ctx(),
+        )
 
     async def get_version(self) -> dict:
         log.info("Proxmox: testing API at %s", self.base)
@@ -376,7 +386,7 @@ class ProxmoxClient:
                 async with make_breaker_client(
                     base_url=self.base,
                     headers=self.headers,
-                    verify=self.verify_ssl,
+                    ssl_context=self._ssl_ctx(),
                     timeout=httpx.Timeout(connect=5, read=5, write=5, pool=5),
                 ) as c:
                     r = await c.get(f"/api2/json/nodes/{node}/status")

--- a/app/templates/partials/admin_integrations.html
+++ b/app/templates/partials/admin_integrations.html
@@ -182,10 +182,7 @@
           <input type="password" id="proxmox-secret" name="proxmox_secret" placeholder="{% if integ.proxmox_secret_set %}Leave blank to keep{% else %}xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx{% endif %}" class="field-input">
         </div>
       </div>
-      <div class="ssl-row">
-        <input type="checkbox" id="proxmox-ssl" name="proxmox_verify_ssl" value="on" {% if integ.proxmox_verify_ssl %}checked{% endif %}>
-        <label for="proxmox-ssl">Verify SSL certificate</label>
-      </div>
+      {% if integ.proxmox_pinned %}<div class="field-hint" style="color:#3fb950;margin-bottom:6px;">&#128274; Certificate pinned &mdash; <span style="font-family:monospace;font-size:10px;">{{ integ.proxmox_cert_fingerprint[:29] }}&hellip;</span></div>{% endif %}
       {% if integ.proxmox_configured %}
       <div style="border-top:0.5px solid #21262d;margin:10px 0 12px;"></div>
       <div class="field-label" style="margin-bottom:6px;">SSH ACCESS FOR LXC UPDATES</div>
@@ -228,11 +225,11 @@
       <div class="btn-row">
         <button class="btn-test"
           hx-post="/setup/connect/proxmox/test"
-          hx-include="#proxmox-url,#proxmox-api-user,#proxmox-token-id,#proxmox-secret,#proxmox-ssl"
+          hx-include="#proxmox-url,#proxmox-api-user,#proxmox-token-id,#proxmox-secret"
           hx-target="#proxmox-test-result">Test API</button>
         <button class="btn-save"
           hx-post="/setup/connect/proxmox/save"
-          hx-include="#proxmox-url,#proxmox-api-user,#proxmox-token-id,#proxmox-secret,#proxmox-ssl,#proxmox-ssh-user,#proxmox-ssh-auth,#proxmox-ssh-key,#proxmox-ssh-pass"
+          hx-include="#proxmox-url,#proxmox-api-user,#proxmox-token-id,#proxmox-secret,#proxmox-ssh-user,#proxmox-ssh-auth,#proxmox-ssh-key,#proxmox-ssh-pass"
           hx-target="#proxmox-result">Save</button>
         {% if integ.proxmox_configured %}
         <button class="btn-test"
@@ -283,19 +280,16 @@
           <input type="password" id="pbs-secret" name="pbs_secret" placeholder="{% if integ.pbs_secret_set %}Leave blank to keep{% else %}xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx{% endif %}" class="field-input">
         </div>
       </div>
-      <div class="ssl-row">
-        <input type="checkbox" id="pbs-ssl" name="pbs_verify_ssl" value="on" {% if integ.pbs_verify_ssl %}checked{% endif %}>
-        <label for="pbs-ssl">Verify SSL certificate</label>
-      </div>
+      {% if integ.pbs_pinned %}<div class="field-hint" style="color:#3fb950;margin-bottom:6px;">&#128274; Certificate pinned &mdash; <span style="font-family:monospace;font-size:10px;">{{ integ.pbs_cert_fingerprint[:29] }}&hellip;</span></div>{% endif %}
       <div id="pbs-test-result" class="result-area"></div>
       <div class="btn-row">
         <button class="btn-test"
           hx-post="/setup/connect/pbs/test"
-          hx-include="#pbs-url,#pbs-user,#pbs-token-id,#pbs-secret,#pbs-ssl"
+          hx-include="#pbs-url,#pbs-user,#pbs-token-id,#pbs-secret"
           hx-target="#pbs-test-result">Test connection</button>
         <button class="btn-save"
           hx-post="/setup/connect/pbs/save"
-          hx-include="#pbs-url,#pbs-user,#pbs-token-id,#pbs-secret,#pbs-ssl"
+          hx-include="#pbs-url,#pbs-user,#pbs-token-id,#pbs-secret"
           hx-target="#pbs-result">Save</button>
       </div>
     </div>
@@ -331,19 +325,16 @@
         </div>
       </div>
       <div class="field-hint" style="margin-bottom:8px">System → Access → Users → your user → API keys</div>
-      <div class="ssl-row">
-        <input type="checkbox" id="opn-ssl" name="opnsense_verify_ssl" value="on" {% if integ.opnsense_verify_ssl %}checked{% endif %}>
-        <label for="opn-ssl">Verify SSL certificate</label>
-      </div>
+      {% if integ.opnsense_pinned %}<div class="field-hint" style="color:#3fb950;margin-bottom:6px;">&#128274; Certificate pinned &mdash; <span style="font-family:monospace;font-size:10px;">{{ integ.opnsense_cert_fingerprint[:29] }}&hellip;</span></div>{% endif %}
       <div id="opnsense-test-result" class="result-area"></div>
       <div class="btn-row">
         <button class="btn-test"
           hx-post="/setup/connect/opnsense/test"
-          hx-include="#opn-url,#opn-key,#opn-secret,#opn-ssl"
+          hx-include="#opn-url,#opn-key,#opn-secret"
           hx-target="#opnsense-test-result">Test connection</button>
         <button class="btn-save"
           hx-post="/setup/connect/opnsense/save"
-          hx-include="#opn-url,#opn-key,#opn-secret,#opn-ssl"
+          hx-include="#opn-url,#opn-key,#opn-secret"
           hx-target="#opnsense-result">Save</button>
       </div>
     </div>
@@ -373,19 +364,16 @@
         <input type="password" id="pf-key" name="pfsense_api_key" placeholder="{% if integ.pfsense_configured %}Leave blank to keep{% else %}Paste API key here{% endif %}" class="field-input">
         <div class="field-hint">System → API → Keys in the pfSense-API package</div>
       </div>
-      <div class="ssl-row">
-        <input type="checkbox" id="pf-ssl" name="pfsense_verify_ssl" value="on" {% if integ.pfsense_verify_ssl %}checked{% endif %}>
-        <label for="pf-ssl">Verify SSL certificate</label>
-      </div>
+      {% if integ.pfsense_pinned %}<div class="field-hint" style="color:#3fb950;margin-bottom:6px;">&#128274; Certificate pinned &mdash; <span style="font-family:monospace;font-size:10px;">{{ integ.pfsense_cert_fingerprint[:29] }}&hellip;</span></div>{% endif %}
       <div id="pfsense-test-result" class="result-area"></div>
       <div class="btn-row">
         <button class="btn-test"
           hx-post="/setup/connect/pfsense/test"
-          hx-include="#pf-url,#pf-key,#pf-ssl"
+          hx-include="#pf-url,#pf-key"
           hx-target="#pfsense-test-result">Test connection</button>
         <button class="btn-save"
           hx-post="/setup/connect/pfsense/save"
-          hx-include="#pf-url,#pf-key,#pf-ssl"
+          hx-include="#pf-url,#pf-key"
           hx-target="#pfsense-result">Save</button>
       </div>
     </div>
@@ -457,19 +445,16 @@
         <input type="password" id="port-key" name="portainer_api_key" placeholder="{% if integ.portainer_key_set %}Leave blank to keep{% else %}Paste token here{% endif %}" class="field-input">
         <div class="field-hint">Your account → Access tokens → Add access token</div>
       </div>
-      <div class="ssl-row">
-        <input type="checkbox" id="port-ssl" name="portainer_verify_ssl" value="on" {% if integ.portainer_verify_ssl %}checked{% endif %}>
-        <label for="port-ssl">Verify SSL certificate</label>
-      </div>
+      {% if integ.portainer_pinned %}<div class="field-hint" style="color:#3fb950;margin-bottom:6px;">&#128274; Certificate pinned &mdash; <span style="font-family:monospace;font-size:10px;">{{ integ.portainer_cert_fingerprint[:29] }}&hellip;</span></div>{% endif %}
       <div id="portainer-test-result" class="result-area"></div>
       <div class="btn-row">
         <button class="btn-test"
           hx-post="/admin/integrations/portainer/test"
-          hx-include="#port-url,#port-key,#port-ssl"
+          hx-include="#port-url,#port-key"
           hx-target="#portainer-test-result">Test connection</button>
         <button class="btn-save"
           hx-post="/admin/integrations/portainer"
-          hx-include="#port-url,#port-key,#port-ssl"
+          hx-include="#port-url,#port-key"
           hx-target="#portainer-result">Save</button>
       </div>
     </div>

--- a/app/templates/partials/cert_trust_prompt.html
+++ b/app/templates/partials/cert_trust_prompt.html
@@ -1,0 +1,27 @@
+<div style="background:#161b22;border:1px solid {% if changed %}#9e6a03{% else %}#30363d{% endif %};border-radius:6px;padding:12px;font-size:12px;">
+  <div style="color:{% if changed %}#e3b341{% else %}#d29922{% endif %};font-weight:600;margin-bottom:6px;">
+    {% if changed %}&#9888;&#xFE0F; Certificate changed{% else %}&#128274; Untrusted certificate{% endif %}
+  </div>
+  <div style="color:#8b949e;margin-bottom:10px;">
+    {% if changed %}
+      This server&#39;s certificate no longer matches the one you pinned. Review the new certificate and re-trust to continue.
+    {% else %}
+      This server uses a self-signed certificate. Review it carefully — once trusted, Keepup will only accept this exact certificate from this server.
+    {% endif %}
+  </div>
+  <div style="background:#0d1117;border:1px solid #21262d;border-radius:4px;padding:8px;margin-bottom:10px;font-family:monospace;line-height:1.6;">
+    <div><span style="color:#8b949e;display:inline-block;width:80px;">SHA-256</span><span style="color:#cdd9e5;word-break:break-all;">{{ info.fingerprint }}</span></div>
+    <div><span style="color:#8b949e;display:inline-block;width:80px;">Subject</span><span style="color:#cdd9e5;">{{ info.subject_cn }}</span></div>
+    <div><span style="color:#8b949e;display:inline-block;width:80px;">Issuer</span><span style="color:#cdd9e5;">{{ info.issuer_cn }}</span></div>
+    <div><span style="color:#8b949e;display:inline-block;width:80px;">Valid from</span><span style="color:#cdd9e5;">{{ info.not_before }}</span></div>
+    <div><span style="color:#8b949e;display:inline-block;width:80px;">Valid to</span><span style="color:#cdd9e5;">{{ info.not_after }}</span></div>
+  </div>
+  <button
+    style="font-size:12px;padding:4px 12px;border-radius:5px;border:1px solid #388bfd;background:transparent;color:#388bfd;cursor:pointer;"
+    hx-post="{{ test_url }}"
+    hx-include="{{ include_ids }}"
+    hx-vals='{"trust_accepted": "1"}'
+    hx-target="{{ target_id }}">
+    Trust this certificate
+  </button>
+</div>

--- a/app/templates/partials/setup_portainer_section.html
+++ b/app/templates/partials/setup_portainer_section.html
@@ -27,21 +27,17 @@
         class="w-full bg-slate-700 border border-slate-600 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:border-blue-500 placeholder:text-slate-500">
       <p class="text-xs text-slate-500 mt-1">In Portainer: My Account → Access tokens → Add access token.</p>
     </div>
-    <label class="flex items-center gap-2 cursor-pointer select-none">
-      <input type="checkbox" name="portainer_verify_ssl" value="on" class="w-4 h-4 rounded accent-blue-500">
-      <span class="text-sm text-slate-300">Verify SSL certificate</span>
-    </label>
     <div class="flex gap-2 items-center flex-wrap">
       <button
         hx-post="/setup/portainer/test"
-        hx-include="[name='portainer_url'],[name='portainer_api_key'],[name='portainer_verify_ssl']"
+        hx-include="[name='portainer_url'],[name='portainer_api_key']"
         hx-target="#portainer-test-result"
         class="px-4 py-2 rounded-lg bg-slate-600 hover:bg-slate-500 text-sm font-medium text-slate-200 transition-colors">
         Test connection
       </button>
       <button
         hx-post="/setup/portainer/save"
-        hx-include="[name='portainer_url'],[name='portainer_api_key'],[name='portainer_verify_ssl']"
+        hx-include="[name='portainer_url'],[name='portainer_api_key']"
         hx-target="#portainer-section"
         hx-swap="outerHTML"
         class="px-4 py-2 rounded-lg bg-blue-600 hover:bg-blue-500 text-sm font-medium text-white transition-colors">

--- a/app/templates/partials/setup_proxmox_section.html
+++ b/app/templates/partials/setup_proxmox_section.html
@@ -314,21 +314,17 @@
       <p class="text-xs text-slate-500 mt-1">Datacenter → Permissions → API Tokens → Secret</p>
     </div>
   </div>
-  <label class="flex items-center gap-2 cursor-pointer select-none">
-    <input type="checkbox" name="proxmox_verify_ssl" value="on" class="w-4 h-4 rounded accent-blue-500">
-    <span class="text-sm text-slate-300">Verify SSL certificate</span>
-  </label>
   <div class="flex gap-2 items-center flex-wrap">
     <button
       hx-post="/setup/connect/proxmox/test"
-      hx-include="[name='proxmox_url'],[name='proxmox_token_id'],[name='proxmox_secret'],[name='proxmox_verify_ssl']"
+      hx-include="[name='proxmox_url'],[name='proxmox_token_id'],[name='proxmox_secret']"
       hx-target="#proxmox-test-result"
       class="px-4 py-2 rounded-lg bg-slate-600 hover:bg-slate-500 text-sm font-medium text-slate-200 transition-colors">
       Test connection
     </button>
     <button
       hx-post="/setup/connect/proxmox/save"
-      hx-include="[name='proxmox_url'],[name='proxmox_token_id'],[name='proxmox_secret'],[name='proxmox_verify_ssl']"
+      hx-include="[name='proxmox_url'],[name='proxmox_token_id'],[name='proxmox_secret']"
       hx-target="#proxmox-section"
       hx-swap="outerHTML"
       class="px-4 py-2 rounded-lg bg-blue-600 hover:bg-blue-500 text-sm font-medium text-white transition-colors">

--- a/app/templates/setup_connect.html
+++ b/app/templates/setup_connect.html
@@ -287,19 +287,15 @@
               <div class="field-hint">Configuration → Access Control → API Tokens → Secret</div>
             </div>
           </div>
-          <div class="ssl-row">
-            <input type="checkbox" id="pbs-ssl" name="pbs_verify_ssl" value="on">
-            <label for="pbs-ssl">Verify SSL certificate</label>
-          </div>
           <div id="pbs-test-result" style="font-size:12px;margin-bottom:6px"></div>
           <div class="btn-row">
             <button class="btn-test"
               hx-post="/setup/connect/pbs/test"
-              hx-include="#pbs-url,#pbs-user,#pbs-token-id,#pbs-secret,#pbs-ssl"
+              hx-include="#pbs-url,#pbs-user,#pbs-token-id,#pbs-secret"
               hx-target="#pbs-test-result">Test connection</button>
             <button class="btn-save"
               hx-post="/setup/connect/pbs/save"
-              hx-include="#pbs-url,#pbs-user,#pbs-token-id,#pbs-secret,#pbs-ssl"
+              hx-include="#pbs-url,#pbs-user,#pbs-token-id,#pbs-secret"
               hx-target="#pbs-result">Save</button>
           </div>
         </div>
@@ -343,19 +339,15 @@
             </div>
           </div>
           <div class="field-hint" style="margin-bottom:8px">OPNsense: System → Access → Users → your user → API keys</div>
-          <div class="ssl-row">
-            <input type="checkbox" id="opn-ssl" name="opnsense_verify_ssl" value="on">
-            <label for="opn-ssl">Verify SSL certificate</label>
-          </div>
           <div id="opnsense-test-result" style="font-size:12px;margin-bottom:6px"></div>
           <div class="btn-row">
             <button class="btn-test"
               hx-post="/setup/connect/opnsense/test"
-              hx-include="#opn-url,#opn-key,#opn-secret,#opn-ssl"
+              hx-include="#opn-url,#opn-key,#opn-secret"
               hx-target="#opnsense-test-result">Test connection</button>
             <button class="btn-save"
               hx-post="/setup/connect/opnsense/save"
-              hx-include="#opn-url,#opn-key,#opn-secret,#opn-ssl"
+              hx-include="#opn-url,#opn-key,#opn-secret"
               hx-target="#opnsense-result">Save</button>
           </div>
         </div>
@@ -392,19 +384,15 @@
             <div class="field-label">API key</div>
             <input type="password" id="pf-key" name="pfsense_api_key" placeholder="API key" class="field-input">
           </div>
-          <div class="ssl-row">
-            <input type="checkbox" id="pf-ssl" name="pfsense_verify_ssl" value="on">
-            <label for="pf-ssl">Verify SSL certificate</label>
-          </div>
           <div id="pfsense-test-result" style="font-size:12px;margin-bottom:6px"></div>
           <div class="btn-row">
             <button class="btn-test"
               hx-post="/setup/connect/pfsense/test"
-              hx-include="#pf-url,#pf-key,#pf-ssl"
+              hx-include="#pf-url,#pf-key"
               hx-target="#pfsense-test-result">Test connection</button>
             <button class="btn-save"
               hx-post="/setup/connect/pfsense/save"
-              hx-include="#pf-url,#pf-key,#pf-ssl"
+              hx-include="#pf-url,#pf-key"
               hx-target="#pfsense-result">Save</button>
           </div>
         </div>

--- a/tests/test_admin_extra.py
+++ b/tests/test_admin_extra.py
@@ -1,6 +1,6 @@
 """Additional admin route tests for coverage gaps."""
 
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 
 # ---------------------------------------------------------------------------
@@ -76,7 +76,8 @@ def test_portainer_test_connection_connect_error(client):
 
 
 def test_portainer_test_connection_ssl_error(client):
-    with patch("app.portainer_client.PortainerClient") as MockClient:
+    with patch("app.portainer_client.PortainerClient") as MockClient, \
+         patch("app.admin.fetch_server_cert", side_effect=Exception("no conn")):
         instance = MockClient.return_value
         instance.get_endpoints = AsyncMock(
             side_effect=Exception("SSL certificate verify failed")
@@ -118,7 +119,6 @@ def test_save_portainer_config(client):
         data={
             "portainer_url": "https://portainer.example.com:9443",
             "portainer_api_key": "my-api-key",
-            "portainer_verify_ssl": "",
         },
     )
     assert response.status_code == 200

--- a/tests/test_admin_routes.py
+++ b/tests/test_admin_routes.py
@@ -31,7 +31,7 @@ def test_admin_integrations_shows_portainer_configured(client, data_dir, config_
     from app.config_manager import save_portainer_config
     from app.credentials import save_integration_credentials
 
-    save_portainer_config(url="https://portainer.test:9443", verify_ssl=False)
+    save_portainer_config(url="https://portainer.test:9443")
     save_integration_credentials("portainer", api_key="test-api-key")
     response = client.get("/admin/integrations")
     assert "portainer.test" in response.text
@@ -462,7 +462,6 @@ def test_admin_integrations_test_portainer_success(client):
             data={
                 "portainer_url": "https://portainer.test:9443",
                 "portainer_api_key": "testkey",
-                "portainer_verify_ssl": "",
             },
         )
     assert response.status_code == 200
@@ -490,7 +489,7 @@ def test_admin_integrations_test_portainer_ssl_error(client):
     with patch(
         "app.portainer_client.PortainerClient.get_endpoints",
         new=AsyncMock(side_effect=Exception("SSL certificate verify failed")),
-    ):
+    ), patch("app.admin.fetch_server_cert", side_effect=Exception("no conn")):
         response = client.post(
             "/admin/integrations/portainer/test",
             data={
@@ -499,7 +498,7 @@ def test_admin_integrations_test_portainer_ssl_error(client):
             },
         )
     assert response.status_code == 200
-    assert "SSL error" in response.text
+    assert "SSL" in response.text
 
 
 # ---------------------------------------------------------------------------
@@ -514,7 +513,6 @@ def test_admin_integrations_save_portainer(client):
             data={
                 "portainer_url": "https://portainer.test:9443",
                 "portainer_api_key": "mykey",
-                "portainer_verify_ssl": "",
             },
         )
     assert response.status_code == 200
@@ -561,7 +559,7 @@ def test_admin_proxmox_discover_success(client, data_dir, config_file):
     from app.auth_router import save_proxmox_config
     from app.credentials import save_integration_credentials
 
-    save_proxmox_config(url="https://192.168.1.10:8006", verify_ssl=False)
+    save_proxmox_config(url="https://192.168.1.10:8006")
     save_integration_credentials("proxmox", token_id="root@pam!tok", secret="abc123")
 
     resources = [
@@ -583,7 +581,7 @@ def test_admin_proxmox_discover_error(client, data_dir, config_file):
     from app.auth_router import save_proxmox_config
     from app.credentials import save_integration_credentials
 
-    save_proxmox_config(url="https://192.168.1.10:8006", verify_ssl=False)
+    save_proxmox_config(url="https://192.168.1.10:8006")
     save_integration_credentials("proxmox", token_id="root@pam!tok", secret="abc123")
 
     with patch(
@@ -730,7 +728,7 @@ def test_admin_proxmox_add_node_host_success(client, data_dir, config_file):
     from app.auth_router import save_proxmox_config
     from app.credentials import save_integration_credentials
 
-    save_proxmox_config(url="https://192.168.1.10:8006", verify_ssl=False)
+    save_proxmox_config(url="https://192.168.1.10:8006")
     save_integration_credentials("proxmox", token_id="root@pam!tok", secret="abc")
 
     with patch(
@@ -752,7 +750,7 @@ def test_admin_proxmox_add_node_host_already_exists(client, data_dir, config_fil
     from app.credentials import save_integration_credentials
 
     # Use a Proxmox URL whose hostname resolves to an existing host IP
-    save_proxmox_config(url=f"https://{existing_ip}:8006", verify_ssl=False)
+    save_proxmox_config(url=f"https://{existing_ip}:8006")
     save_integration_credentials("proxmox", token_id="root@pam!tok", secret="abc")
 
     with patch(
@@ -768,7 +766,7 @@ def test_admin_proxmox_add_node_host_api_error(client, data_dir, config_file):
     from app.auth_router import save_proxmox_config
     from app.credentials import save_integration_credentials
 
-    save_proxmox_config(url="https://192.168.1.10:8006", verify_ssl=False)
+    save_proxmox_config(url="https://192.168.1.10:8006")
     save_integration_credentials("proxmox", token_id="root@pam!tok", secret="abc")
 
     with patch(

--- a/tests/test_auth_router.py
+++ b/tests/test_auth_router.py
@@ -431,7 +431,6 @@ def test_setup_save_proxmox(auth_client, data_dir):
             "proxmox_api_user": "user@pam",
             "proxmox_token_id": "user@pam!token",
             "proxmox_secret": "abc123",
-            "proxmox_verify_ssl": "",
         },
     )
     assert response.status_code == 200
@@ -446,7 +445,6 @@ def test_setup_save_opnsense(auth_client, data_dir):
             "opnsense_url": "https://192.168.1.1",
             "opnsense_api_key": "mykey",
             "opnsense_api_secret": "mysecret",
-            "opnsense_verify_ssl": "",
         },
     )
     assert response.status_code == 200
@@ -475,7 +473,6 @@ def test_setup_save_pbs(auth_client, data_dir):
             "pbs_api_user": "user@pbs",
             "pbs_token_id": "user@pbs!token",
             "pbs_secret": "abc",
-            "pbs_verify_ssl": "",
         },
     )
     assert response.status_code == 200
@@ -489,7 +486,6 @@ def test_setup_save_pfsense(auth_client, data_dir):
         data={
             "pfsense_url": "https://192.168.1.1",
             "pfsense_api_key": "mykey",
-            "pfsense_verify_ssl": "",
         },
     )
     assert response.status_code == 200

--- a/tests/test_backend_loader.py
+++ b/tests/test_backend_loader.py
@@ -25,7 +25,7 @@ async def test_reload_backends_with_portainer_ui_config():
     from app.config_manager import save_portainer_config
     from app.credentials import save_integration_credentials
 
-    save_portainer_config(url="https://portainer.test:9443", verify_ssl=False)
+    save_portainer_config(url="https://portainer.test:9443")
     save_integration_credentials("portainer", api_key="test-api-key")
 
     import app.backend_loader as bl

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -299,7 +299,7 @@ async def test_discover_stacks_pct_host_uses_pct_exec(config_file, data_dir):
     from app.config_manager import save_proxmox_config
     from app.credentials import save_integration_credentials
 
-    save_proxmox_config(url="https://pve.example:8006", verify_ssl=False)
+    save_proxmox_config(url="https://pve.example:8006")
     save_integration_credentials("proxmox", ssh_user="root", ssh_key="id_proxmox")
 
     raw = yaml.safe_load(config_file.read_text())
@@ -394,7 +394,7 @@ async def test_discover_containers_pct_host_uses_pct_exec(config_file, data_dir)
     from app.config_manager import save_proxmox_config
     from app.credentials import save_integration_credentials
 
-    save_proxmox_config(url="https://pve.example:8006", verify_ssl=False)
+    save_proxmox_config(url="https://pve.example:8006")
     save_integration_credentials("proxmox", ssh_user="root", ssh_key="id_proxmox")
 
     raw = yaml.safe_load(config_file.read_text())
@@ -618,7 +618,7 @@ async def test_proxmox_lxc_all_mode(config_file, data_dir):
     from app.config_manager import save_proxmox_config
     from app.credentials import save_integration_credentials
 
-    save_proxmox_config(url="https://pve.example:8006", verify_ssl=False)
+    save_proxmox_config(url="https://pve.example:8006")
     save_integration_credentials("proxmox", ssh_user="root", ssh_key="id_proxmox")
 
     raw = yaml.safe_load(config_file.read_text())
@@ -652,7 +652,7 @@ async def test_proxmox_lxc_selected_mode(config_file, data_dir):
     from app.config_manager import save_proxmox_config
     from app.credentials import save_integration_credentials
 
-    save_proxmox_config(url="https://pve.example:8006", verify_ssl=False)
+    save_proxmox_config(url="https://pve.example:8006")
     save_integration_credentials("proxmox", ssh_user="root", ssh_key="id_proxmox")
 
     raw = yaml.safe_load(config_file.read_text())
@@ -1747,7 +1747,7 @@ def test_ssh_params_for_pct_host_wraps_with_pct_exec(config_file, data_dir):
     from app.config_manager import save_proxmox_config
     from app.credentials import save_integration_credentials
 
-    save_proxmox_config(url="https://pve.example:8006", verify_ssl=False)
+    save_proxmox_config(url="https://pve.example:8006")
     save_integration_credentials(
         "proxmox", ssh_user="root", ssh_key="id_proxmox", ssh_password=""
     )
@@ -1776,7 +1776,7 @@ def test_ssh_params_for_pct_host_password_auth(config_file, data_dir):
     from app.config_manager import save_proxmox_config
     from app.credentials import save_integration_credentials
 
-    save_proxmox_config(url="https://pve.example:8006", verify_ssl=False)
+    save_proxmox_config(url="https://pve.example:8006")
     save_integration_credentials(
         "proxmox", ssh_user="root", ssh_key="", ssh_password="hunter2"
     )
@@ -1801,7 +1801,7 @@ async def test_containers_for_host_pct_wraps_docker_ps(config_file, data_dir):
     from app.config_manager import save_proxmox_config
     from app.credentials import save_integration_credentials
 
-    save_proxmox_config(url="https://pve.example:8006", verify_ssl=False)
+    save_proxmox_config(url="https://pve.example:8006")
     save_integration_credentials("proxmox", ssh_user="root", ssh_key="id_proxmox")
 
     raw = yaml.safe_load(config_file.read_text())
@@ -1845,7 +1845,7 @@ async def test_update_compose_pct_wraps_commands(config_file, data_dir):
     from app.config_manager import save_proxmox_config
     from app.credentials import save_integration_credentials
 
-    save_proxmox_config(url="https://pve.example:8006", verify_ssl=False)
+    save_proxmox_config(url="https://pve.example:8006")
     save_integration_credentials("proxmox", ssh_user="root", ssh_key="id_proxmox")
 
     raw = yaml.safe_load(config_file.read_text())
@@ -1891,7 +1891,7 @@ async def test_update_standalone_pct_wraps_commands(config_file, data_dir):
     from app.config_manager import save_proxmox_config
     from app.credentials import save_integration_credentials
 
-    save_proxmox_config(url="https://pve.example:8006", verify_ssl=False)
+    save_proxmox_config(url="https://pve.example:8006")
     save_integration_credentials("proxmox", ssh_user="root", ssh_key="id_proxmox")
 
     raw = yaml.safe_load(config_file.read_text())

--- a/tests/test_factory_reset.py
+++ b/tests/test_factory_reset.py
@@ -62,7 +62,7 @@ def test_reset_config_clears_hosts(config_file):
 def test_reset_config_clears_portainer(config_file):
     from app.config_manager import save_portainer_config, reset_config, load_config
 
-    save_portainer_config(url="https://portainer.test", verify_ssl=False)
+    save_portainer_config(url="https://portainer.test")
     reset_config()
     config = load_config()
     assert "portainer" not in config
@@ -171,7 +171,7 @@ def test_factory_reset_resets_config(config_file):
     """reset_config() clears portainer from config."""
     from app.config_manager import load_config, save_portainer_config, reset_config
 
-    save_portainer_config(url="https://portainer.example:9443", verify_ssl=False)
+    save_portainer_config(url="https://portainer.example:9443")
     reset_config()
     config = load_config()
     assert "portainer" not in config

--- a/tests/test_main_coverage.py
+++ b/tests/test_main_coverage.py
@@ -105,11 +105,13 @@ async def test_startup_calls_all_hooks(monkeypatch):
     mock_reload = AsyncMock()
     mock_apply = MagicMock()
     mock_start = MagicMock()
+    mock_migrate = AsyncMock()
 
     monkeypatch.setattr(m, "_check_version_notification", mock_check)
     monkeypatch.setattr(m, "reload_backends", mock_reload)
     monkeypatch.setattr(m, "apply_all_schedules", mock_apply)
     monkeypatch.setattr(m.scheduler, "start", mock_start)
+    monkeypatch.setattr(m, "_migrate_tofu_certs", mock_migrate)
 
     await m._startup()
 
@@ -117,6 +119,7 @@ async def test_startup_calls_all_hooks(monkeypatch):
     mock_reload.assert_awaited_once()
     mock_apply.assert_called_once()
     mock_start.assert_called_once()
+    mock_migrate.assert_awaited_once()
 
 
 # ---------------------------------------------------------------------------
@@ -267,7 +270,7 @@ def test_pbs_status_success(client, data_dir, config_file):
     from app.config_manager import save_pbs_config
     from app.credentials import save_integration_credentials
 
-    save_pbs_config(url="https://pbs.test:8007", verify_ssl=False)
+    save_pbs_config(url="https://pbs.test:8007")
     save_integration_credentials("proxmox_backup", token_id="root@pam!pbs", secret="abc")
 
     import httpx
@@ -285,7 +288,7 @@ def test_pbs_status_failure_returns_error_card(client, data_dir, config_file):
     from app.config_manager import save_pbs_config
     from app.credentials import save_integration_credentials
 
-    save_pbs_config(url="https://pbs.test:8007", verify_ssl=False)
+    save_pbs_config(url="https://pbs.test:8007")
     save_integration_credentials("proxmox_backup", token_id="root@pam!pbs", secret="abc")
 
     import httpx
@@ -309,7 +312,7 @@ def test_host_check_proxmox_node_returns_status(client, data_dir, config_file):
     from app.auth_router import save_proxmox_config
     from app.credentials import save_integration_credentials
 
-    save_proxmox_config(url="https://192.168.1.10:8006", verify_ssl=False)
+    save_proxmox_config(url="https://192.168.1.10:8006")
     save_integration_credentials("proxmox", token_id="root@pam!tok", secret="abc")
 
     packages = [{"name": "curl", "current": "7.81", "available": "7.90"}]
@@ -337,7 +340,7 @@ def test_host_check_proxmox_lxc_returns_status(client, data_dir, config_file):
     from app.auth_router import save_proxmox_config
     from app.credentials import save_integration_credentials
 
-    save_proxmox_config(url="https://192.168.1.10:8006", verify_ssl=False)
+    save_proxmox_config(url="https://192.168.1.10:8006")
     save_integration_credentials(
         "proxmox", token_id="root@pam!tok", secret="abc",
         ssh_user="root", ssh_key="", ssh_password="secret",

--- a/tests/test_main_coverage.py
+++ b/tests/test_main_coverage.py
@@ -353,3 +353,104 @@ def test_host_check_proxmox_lxc_returns_status(client, data_dir, config_file):
     ):
         response = client.get("/api/host/test-host/check")
     assert response.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# _migrate_tofu_certs
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_migrate_tofu_skips_when_already_migrated(data_dir, config_file, monkeypatch):
+    """Migration is a no-op when the tofu_migrated flag is set."""
+    import app.main as m
+
+    monkeypatch.setattr(m, "get_tofu_migrated", lambda: True)
+    with patch("app.cert_utils.fetch_server_cert") as mock_fetch:
+        await m._migrate_tofu_certs()
+    mock_fetch.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_migrate_tofu_pins_cert_for_verify_ssl_false(data_dir, config_file, monkeypatch):
+    """Migration auto-pins a cert when verify_ssl=False is in the saved config."""
+    import app.main as m
+    from app.config_manager import get_portainer_config
+
+    import yaml
+    import app.config_manager as cm
+    cfg_path = cm._CONFIG_PATH
+    raw = yaml.safe_load(cfg_path.read_text()) if cfg_path.exists() else {}
+    raw["portainer"] = {
+        "url": "https://portainer.test:9443",
+        "verify_ssl": False,
+    }
+    cfg_path.write_text(yaml.dump(raw))
+
+    monkeypatch.setattr(m, "get_tofu_migrated", lambda: False)
+    monkeypatch.setattr(m, "mark_tofu_migrated", lambda: None)
+
+    from app.ssl_manager import generate_self_signed_cert
+    pem, _ = generate_self_signed_cert("portainer.test")
+
+    with patch("app.cert_utils.fetch_server_cert", return_value=pem), \
+         patch("app.notifications.notify") as mock_notify:
+        await m._migrate_tofu_certs()
+
+    cfg = get_portainer_config()
+    assert cfg.get("pinned_cert_pem") == pem
+    assert cfg.get("pinned_fingerprint")
+    mock_notify.assert_called_once()
+    assert "portainer" in str(mock_notify.call_args)
+
+
+@pytest.mark.asyncio
+async def test_migrate_tofu_skips_when_already_pinned(data_dir, config_file, monkeypatch):
+    """Migration skips integrations that already have a pinned cert."""
+    import app.main as m
+    from app.ssl_manager import generate_self_signed_cert
+
+    import yaml
+    import app.config_manager as cm
+    pem, _ = generate_self_signed_cert("portainer.test")
+    cfg_path = cm._CONFIG_PATH
+    raw = yaml.safe_load(cfg_path.read_text()) if cfg_path.exists() else {}
+    raw["portainer"] = {
+        "url": "https://portainer.test:9443",
+        "verify_ssl": False,
+        "pinned_cert_pem": pem,
+        "pinned_fingerprint": "AA:BB:CC",
+    }
+    cfg_path.write_text(yaml.dump(raw))
+
+    monkeypatch.setattr(m, "get_tofu_migrated", lambda: False)
+    monkeypatch.setattr(m, "mark_tofu_migrated", lambda: None)
+
+    with patch("app.cert_utils.fetch_server_cert") as mock_fetch:
+        await m._migrate_tofu_certs()
+    mock_fetch.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_migrate_tofu_handles_fetch_error_gracefully(data_dir, config_file, monkeypatch):
+    """Migration logs and continues when cert fetch fails for an integration."""
+    import app.main as m
+
+    import yaml
+    import app.config_manager as cm
+    cfg_path = cm._CONFIG_PATH
+    raw = yaml.safe_load(cfg_path.read_text()) if cfg_path.exists() else {}
+    raw["portainer"] = {
+        "url": "https://portainer.test:9443",
+        "verify_ssl": False,
+    }
+    cfg_path.write_text(yaml.dump(raw))
+
+    monkeypatch.setattr(m, "get_tofu_migrated", lambda: False)
+    monkeypatch.setattr(m, "mark_tofu_migrated", lambda: None)
+
+    with patch("app.cert_utils.fetch_server_cert", side_effect=Exception("connection refused")), \
+         patch("app.notifications.notify") as mock_notify:
+        await m._migrate_tofu_certs()  # must not raise
+
+    mock_notify.assert_not_called()  # no notification when nothing was pinned

--- a/tests/test_proxmox_client.py
+++ b/tests/test_proxmox_client.py
@@ -13,7 +13,6 @@ def mock_client():
     return ProxmoxClient(
         url="https://192.168.1.10:8006",
         api_token="user@pam!token=abc",
-        verify_ssl=False,
     )
 
 

--- a/tests/test_setup_connect.py
+++ b/tests/test_setup_connect.py
@@ -177,7 +177,7 @@ def test_proxmox_discover_auto_adds_node(setup_client, data_dir, config_file):
     _create_admin()
     from app.config_manager import save_proxmox_config
     from app.credentials import save_integration_credentials
-    save_proxmox_config(url="https://192.168.5.227:8006", verify_ssl=False)
+    save_proxmox_config(url="https://192.168.5.227:8006")
     save_integration_credentials("proxmox", token_id="root@pam!t", secret="s", api_user="root@pam")
     with patch("app.auth_router.ProxmoxClient") as MockClient:
         instance = AsyncMock()
@@ -295,7 +295,7 @@ def test_proxmox_discover_success(setup_client, data_dir):
     from app.config_manager import save_proxmox_config
     from app.credentials import save_integration_credentials
 
-    save_proxmox_config(url="https://192.168.1.10:8006", verify_ssl=False)
+    save_proxmox_config(url="https://192.168.1.10:8006")
     save_integration_credentials("proxmox", api_user="user@pam", token_id="user@pam!token", secret="abc")
 
     with patch("app.auth_router.ProxmoxClient") as MockClient:
@@ -315,7 +315,7 @@ def test_proxmox_discover_failure(setup_client, data_dir):
     from app.config_manager import save_proxmox_config
     from app.credentials import save_integration_credentials
 
-    save_proxmox_config(url="https://192.168.1.10:8006", verify_ssl=False)
+    save_proxmox_config(url="https://192.168.1.10:8006")
     save_integration_credentials("proxmox", api_user="user@pam", token_id="user@pam!token", secret="abc")
 
     with patch("app.auth_router.ProxmoxClient") as MockClient:
@@ -350,7 +350,7 @@ def test_proxmox_test_ssh_success(setup_client, data_dir):
     _create_admin()
     from app.config_manager import save_proxmox_config
 
-    save_proxmox_config(url="https://192.168.1.10:8006", verify_ssl=False)
+    save_proxmox_config(url="https://192.168.1.10:8006")
 
     with patch("app.auth_router.verify_connection", new_callable=AsyncMock) as mock_vc:
         mock_vc.return_value = {"ok": True, "message": ""}
@@ -367,7 +367,7 @@ def test_proxmox_test_ssh_failure(setup_client, data_dir):
     _create_admin()
     from app.config_manager import save_proxmox_config
 
-    save_proxmox_config(url="https://192.168.1.10:8006", verify_ssl=False)
+    save_proxmox_config(url="https://192.168.1.10:8006")
 
     with patch("app.auth_router.verify_connection", new_callable=AsyncMock) as mock_vc:
         mock_vc.return_value = {"ok": False, "message": "Connection refused"}
@@ -831,7 +831,7 @@ def test_proxmox_discover_removes_proxmox_from_integration_pending(setup_client,
     from app.config_manager import save_proxmox_config
     from app.credentials import save_integration_credentials
     _create_admin()
-    save_proxmox_config(url="https://192.168.5.229:8006", verify_ssl=False)
+    save_proxmox_config(url="https://192.168.5.229:8006")
     save_integration_credentials("proxmox", token_id="root@pam!t", secret="s", api_user="root@pam")
     with patch("app.auth_router.ProxmoxClient") as MockClient:
         instance = AsyncMock()

--- a/tests/test_setup_summary.py
+++ b/tests/test_setup_summary.py
@@ -65,7 +65,7 @@ def test_setup_summary_shows_configured_integration(setup_client, data_dir):
     from app.credentials import save_integration_credentials
 
     _create_admin()
-    save_proxmox_config(url="https://192.168.1.10:8006", verify_ssl=False)
+    save_proxmox_config(url="https://192.168.1.10:8006")
     save_integration_credentials("proxmox", api_token="user@pam!token=abc")
     response = setup_client.get("/setup/summary")
     assert "Proxmox VE" in response.text

--- a/tests/test_tofu.py
+++ b/tests/test_tofu.py
@@ -1,0 +1,285 @@
+"""Tests for the TOFU (Trust On First Use) certificate pinning flow."""
+
+import ssl
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_test_pem() -> str:
+    """Return a self-signed PEM cert for testing."""
+    from app.ssl_manager import generate_self_signed_cert
+
+    cert_pem, _ = generate_self_signed_cert("testserver.local")
+    return cert_pem
+
+
+# ---------------------------------------------------------------------------
+# cert_utils unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestCertUtils:
+    def test_fingerprint_returns_colon_hex(self):
+        from app.cert_utils import fingerprint
+
+        pem = _make_test_pem()
+        fp = fingerprint(pem)
+        # SHA-256 = 32 bytes = 64 hex chars + 31 colons = 95 chars
+        assert len(fp) == 95
+        assert fp == fp.upper()
+        parts = fp.split(":")
+        assert len(parts) == 32
+        assert all(len(p) == 2 for p in parts)
+
+    def test_cert_info_returns_expected_fields(self):
+        from app.cert_utils import cert_info
+
+        pem = _make_test_pem()
+        info = cert_info(pem)
+        assert "fingerprint" in info
+        assert "subject_cn" in info
+        assert "issuer_cn" in info
+        assert "not_before" in info
+        assert "not_after" in info
+        assert "testserver.local" in info["subject_cn"]
+
+    def test_build_pinned_ssl_ctx_returns_ssl_context(self):
+        from app.cert_utils import build_pinned_ssl_ctx
+
+        pem = _make_test_pem()
+        ctx = build_pinned_ssl_ctx(pem)
+        assert isinstance(ctx, ssl.SSLContext)
+        assert ctx.verify_mode == ssl.CERT_REQUIRED
+        assert not ctx.check_hostname
+
+    def test_fingerprint_is_stable(self):
+        """Same cert always yields the same fingerprint."""
+        from app.cert_utils import fingerprint
+
+        pem = _make_test_pem()
+        assert fingerprint(pem) == fingerprint(pem)
+
+    def test_different_certs_have_different_fingerprints(self):
+        from app.cert_utils import fingerprint
+        from app.ssl_manager import generate_self_signed_cert
+
+        pem_a, _ = generate_self_signed_cert("host-a.local")
+        pem_b, _ = generate_self_signed_cert("host-b.local")
+        assert fingerprint(pem_a) != fingerprint(pem_b)
+
+    def test_fetch_server_cert_returns_pem(self):
+        """fetch_server_cert wraps socket I/O and returns a PEM string."""
+        import ssl
+        from unittest.mock import MagicMock, patch
+
+        from app.cert_utils import fetch_server_cert
+        from app.ssl_manager import generate_self_signed_cert
+        from cryptography import x509
+        from cryptography.hazmat.primitives.serialization import Encoding
+
+        pem, _ = generate_self_signed_cert("testserver.local")
+        cert_obj = x509.load_pem_x509_certificate(pem.encode())
+        der_bytes = cert_obj.public_bytes(Encoding.DER)
+
+        mock_ssock = MagicMock()
+        mock_ssock.getpeercert.return_value = der_bytes
+        mock_ssock.__enter__ = lambda s: s
+        mock_ssock.__exit__ = MagicMock(return_value=False)
+
+        mock_sock = MagicMock()
+        mock_sock.__enter__ = lambda s: s
+        mock_sock.__exit__ = MagicMock(return_value=False)
+
+        mock_ctx = MagicMock()
+        mock_ctx.wrap_socket.return_value = mock_ssock
+
+        with patch("app.cert_utils.socket.create_connection", return_value=mock_sock), \
+             patch("app.cert_utils.ssl.create_default_context", return_value=mock_ctx):
+            result = fetch_server_cert("https://testserver.local:9443")
+
+        assert result.startswith("-----BEGIN CERTIFICATE-----")
+        assert result.strip().endswith("-----END CERTIFICATE-----")
+
+
+# ---------------------------------------------------------------------------
+# Admin TOFU flow — Portainer (/admin/integrations/portainer/test)
+# ---------------------------------------------------------------------------
+
+
+class TestAdminPortainerTOFUFlow:
+    """Tests for the admin Portainer test endpoint TOFU flow."""
+
+    def test_ssl_error_returns_cert_prompt(self, client):
+        """An SSL error causes the cert trust prompt to be rendered."""
+        pem = _make_test_pem()
+        with patch(
+            "app.portainer_client.PortainerClient.get_endpoints",
+            new=AsyncMock(side_effect=Exception("SSL certificate verify failed")),
+        ), patch("app.admin.fetch_server_cert", return_value=pem):
+            response = client.post(
+                "/admin/integrations/portainer/test",
+                data={"portainer_url": "https://portainer.test:9443", "portainer_api_key": "key"},
+            )
+        assert response.status_code == 200
+        assert "Trust this certificate" in response.text
+        assert "SHA-256" in response.text or "fingerprint" in response.text.lower()
+
+    def test_ssl_error_shows_fingerprint_in_prompt(self, client):
+        """Cert prompt contains the certificate fingerprint."""
+        from app.cert_utils import fingerprint
+
+        pem = _make_test_pem()
+        expected_fp = fingerprint(pem)
+        with patch(
+            "app.portainer_client.PortainerClient.get_endpoints",
+            new=AsyncMock(side_effect=Exception("SSL certificate verify failed")),
+        ), patch("app.admin.fetch_server_cert", return_value=pem):
+            response = client.post(
+                "/admin/integrations/portainer/test",
+                data={"portainer_url": "https://portainer.test:9443", "portainer_api_key": "key"},
+            )
+        assert expected_fp[:16] in response.text  # partial fingerprint match
+
+    def test_trust_accepted_with_valid_cert_returns_connected(self, client):
+        """trust_accepted=1 with a valid pending cert pins and succeeds."""
+        pem = _make_test_pem()
+
+        # Step 1: trigger SSL error to store pending cert in session
+        with patch(
+            "app.portainer_client.PortainerClient.get_endpoints",
+            new=AsyncMock(side_effect=Exception("SSL certificate verify failed")),
+        ), patch("app.admin.fetch_server_cert", return_value=pem):
+            client.post(
+                "/admin/integrations/portainer/test",
+                data={"portainer_url": "https://portainer.test:9443", "portainer_api_key": "key"},
+            )
+
+        # Step 2: re-POST with trust_accepted=1; mock successful re-test
+        with patch(
+            "app.portainer_client.PortainerClient.get_endpoints",
+            new=AsyncMock(return_value=[{"Id": 1}]),
+        ):
+            response = client.post(
+                "/admin/integrations/portainer/test",
+                data={
+                    "portainer_url": "https://portainer.test:9443",
+                    "portainer_api_key": "key",
+                    "trust_accepted": "1",
+                },
+            )
+        assert response.status_code == 200
+        assert "Connected" in response.text or "pinned" in response.text.lower()
+
+    def test_trust_accepted_without_pending_cert_shows_error(self, client):
+        """trust_accepted=1 with no pending cert in session shows an error."""
+        response = client.post(
+            "/admin/integrations/portainer/test",
+            data={
+                "portainer_url": "https://portainer.test:9443",
+                "portainer_api_key": "key",
+                "trust_accepted": "1",
+            },
+        )
+        assert response.status_code == 200
+        # Should show an error, not silently succeed
+        assert "Connected" not in response.text or "error" in response.text.lower()
+
+    def test_ssl_fetch_failure_shows_ssl_error_message(self, client):
+        """When cert fetch itself fails, a generic SSL error message is shown."""
+        with patch(
+            "app.portainer_client.PortainerClient.get_endpoints",
+            new=AsyncMock(side_effect=Exception("SSL certificate verify failed")),
+        ), patch("app.admin.fetch_server_cert", side_effect=Exception("connection refused")):
+            response = client.post(
+                "/admin/integrations/portainer/test",
+                data={"portainer_url": "https://portainer.test:9443", "portainer_api_key": "key"},
+            )
+        assert response.status_code == 200
+        assert "SSL" in response.text
+
+    def test_cert_changed_shows_changed_prompt(self, client):
+        """If a different cert is presented than the one pinned, a 'changed' prompt appears."""
+        from app.cert_utils import fingerprint as fp_fn
+        from app.config_manager import save_portainer_config
+        from app.ssl_manager import generate_self_signed_cert
+
+        # Pin an existing cert
+        old_pem, _ = generate_self_signed_cert("old.local")
+        old_fp = fp_fn(old_pem)
+        save_portainer_config(
+            url="https://portainer.test:9443",
+            pinned_cert_pem=old_pem,
+            pinned_fingerprint=old_fp,
+        )
+
+        # Server now presents a different cert
+        new_pem, _ = generate_self_signed_cert("new.local")
+        with patch(
+            "app.portainer_client.PortainerClient.get_endpoints",
+            new=AsyncMock(side_effect=Exception("SSL certificate verify failed")),
+        ), patch("app.admin.fetch_server_cert", return_value=new_pem):
+            response = client.post(
+                "/admin/integrations/portainer/test",
+                data={"portainer_url": "https://portainer.test:9443", "portainer_api_key": "key"},
+            )
+        assert response.status_code == 200
+        assert "changed" in response.text.lower() or "Certificate changed" in response.text
+
+
+# ---------------------------------------------------------------------------
+# Setup wizard TOFU flow — Portainer (/setup/portainer/test)
+# ---------------------------------------------------------------------------
+
+
+class TestSetupPortainerTOFUFlow:
+    """Tests for the setup wizard Portainer test endpoint TOFU flow."""
+
+    def test_ssl_error_returns_cert_prompt(self, anon_client):
+        """SSL error in setup wizard shows cert trust prompt."""
+        pem = _make_test_pem()
+        with patch(
+            "app.portainer_client.PortainerClient.get_endpoints",
+            new=AsyncMock(side_effect=Exception("SSL certificate verify failed")),
+        ), patch("app.auth_router.fetch_server_cert", return_value=pem):
+            response = anon_client.post(
+                "/setup/portainer/test",
+                data={"portainer_url": "https://portainer.test:9443", "portainer_api_key": "key"},
+            )
+        assert response.status_code == 200
+        assert "Trust this certificate" in response.text
+
+    def test_trust_accepted_returns_connected(self, anon_client):
+        """trust_accepted=1 in setup wizard with valid pending cert succeeds."""
+        pem = _make_test_pem()
+
+        # Step 1: trigger SSL error
+        with patch(
+            "app.portainer_client.PortainerClient.get_endpoints",
+            new=AsyncMock(side_effect=Exception("SSL certificate verify failed")),
+        ), patch("app.auth_router.fetch_server_cert", return_value=pem):
+            anon_client.post(
+                "/setup/portainer/test",
+                data={"portainer_url": "https://portainer.test:9443", "portainer_api_key": "key"},
+            )
+
+        # Step 2: trust
+        with patch(
+            "app.portainer_client.PortainerClient.get_endpoints",
+            new=AsyncMock(return_value=[{"Id": 1}]),
+        ):
+            response = anon_client.post(
+                "/setup/portainer/test",
+                data={
+                    "portainer_url": "https://portainer.test:9443",
+                    "portainer_api_key": "key",
+                    "trust_accepted": "1",
+                },
+            )
+        assert response.status_code == 200
+        assert "Connected" in response.text or "pinned" in response.text.lower()


### PR DESCRIPTION
OP#115

## Summary

- Removes all `verify_ssl` toggles from setup screens (Proxmox, PBS, OPNsense, pfSense, Portainer); all connections now default to `verify=True`
- Implements Trust-On-First-Use flow: SSL errors show cert details (SHA-256 fingerprint, CN, issuer, validity) and require explicit user confirmation before pinning
- Stores pinned certs as `pinned_cert_pem` / `pinned_fingerprint` per integration; subsequent connections use a custom `ssl.SSLContext` trusting only that cert
- One-shot migration auto-pins certs for existing `verify_ssl=False` configs on startup with an admin notification
- New `app/cert_utils.py` module for cert fetching, fingerprinting, and SSLContext construction
- New `tests/test_tofu.py` with 14 tests covering the trust flow, cert-change detection, and socket-level cert fetching

## Test plan

- [ ] `python -m pytest tests/test_tofu.py -v` — all TOFU-specific tests pass
- [ ] `python -m pytest tests/ -q` — 1073 tests pass, 95% total coverage
- [ ] SSL error on Portainer/Proxmox test connection shows cert prompt with fingerprint
- [ ] "Trust this certificate" pins cert and retests successfully
- [ ] Revisiting with a different cert shows "Certificate changed" warning
- [ ] Migration: existing `verify_ssl=False` configs are auto-migrated on startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)