### PR TITLE
[#125] Pre-commit workflow guard, contributor-safe

### DIFF
--- a/scripts/hooks/pre-commit
+++ b/scripts/hooks/pre-commit
@@ -1,13 +1,11 @@
 #!/usr/bin/env bash
-# keepup workflow guard — block commits on main and other non-feature branches
+# Branch-name guard: only commit on main or a topic branch.
 branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)
-if [[ "$branch" =~ ^(user-story|bug)/[0-9]+- || "$branch" == "main" ]]; then
+if [[ "$branch" == "main" || "$branch" =~ ^(feat|fix|docs|chore)/ ]]; then
   exit 0
 fi
 echo >&2
-echo "BLOCKED by keepup workflow guard: commits to /home/daniel/update-dashboard" >&2
-echo "require a feature branch named user-story/{id}-... or bug/{id}-... with an" >&2
-echo "approved OpenProject ticket. Current branch: $branch" >&2
-echo "See CLAUDE.md for the workflow." >&2
+echo "BLOCKED: commits require a feature branch (feat/..., fix/..., docs/..., or chore/...)." >&2
+echo "Current branch: $branch" >&2
 echo >&2
 exit 1


### PR DESCRIPTION
OP#125

## Summary

Rewrites the optional pre-commit hook (`scripts/hooks/pre-commit`) so an outside contributor can run `bash scripts/install-hooks.sh` without instantly being blocked by a maintainer-only error. The hook now allows any topic branch named `feat/...`, `fix/...`, `docs/...`, or `chore/...` (matching the convention in `CONTRIBUTING.md`), allows `main` as a no-op, and rejects anything else with a generic message.

The previous error message named OpenProject and CLAUDE.md — both removed.

## Maintainer impact

Future maintainer branches use the same `feat|fix|docs|chore/<slug>` convention. The OpenProject ↔ GitHub auto-link is preserved through the commit-message URL and the `OP#{id}` line in PR bodies, not the branch name. The maintainer's local `CLAUDE.local.md` has been updated locally to reflect the new convention.

## Diff

`scripts/hooks/pre-commit` — 4 insertions, 6 deletions. No other files in this PR.

## Manual repro

Repro was run against a clean temp repo, copying the new hook into `.git/hooks/pre-commit` and seeding an initial commit on `main` before installing the hook (a fresh `git init` reports HEAD as `HEAD` until the first commit lands — same limitation as the previous hook):

| Branch | Expected | Actual |
|---|---|---|
| `feat/foo` | succeed | ✅ exit 0 |
| `random-name` | blocked, generic message | ✅ exit 1, `BLOCKED: commits require a feature branch (feat/..., fix/..., docs/..., or chore/...).` `Current branch: random-name` |
| `main` | succeed | ✅ exit 0 |
| `fix/bar` | succeed | ✅ exit 0 |
| `docs/x` | succeed | ✅ exit 0 |
| `chore/y` | succeed | ✅ exit 0 |
| `user-story/125-foo` (legacy) | blocked under new policy | ✅ exit 1, generic message |

Full transcript captured in OP#125's Ready-for-QA comment.

## Tests

Hook is shell — covered by the manual repro above, not by pytest. Full Python regression suite was run as a sanity check:

```
1077 passed, ... in 163.86s
Required test coverage of 95% reached. Total coverage: 95.01%
```

## Notes

- `ruff` Lint check on this PR will fail for the same 5 pre-existing F401 warnings flagged in OP#123's PR description — no Python touched here.