### PR TITLE
docs: README freshness audit (OP#129)

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ volumes:
   - ./keys:/app/keys:ro
 ```
 
-Then set the key path in **Admin → SSH Settings → Default key** to `/app/keys/id_ed25519`.
+Then set the key path in **Admin → SSH → Default key** to `/app/keys/id_ed25519`.
 
 ### SSH Password
 
@@ -148,7 +148,7 @@ If your SSH user is not root, updates and reboots require `sudo`. The dashboard 
 Docker monitoring works over the same SSH connection used for OS updates — no Portainer or agent required on the remote host.
 
 **Requirements on the remote host:**
-- Docker Engine and Docker Compose v2 (`docker compose` subcommand)
+- Docker Engine and Docker Compose — v2 (`docker compose`) or legacy v1 (`docker-compose`); Keepup auto-detects which is available
 - The SSH user must be root or a member of the `docker` group
 
 **How it works:**
@@ -248,7 +248,7 @@ Configure push notifications in the setup wizard (step 8) or **Admin → Connect
 
 **Email (SMTP)** — sends email alerts. Configure sender address, recipient address, SMTP host, port, and optional password.
 
-Notifications fire when auto-update jobs complete or fail. You can configure which events trigger alerts in **Admin → Notifications** after setup.
+Notifications fire when auto-update jobs complete or fail. You can configure Pushover and Email settings in **Admin → Connections** after setup.
 
 ---
 


### PR DESCRIPTION
OP#129

## Summary

Audit of all 486 README lines against current code state. Three stale references corrected; all other sections verified accurate.

## Corrections

| Location | Was | Now |
|---|---|---|
| Line 134 | Admin → SSH **Settings** → Default key | Admin → **SSH** → Default key |
| Lines 151–152 | Docker Compose v2 only | v2 (`docker compose`) or legacy v1 (`docker-compose`) — auto-detected (fixed in OP#103 but README never updated) |
| Line 251 | Admin → **Notifications** | Admin → **Connections** (no Notifications page exists; bell is a history dropdown) |

## Verified clean

- Features list matches current capabilities
- `CONFIG_PATH` and `DATA_PATH` env vars confirmed in code
- `config.yml` example fields accurate
- Architecture diagram components all exist in code
- Screenshots `dashboard.png`, `admin.png`, `admin_auto_updates.png` present
- `auto_update_log.json` filename confirmed
- All other `Admin → ...` nav paths verified against routes and templates
- No OpenProject references

## Test plan

- [ ] Read the three corrected lines in context and confirm they make sense
- [ ] Navigate to Admin → SSH in a running instance to confirm the label matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)