### PR TITLE
Fix: fall back to -p when compose config file not on remote host

### DIFF
--- a/app/backends/ssh_docker_backend.py
+++ b/app/backends/ssh_docker_backend.py
@@ -461,7 +461,17 @@ class SSHDockerBackend:
                             )
             binary = await self._detect_compose_binary(conn, wrap, h)
             config_file = await self._get_config_file(conn, project_name, wrap)
-            args = f"-f {config_file}" if config_file else f"-p {shlex.quote(project_name)}"
+            if config_file:
+                check = await conn.run(
+                    wrap(f"test -f {shlex.quote(config_file)} && echo exists"), check=False
+                )
+                if "exists" not in (check.stdout or ""):
+                    log.warning(
+                        "Docker SSH: compose config %r not found on %s, falling back to -p",
+                        config_file, h,
+                    )
+                    config_file = ""
+            args = f"-f {shlex.quote(config_file)}" if config_file else f"-p {shlex.quote(project_name)}"
             pull = await conn.run(wrap(f"{binary} {args} pull 2>&1"), check=False)
             if pull.returncode != 0:
                 log.error("Docker SSH: pull failed for %s on %s", project_name, h)

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -723,6 +723,7 @@ async def test_update_stack_runs_pull_and_up(config_file, data_dir, monkeypatch)
         side_effect=[
             probe,                                              # compose version probe
             MagicMock(stdout=ps_output, returncode=0),          # docker ps -a (config file lookup)
+            MagicMock(stdout="exists", returncode=0),           # test -f config file
             pull_result,
             up_result,
         ]
@@ -1023,6 +1024,7 @@ async def test_update_stack_pull_failure_raises(config_file, data_dir):
         [
             MagicMock(stdout="v2\n", returncode=0),
             MagicMock(stdout=ps_output, returncode=0),
+            MagicMock(stdout="exists", returncode=0),        # test -f config file
             MagicMock(stdout="error output", returncode=1),  # pull fails
         ]
     )
@@ -1056,7 +1058,8 @@ async def test_update_stack_up_failure_raises(config_file, data_dir):
         [
             MagicMock(stdout="v2\n", returncode=0),
             MagicMock(stdout=ps_output, returncode=0),
-            MagicMock(stdout="Pulled", returncode=0),  # pull succeeds
+            MagicMock(stdout="exists", returncode=0),        # test -f config file
+            MagicMock(stdout="Pulled", returncode=0),        # pull succeeds
             MagicMock(stdout="error output", returncode=1),  # up fails
         ]
     )
@@ -1315,6 +1318,7 @@ async def test_update_compose_ref_triggers_compose_update(config_file, data_dir)
         [
             MagicMock(stdout="v2\n", returncode=0),        # compose binary probe
             MagicMock(stdout=ps_output, returncode=0),     # docker ps -a (config file lookup)
+            MagicMock(stdout="exists", returncode=0),      # test -f config file
             MagicMock(stdout="Pulled", returncode=0),      # compose pull
             MagicMock(stdout="Started", returncode=0),     # compose up -d
         ]
@@ -1867,6 +1871,7 @@ async def test_update_compose_pct_wraps_commands(config_file, data_dir):
         [
             MagicMock(stdout="v2\n", returncode=0),
             MagicMock(stdout=ps_output, returncode=0),
+            MagicMock(stdout="exists", returncode=0),      # test -f config file
             MagicMock(stdout="Pulled", returncode=0),
             MagicMock(stdout="Started", returncode=0),
         ]
@@ -2027,6 +2032,7 @@ async def test_update_compose_v1_uses_legacy_binary(config_file, data_dir):
         [
             MagicMock(stdout="v1\n", returncode=0),     # probe → v1
             MagicMock(stdout=ps_output, returncode=0),  # docker ps -a
+            MagicMock(stdout="exists", returncode=0),   # test -f config file
             MagicMock(stdout="Pulled", returncode=0),
             MagicMock(stdout="Started", returncode=0),
         ]
@@ -2068,6 +2074,7 @@ async def test_update_compose_v2_uses_plugin_binary(config_file, data_dir):
         [
             MagicMock(stdout="v2\n", returncode=0),
             MagicMock(stdout=ps_output, returncode=0),
+            MagicMock(stdout="exists", returncode=0),   # test -f config file
             MagicMock(stdout="Pulled", returncode=0),
             MagicMock(stdout="Started", returncode=0),
         ]
@@ -2328,6 +2335,7 @@ async def test_update_compose_v1_relative_path_resolved(config_file, data_dir):
         [
             MagicMock(stdout="v1\n", returncode=0),
             MagicMock(stdout=ps_output, returncode=0),
+            MagicMock(stdout="exists", returncode=0),   # test -f config file
             MagicMock(stdout="Pulled", returncode=0),
             MagicMock(stdout="Started", returncode=0),
         ]


### PR DESCRIPTION
## Summary
- When a container is deployed by Portainer using a direct Docker API connection (no agent), Docker writes the compose file path from Portainer's data volume into the container labels (e.g. `/data/compose/58/docker-compose.yml`)
- Keepup was passing that path to `docker compose -f <path> pull`, but the file lives on the Portainer host, not the target LXC — causing `FileNotFoundError`
- Fix: run `test -f <config_file>` on the remote before using `-f`; if the file is missing, fall back to `-p <project_name>`
- Also adds `shlex.quote` around the config_file path

## Test plan
- [ ] 8 existing compose-update tests updated to include the new `test -f` mock response
- [ ] Full suite: 1103 passed, 95.01% coverage
- [ ] `ruff check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)