### PR TITLE
chore: remove unused imports (ruff)

### DIFF
--- a/app/admin.py
+++ b/app/admin.py
@@ -47,7 +47,7 @@ from .config_manager import (
     set_docker_monitoring,
     update_host,
 )
-from .cert_utils import build_pinned_ssl_ctx, cert_info, fetch_server_cert, fingerprint
+from .cert_utils import cert_info, fetch_server_cert, fingerprint
 from .proxmox_client import ProxmoxClient
 from .credentials import (
     credential_status,

--- a/app/main.py
+++ b/app/main.py
@@ -355,7 +355,7 @@ async def _migrate_tofu_certs() -> None:
     if get_tofu_migrated():
         return
 
-    from .cert_utils import cert_info, fetch_server_cert, fingerprint as fp_of
+    from .cert_utils import cert_info, fetch_server_cert
     from .notifications import notify
 
     # Map integration key → (get_cfg_fn, save_cfg_fn, url_from_cfg)

--- a/tests/test_admin_extra.py
+++ b/tests/test_admin_extra.py
@@ -1,6 +1,6 @@
 """Additional admin route tests for coverage gaps."""
 
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, patch
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_tofu.py
+++ b/tests/test_tofu.py
@@ -3,7 +3,6 @@
 import ssl
 from unittest.mock import AsyncMock, patch
 
-import pytest
 
 
 # ---------------------------------------------------------------------------
@@ -75,7 +74,6 @@ class TestCertUtils:
 
     def test_fetch_server_cert_returns_pem(self):
         """fetch_server_cert wraps socket I/O and returns a PEM string."""
-        import ssl
         from unittest.mock import MagicMock, patch
 
         from app.cert_utils import fetch_server_cert


### PR DESCRIPTION
Pre-existing ruff F401 violations found during release regression check. Auto-fixed with `ruff --fix`.

- `app/admin.py`: `build_pinned_ssl_ctx` unused import removed
- `app/main.py`: `fingerprint as fp_of` unused import removed
- `tests/test_admin_extra.py`: `MagicMock` unused import removed
- `tests/test_tofu.py`: `pytest` and inner `ssl` unused imports removed

No logic changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)