### PR TITLE
[#123] Forkability foundations — LICENSE, SECURITY.md, CONTRIBUTING.md, templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,45 @@
+---
+name: Bug report
+about: Something is broken or behaving unexpectedly
+title: ''
+labels: bug
+assignees: ''
+---
+
+## Steps to reproduce
+
+1.
+2.
+3.
+
+## Expected result
+
+<!-- What did you expect to happen? -->
+
+## Actual result
+
+<!-- What actually happened? Include error messages verbatim. -->
+
+## Environment
+
+- **Keepup version:** <!-- e.g. v0.31.0, or git SHA if running from source -->
+- **Deployment:** <!-- Docker / dev server (uvicorn) -->
+- **Host OS:** <!-- e.g. Debian 12, Fedora 40 -->
+- **Browser (if UI bug):** <!-- e.g. Firefox 124, Chrome 125 -->
+
+## Logs
+
+<!--
+Last ~200 lines of container logs are usually enough:
+  docker compose logs --tail=200
+
+Redact any IPs, hostnames, or credentials before pasting.
+-->
+
+```
+paste logs here
+```
+
+## Additional context
+
+<!-- Screenshots, related issues, anything else that helps. -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,24 @@
+---
+name: Feature request
+about: Suggest a new feature or improvement
+title: ''
+labels: enhancement
+assignees: ''
+---
+
+## Problem
+
+<!-- What problem are you trying to solve? Who hits it and how often? -->
+
+## Proposed solution
+
+<!-- What would the feature look like? UI sketch, API shape, config example
+     — whatever helps describe the change. -->
+
+## Alternatives considered
+
+<!-- Other ways to solve the same problem, and why they're worse. -->
+
+## Additional context
+
+<!-- Screenshots, links to similar features in other tools, etc. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,20 @@
+## Summary
+
+<!-- One or two sentences describing what this PR changes and why. -->
+
+## Related issue
+
+<!-- e.g. Fixes #42, Closes #99. Skip if there is no related issue. -->
+
+## Screenshots
+
+<!-- For any user-visible change, attach a screenshot or short recording.
+     Delete this section if the change has no UI impact. -->
+
+## Checklist
+
+- [ ] Tests pass locally (`pytest --cov=app --cov-fail-under=95`)
+- [ ] Lint passes (`ruff check app/ tests/`)
+- [ ] Coverage is at or above 95%
+- [ ] README updated (for any user-visible change)
+- [ ] CONTRIBUTING.md updated (for any developer-visible change)

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ __pycache__/
 *.pyo
 .env
 .aider*
+
+# Maintainer-private Claude Code instructions (template at CLAUDE.local.md.example)
+CLAUDE.local.md

--- a/CLAUDE.local.md.example
+++ b/CLAUDE.local.md.example
@@ -1,0 +1,135 @@
+# Keepup — Maintainer-Only Claude Code Instructions
+
+> **This file is gitignored.** Copy it to `CLAUDE.local.md` and fill in the
+> placeholders. Contains the maintainer's private workflow: issue tracker,
+> ticket templates, status flow, role definitions, and access credentials.
+>
+> Outside contributors do not need this file. See `CLAUDE.md` and
+> `CONTRIBUTING.md` for the public workflow.
+
+## OpenProject & GitHub Workflow
+
+These rules apply every time work touches OpenProject tickets or GitHub.
+
+### Ticket Creation Rules
+
+1. **NEVER create a work package without first showing the full draft to the
+   product owner and explicitly asking for confirmation before submitting.**
+2. **NEVER add comments to work packages** — if a description update fails,
+   inform the product owner and let them handle it manually. (The
+   technical-approach comment posted at the start of each user story is the
+   one allowed exception.)
+3. **NEVER list work package dependencies in the description.** Capture them
+   via the Relations API (`POST /api/v3/work_packages/{id}/relations`) using
+   relation types like `blocked_by` or `follows`. Non-work-package
+   dependencies (config changes, external systems) still go in a
+   **Dependencies** section. Omit that section if no such dependencies exist.
+
+### Ticket Templates
+
+**Bug:**
+```
+## Steps to Reproduce
+1. ...
+
+## Expected Result
+...
+
+## Actual Result
+...
+```
+
+**User Story:**
+```
+## Description
+...
+
+## Acceptance Criteria
+- ...
+
+## Dependencies
+(omit if none)
+```
+
+### Ticket Status Flow
+
+| Status | Meaning |
+|---|---|
+| **New** | Ticket created — waiting for product owner approval to begin work |
+| **In Progress** | Claude is actively working as Lead Developer |
+| **Ready for QA** | Development done — unit test summary posted |
+| **In QA** | Claude is testing as QA persona |
+| **Passed QA** | QA passed |
+| **Returned by QA** | QA failed — pick back up as Lead Developer |
+| **Closed** | Released to production |
+
+### Standard Workflow (per ticket)
+
+1. Search OpenProject for duplicates/related tickets first
+2. Draft the full ticket and present to the product owner for review
+3. Await explicit confirmation, then submit (status: **New**)
+4. Create relations for work package dependencies via the Relations API
+5. Post technical approach as a **comment** on each user story (never on epics)
+6. Wait for product owner approval comment → set **In Progress**, begin
+   implementation
+7. Maintain **95% test coverage** at all times
+8. When done: post unit test summary → set **Ready for QA**
+9. **Immediately post the PR URL as a comment on the OpenProject ticket** when
+   the PR is created
+10. Switch to QA persona → set **In QA** → test all acceptance criteria
+11. If passed: post QA notes → set **Passed QA**
+12. If failed: post failure notes → set **Returned by QA** → back to
+    **In Progress**
+13. Status moves to **Closed** after release
+
+### Feature Branch & PR Rules (maintainer)
+
+The maintainer's branches and commits use OpenProject-linked names so the OP
+GitHub integration auto-links the PR. Outside contributors use the simpler
+`feat|fix|docs|chore/<slug>` convention from `CONTRIBUTING.md`.
+
+**Branch name:** `user-story/{id}-{slugified-subject}`
+
+**Every commit message:** `[#{id}] {full subject}{op-base-url}/work_packages/{id}`
+
+**Start a ticket:**
+```
+git checkout main && git pull
+git checkout -b 'user-story/{id}-{slug}'
+git commit --allow-empty -m '[#{id}] {subject}{op-base-url}/work_packages/{id}'
+git push -u origin 'user-story/{id}-{slug}'
+```
+
+**PR description must start with `OP#{id}` on its own line** — required for
+OpenProject's GitHub integration to auto-link the PR.
+
+### Release Rules
+
+- Do NOT bump `app/__version__.py` or create git tags/GitHub releases
+  autonomously
+- The product owner decides when to release and what version number to use
+- When QA is done, notify the product owner and wait for an explicit "release"
+  instruction
+
+---
+
+## OpenProject Access
+
+- **Instance:** `{op-base-url}`  (e.g. `https://op.example.com/openproject`)
+- **Claude AI user:** `claude`, user id: `{claude-user-id}`
+- **API token:** `<YOUR_API_KEY>`
+- **Auth:** `apikey:<token>` as HTTP basic auth
+- **Project:** identifier `keepup`, id: `{project-id}`
+- **Work package types:** Task (1), Epic (5), User Story (6), Bug (7)
+
+> Treat the API token like any other secret: do not paste it into chat
+> transcripts, commit messages, or PR descriptions. Rotate it if it leaks.
+
+---
+
+## Roles
+
+- **Product Owner** — defines what and why
+- **Claude = Solutions Architect** — provides technical approach per ticket
+- **Claude = Lead Developer** — implements once approved
+- **Claude = QA** — tests before release

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,130 +1,48 @@
 # Keepup — Claude Code Instructions
 
-## OpenProject & GitHub Workflow
+This file holds project-wide guidance for any Claude Code session working on
+Keepup. It is intentionally generic so a fork can use it as-is.
 
-These rules apply every time work touches OpenProject tickets or GitHub.
-
-### Ticket Creation Rules
-
-1. **NEVER create a work package without first showing the full draft to Daniel and explicitly asking for confirmation before submitting.**
-2. **NEVER add comments to work packages** — if a description update fails, inform Daniel and let him handle it manually.
-3. **NEVER list work package dependencies in the description.** Capture them via the Relations API (`POST /api/v3/work_packages/{id}/relations`) using relation types like `blocked_by` or `follows`. Non-work-package dependencies (config changes, external systems) still go in a **Dependencies** section. Omit that section if no such dependencies exist.
-
-### Ticket Templates
-
-**Bug:**
-```
-## Steps to Reproduce
-1. ...
-
-## Expected Result
-...
-
-## Actual Result
-...
-```
-
-**User Story:**
-```
-## Description
-...
-
-## Acceptance Criteria
-- ...
-
-## Dependencies
-(omit if none)
-```
-
-### Ticket Status Flow
-
-| Status | Meaning |
-|---|---|
-| **New** | Ticket created — waiting for Daniel's approval to begin work |
-| **In Progress** | Claude is actively working as Lead Developer |
-| **Ready for QA** | Development done — unit test summary posted |
-| **In QA** | Claude is testing as QA persona |
-| **Passed QA** | QA passed |
-| **Returned by QA** | QA failed — pick back up as Lead Developer |
-| **Closed** | Released to production |
-
-### Standard Workflow (per ticket)
-
-1. Search OpenProject for duplicates/related tickets first
-2. Draft the full ticket and present to Daniel for review
-3. Await explicit confirmation, then submit (status: **New**)
-4. Create relations for work package dependencies via the Relations API
-5. Post technical approach as a **comment** on each user story (never on epics)
-6. Wait for Daniel's approval comment → set **In Progress**, begin implementation
-7. Maintain **95% test coverage** at all times
-8. When done: post unit test summary → set **Ready for QA**
-9. **Immediately post the PR URL as a comment on the OpenProject ticket** when the PR is created
-10. Switch to QA persona → set **In QA** → test all acceptance criteria
-11. If passed: post QA notes → set **Passed QA**
-12. If failed: post failure notes → set **Returned by QA** → back to **In Progress**
-13. Status moves to **Closed** after release
-
-### Feature Branch & PR Rules
-
-**Branch name:** `user-story/{id}-{slugified-subject}`
-
-**Every commit message:** `[#{id}] {full subject}https://op.mitchellfamily.info/openproject/work_packages/{id}`
-
-**Start a ticket:**
-```
-git checkout main && git pull
-git checkout -b 'user-story/{id}-{slug}'
-git commit --allow-empty -m '[#{id}] {subject}https://op.mitchellfamily.info/openproject/work_packages/{id}'
-git push -u origin 'user-story/{id}-{slug}'
-```
-
-**PR description must start with `OP#{id}` on its own line** — required for OpenProject's GitHub integration to auto-link the PR.
-
-### Release Rules
-
-- Do NOT bump `app/__version__.py` or create git tags/GitHub releases autonomously
-- Daniel decides when to release and what version number to use
-- When QA is done, notify Daniel and wait for explicit "release" instruction
-
----
+> **Maintainer note:** the project owner's personal workflow (issue tracker,
+> ticket templates, status flow, role definitions, credentials) lives in
+> `CLAUDE.local.md`, which is gitignored. A template is committed at
+> `CLAUDE.local.md.example` — copy it to `CLAUDE.local.md` and fill it in if
+> you are the maintainer. Outside contributors do not need this file.
 
 ## Project Philosophy
 
