### PR TITLE
OP#130 Fix: pass verify_ssl to ProxmoxClient in dashboard check and discover

### DIFF
--- a/app/auth_router.py
+++ b/app/auth_router.py
@@ -624,7 +624,7 @@ async def setup_proxmox_discover(request: Request) -> HTMLResponse:
     if not url or not token:
         return HTMLResponse('<p class="text-sm text-red-400">Proxmox not configured.</p>')
     try:
-        client = ProxmoxClient(url=url, api_token=token, pinned_cert_pem=pinned_pem)
+        client = ProxmoxClient(url=url, api_token=token, pinned_cert_pem=pinned_pem, verify_ssl=get_proxmox_config().get("verify_ssl", True))
         nodes = await client.get_nodes()
         resources = await client.discover_resources()
         request.session["setup_proxmox_resources"] = resources

--- a/app/main.py
+++ b/app/main.py
@@ -738,9 +738,10 @@ async def _proxmox_client_from_config():
     else:
         token = f"{token_id}={secret}"
     pinned_pem = cfg.get("pinned_cert_pem", "")
+    verify_ssl = cfg.get("verify_ssl", True)
     if not url or not token:
         raise RuntimeError("Proxmox integration not configured.")
-    return ProxmoxClient(url=url, api_token=token, pinned_cert_pem=pinned_pem)
+    return ProxmoxClient(url=url, api_token=token, pinned_cert_pem=pinned_pem, verify_ssl=verify_ssl)
 
 
 @app.get("/api/host/{slug}/check", response_class=HTMLResponse)


### PR DESCRIPTION
OP#130

## Summary
- `_proxmox_client_from_config()` in `main.py` was not passing `verify_ssl` from config to `ProxmoxClient`, so the background dashboard check always used `verify_ssl=True` regardless of the saved setting
- `setup_proxmox_discover` in `auth_router.py` had the same gap
- Both now read `verify_ssl` from config and pass it through

## Root cause
The OP#130 implementation missed these two `ProxmoxClient` construction sites, leaving the dashboard's background check unchanged even after a user saved `verify_ssl=false`.

## Test plan
- [ ] Full suite 1103 passed, 95.05% coverage
- [ ] `ruff check app/ tests/` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)