-Keepup is intentionally designed as a project others can fork and build on. The audience for this repo is not just current contributors — it's a developer skimming the code on GitHub deciding whether to spend time on it. Every commit, comment, and PR should respect that audience.
-
-- **Readability over cleverness.** A function should be understandable on first read by someone who has never seen this codebase. If a block requires tribal knowledge or conversation context, add a one-line comment with the *why*.
-- **Module-level docstrings.** Every `.py` file in `app/` opens with a 1–3 line docstring describing its role. Update it when the role changes.
-- **Document non-obvious contracts.** Public functions get a docstring when their behaviour, constraints, or side effects aren't clear from name and signature alone. Skip docstrings that just restate the code.
-- **PR descriptions are self-contained.** Reference the OP ticket, but write the description so a GitHub reader understands the *what* and the *why* without leaving the page. Include screenshots for user-visible changes.
-- **README is part of the product.** Keep features, screenshots, and setup instructions current. If a change touches what the user sees, the README probably needs an update too.
-
----
+The full philosophy lives in [CONTRIBUTING.md](CONTRIBUTING.md#project-philosophy)
+so contributors and Claude read the same source of truth. The short version:
+readability over cleverness, module-level docstrings on every `app/` file,
+self-contained PR descriptions, and the README is part of the product.
 
 ## Development Rules
 
-- **After cloning**, run `bash scripts/install-hooks.sh` to install the workflow guard pre-commit hook.
-- **Do not start implementation** until Daniel explicitly approves the technical approach comment on the ticket
+- **After cloning**, run `bash scripts/install-hooks.sh` to install the
+  branch-name pre-commit hook (optional but recommended).
 - **95% test coverage** must be maintained at all times
-- **Every new feature with UI changes** requires a design task approved by Daniel before any code is written
-- **Before implementing any new feature**, search online to check if a library or existing solution already covers it
-- **CSS-safe HTML IDs**: any string from user config or auto-generation used as an HTML `id` or CSS selector must be validated safe (`[a-z0-9-]` only). Include a test case with special chars (e.g. parentheses) on every PR that touches config-derived IDs.
+  (`pytest --cov=app --cov-fail-under=95`).
+- **Every new feature with UI changes** should have a design discussion before
+  any code is written.
+- **Before implementing any new feature**, search online to check whether a
+  library or existing solution already covers it.
+- **CSS-safe HTML IDs**: any string from user config or auto-generation used as
+  an HTML `id` or CSS selector must be validated safe (`[a-z0-9-]` only).
+  Include a test case with special chars (e.g. parentheses) on every PR that
+  touches config-derived IDs.
+- **Lint with ruff**: `ruff check app/ tests/` must pass.
 
----
+## Branch and commit conventions
 
-## OpenProject Access
+- Topic branches: `feat/<slug>`, `fix/<slug>`, `docs/<slug>`, `chore/<slug>`.
+- Commit subjects are short, imperative, and self-explanatory.
+- See [CONTRIBUTING.md](CONTRIBUTING.md) for the full contributor workflow,
+  including PR templates and review expectations.
 
-- **Instance:** https://op.mitchellfamily.info/openproject/
-- **Claude AI user:** `claude`, user id: 9
-- **API token:** `5399da7e6fd6f9a965e6638bc829a20ed15001d72e336608508a1328d5ece529`
-- **Auth:** `apikey:<token>` as HTTP basic auth
-- **Keepup project:** identifier `keepup`, id: 25
-- **Work package types:** Task (1), Epic (5), User Story (6), Bug (7)
+## Release Rules
 
----
-
-## Roles
-
-- **Daniel = Product Owner** — defines what and why
-- **Claude = Solutions Architect** — provides technical approach per ticket
-- **Claude = Lead Developer** — implements once approved
-- **Claude = QA** — tests before release
+- Do NOT bump `app/__version__.py` or create git tags / GitHub releases
+  autonomously. The maintainer decides when to release and what version number
+  to use.
+- Notify the maintainer when a change is merged and ready for release; wait
+  for an explicit "release" instruction before tagging.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,104 @@
+# Contributing to Keepup
+
+Thanks for your interest in Keepup. This document describes how to set up a
+local dev environment, run the test suite, and submit changes.
+
+> Keepup is maintained by a single person and tracks day-to-day work in a
+> private project tracker. **The OpenProject ticket workflow you may see
+> referenced in commit messages is maintainer-only — outside contributors do
+> not need to follow it.** Use GitHub issues and pull requests as described
+> below.
+
+## Project Philosophy
+
+Keepup is intentionally designed as a project others can fork and build on. The
+audience for this repo is not just current contributors — it's a developer
+skimming the code on GitHub deciding whether to spend time on it. Every commit,
+comment, and PR should respect that audience.
+
+- **Readability over cleverness.** A function should be understandable on first
+  read by someone who has never seen this codebase. If a block requires tribal
+  knowledge or conversation context, add a one-line comment with the *why*.
+- **Module-level docstrings.** Every `.py` file in `app/` opens with a 1–3 line
+  docstring describing its role. Update it when the role changes.
+- **Document non-obvious contracts.** Public functions get a docstring when
+  their behaviour, constraints, or side effects aren't clear from name and
+  signature alone. Skip docstrings that just restate the code.
+- **PR descriptions are self-contained.** Reference the issue, but write the
+  description so a GitHub reader understands the *what* and the *why* without
+  leaving the page. Include screenshots for user-visible changes.
+- **README is part of the product.** Keep features, screenshots, and setup
+  instructions current. If a change touches what the user sees, the README
+  probably needs an update too.
+
+## Quick start
+
+```bash
+git clone https://github.com/d4vastu/Keepup.git
+cd Keepup
+python -m venv .venv && source .venv/bin/activate
+pip install -r requirements.txt -r requirements-dev.txt
+
+DATA_PATH=./data uvicorn app.main:app --reload --port 8000
+```
+
+The dev server is at <http://localhost:8000>. The first time you load it, the
+setup wizard will guide you through creating an admin account.
+
+The test suite uses isolated temp directories — running it does not touch your
+local `./data` or any real SSH host.
+
+## Tests and lint
+
+Both must pass before you submit a PR.
+
+```bash
+pytest --cov=app --cov-fail-under=95
+ruff check app/ tests/
+```
+
+Coverage must stay at or above 95%. If your change drops coverage, add tests.
+
+## Branch and commit conventions
+
+Use a topic branch named after the kind of work:
+
+| Prefix         | When to use                                           |
+| -------------- | ----------------------------------------------------- |
+| `feat/<slug>`  | New functionality                                     |
+| `fix/<slug>`   | Bug fix                                               |
+| `docs/<slug>`  | Documentation only                                    |
+| `chore/<slug>` | Tooling, CI, dependency bumps, repo housekeeping      |
+
+Commit subjects should be short, imperative, and self-explanatory ("Add
+Pushover retry on 5xx", not "fixed bug"). Conventional Commits style is
+welcome but not required.
+
+If you'd like the same branch-name guardrail locally, run
+`bash scripts/install-hooks.sh` to install the pre-commit hook. It is
+optional.
+
+## Pull requests
+
+- Keep PRs focused — one logical change per PR makes review faster.
+- Fill out the PR template (it appears automatically when you open the PR).
+- Link the related GitHub issue with `Fixes #N` or `Closes #N` so it auto-closes
+  on merge.
+- For any user-visible change, attach a screenshot or short screen recording.
+- For any change to setup, configuration, or features, update the README.
+
+A maintainer will review and either approve, request changes, or explain why
+the change doesn't fit the project's scope.
+
+## Reporting bugs and requesting features
+
+Use the GitHub issue templates:
+
+- [Bug report](.github/ISSUE_TEMPLATE/bug_report.md)
+- [Feature request](.github/ISSUE_TEMPLATE/feature_request.md)
+
+## Security issues
+
+**Do not open a public issue for security problems.** Follow the process in
+[SECURITY.md](SECURITY.md), which uses GitHub's private vulnerability
+reporting.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025-2026 Daniel Mitchell
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -475,7 +475,7 @@ Keepup is in active development. It is built and maintained using Claude Code (A
 
 This project is intentionally scoped to **homelab and personal use**. It is not hardened for multi-user environments, enterprise networks, or exposure to the public internet without additional security controls.
 
-Issues and feedback welcome on the [GitHub Issues](https://github.com/d4vastu/Keepup/issues) page.
+Issues and feedback welcome on the [GitHub Issues](https://github.com/d4vastu/Keepup/issues) page. Contributions welcome — see [CONTRIBUTING.md](CONTRIBUTING.md). For security issues, please follow [SECURITY.md](SECURITY.md) instead of opening a public issue.
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,56 @@
+# Security Policy
+
+## Supported Versions
+
+Keepup is pre-1.0 beta software. Only the current `0.x` release line receives
+security fixes. Older minor versions are not supported — please upgrade before
+reporting an issue.
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 0.x (latest) | :white_check_mark: |
+| < latest 0.x | :x:           |
+
+## Reporting a Vulnerability
+
+**Please do not open a public GitHub issue for security problems.**
+
+Use GitHub's private vulnerability reporting:
+
+1. Go to the [Security tab](https://github.com/d4vastu/Keepup/security) of this
+   repository
+2. Click **Report a vulnerability**
+3. Fill in the form — the report is visible only to maintainers
+
+If private vulnerability reporting is unavailable for any reason, contact the
+maintainer directly via the email address listed on their GitHub profile.
+
+### What to expect
+
+- **Acknowledgement:** within 7 days of receipt.
+- **Fix timeline:** Keepup is maintained by a single person on a best-effort
+  basis. There is no SLA for releasing a fix; complex issues may take weeks.
+- **Disclosure:** once a fix is released, the report is made public via a
+  GitHub Security Advisory crediting the reporter (unless they prefer to remain
+  anonymous).
+
+## Scope
+
+Keepup is designed for **personal homelab use**. It has not been audited and is
+not hardened for:
+
+- Multi-tenant or shared environments
+- Direct exposure to the public internet
+- Compliance-regulated workloads
+
+Reports about issues that only manifest in those scenarios are still welcome,
+but the fix priority will reflect the project's intended scope. See the README
+for the full "homelab only" framing.
+
+Out of scope:
+
+- Self-XSS that requires the user to paste attacker-controlled content into the
+  browser DevTools console
+- Vulnerabilities in third-party dependencies that have not yet been published
+  upstream — please report those to the upstream project first
+- Findings from automated scanners with no demonstrated exploit path


### PR DESCRIPTION
OP#123

## Summary

Lays the public-facing forkability layer of epic OP#124. Adds the legal basis for forking, a vulnerability reporting channel, a contributor on-ramp, and triage templates. Strips maintainer-private OpenProject references out of `CLAUDE.md` and into a gitignored `CLAUDE.local.md` (committed template at `CLAUDE.local.md.example`).

## What's in this PR

- `LICENSE` — MIT, `Copyright (c) 2025-2026 Daniel Mitchell`. GitHub will auto-detect it and surface "MIT license" in the About sidebar.
- `SECURITY.md` — supported versions (current `0.x` line only), reporting via GitHub's built-in private vulnerability reporting (enablement is OP#128), 7-day acknowledgement window, homelab-scope reminder.
- `CONTRIBUTING.md` — quick start, `pytest`/`ruff` commands, branch convention (`feat|fix|docs|chore/<slug>`), Project Philosophy section (now the single source of truth), explicit note that the OpenProject ticket workflow is maintainer-only.
- `.github/ISSUE_TEMPLATE/bug_report.md`, `feature_request.md` — markdown templates with appropriate labels.
- `.github/PULL_REQUEST_TEMPLATE.md` — Summary / Related issue / Screenshots / Checklist (tests, ruff, coverage ≥ 95%, README and CONTRIBUTING updates).
- `CLAUDE.md` — rewritten to be fully generic. No OpenProject URL, no API token, no role/workflow tables, no commit-message URL pattern. Links Project Philosophy out to CONTRIBUTING.md so there is one source of truth.
- `CLAUDE.local.md.example` — committed template with the maintainer's full workflow (ticket templates, status flow, OP access placeholders, role definitions). One-time manual step after merge: maintainer copies it to `CLAUDE.local.md`.
- `.gitignore` — adds `CLAUDE.local.md`.
- `README.md` — Status section gains: *Contributions welcome — see CONTRIBUTING.md. For security issues, please follow SECURITY.md instead of opening a public issue.*

## Tests

Documentation-only PR — no app code touched. Existing suite was run as a regression check:

```
1077 passed, ... in 197.88s
Required test coverage of 95% reached. Total coverage: 95.01%
```

## Notes

- `ruff check app/ tests/` reports 5 pre-existing `F401` warnings on `main` (unrelated to this PR — verified by stashing changes and re-running).
- The repo URL the PR template links to (`https://github.com/d4vastu/Keepup`) and the security contact path both assume the repo lives under `d4vastu/Keepup`. If the slug ever changes, those links need updating.
- Maintainer follow-up after merge: `cp CLAUDE.local.md.example CLAUDE.local.md` and fill in the OP base URL, project id, and API token. The committed template uses placeholders only.